### PR TITLE
Exclude `tests` instead of including `serialx` in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["serialx"]
+exclude = ["tests", "tests.*"]
 
 [tool.setuptools-git-versioning]
 enabled = true


### PR DESCRIPTION
Looks like the `pyproject.toml` config managed to exclude all submodules, breaking v0.1.0 on PyPI.