### PR TITLE
Move `os.close` into thread pool executor

### DIFF
--- a/serialx/descriptor_transport.py
+++ b/serialx/descriptor_transport.py
@@ -3,15 +3,34 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Coroutine
 import errno
 import logging
 import os
+import sys
 import typing
 from typing import Any
 import warnings
 
+if sys.version_info >= (3, 11):
+    from asyncio import timeout as asyncio_timeout
+else:
+    from async_timeout import timeout as asyncio_timeout
+
 LOGGER = logging.getLogger(__name__)
 LOG_THRESHOLD_FOR_CONNLOST_WRITES = 5
+
+FLUSH_TIMEOUT_S = 10.0
+
+# Prevent tasks from being garbage collected.
+_BACKGROUND_TASKS: set[asyncio.Task] = set()
+
+
+def _create_background_task(coro: Coroutine) -> None:
+    """Create a background task that will not be garbage collected."""
+    task = asyncio.create_task(coro)
+    _BACKGROUND_TASKS.add(task)
+    task.add_done_callback(_BACKGROUND_TASKS.discard)
 
 
 class DescriptorTransport(asyncio.Transport):
@@ -71,7 +90,7 @@ class DescriptorTransport(asyncio.Transport):
                 self._closing = True
                 self._loop.remove_reader(self._fileno)
                 self._loop.call_soon(self._protocol.eof_received)
-                self._loop.call_soon(self._call_connection_lost, None)
+                _create_background_task(self._call_connection_lost(None, flush=False))
 
     def pause_reading(self) -> None:
         """Pause reading from the file descriptor."""
@@ -251,7 +270,9 @@ class DescriptorTransport(asyncio.Transport):
                 self._maybe_resume_protocol()  # May append to buffer.
                 if self._closing:
                     self._loop.remove_reader(self._fileno)
-                    self._call_connection_lost(None)
+                    _create_background_task(
+                        self._call_connection_lost(None, flush=True)
+                    )
                 return
             elif n > 0:
                 del self._buffer[:n]
@@ -268,7 +289,7 @@ class DescriptorTransport(asyncio.Transport):
         self._closing = True
         if not self._buffer:
             self._loop.remove_reader(self._fileno)
-            self._loop.call_soon(self._call_connection_lost, None)
+            _create_background_task(self._call_connection_lost(None, flush=True))
 
     def set_protocol(self, protocol: asyncio.Protocol) -> None:  # type: ignore[override]
         """Set the protocol to use with this transport."""
@@ -284,19 +305,16 @@ class DescriptorTransport(asyncio.Transport):
         if self._fileno is not None and not self._closing:
             self.write_eof()
 
-    def _cleanup(self):
-        assert self._fileno is not None
-        LOGGER.debug("Closing file descriptor %s", self._fileno)
-        self._loop.remove_reader(self._fileno)
-        os.close(self._fileno)
-        LOGGER.debug("Closing file descriptor %s: DONE", self._fileno)
-        self._fileno = None
-
     def __del__(self) -> None:
         """Clean up transport on deletion."""
         if getattr(self, "_fileno", None) is not None:
+            assert self._fileno is not None
+
             warnings.warn(f"unclosed transport {self!r}", ResourceWarning, source=self)
-            self._cleanup()
+            if self._loop is not None:
+                self._loop.remove_reader(self._fileno)
+
+            os.close(self._fileno)
 
     def _fatal_error(
         self,
@@ -322,6 +340,15 @@ class DescriptorTransport(asyncio.Transport):
         """Abort the transport immediately."""
         self._close(None)
 
+    def _abort(self, exc: Exception | None = None) -> None:
+        self._closing = True
+        assert self._fileno is not None
+        if self._buffer:
+            self._loop.remove_writer(self._fileno)
+        self._buffer.clear()
+        self._loop.remove_reader(self._fileno)
+        _create_background_task(self._call_connection_lost(exc, flush=False))
+
     def _close(self, exc: Exception | None = None) -> None:
         self._closing = True
         assert self._fileno is not None
@@ -329,14 +356,40 @@ class DescriptorTransport(asyncio.Transport):
             self._loop.remove_writer(self._fileno)
         self._buffer.clear()
         self._loop.remove_reader(self._fileno)
-        self._loop.call_soon(self._call_connection_lost, exc)
+        _create_background_task(self._call_connection_lost(exc, flush=True))
 
-    def _call_connection_lost(self, exc: Exception | None) -> None:
-        LOGGER.debug("Connection was lost: %r", exc)
+    def _flush(self) -> None:
+        """Flush the write buffer."""
+        # This function is not necessary to implement when working with normal file
+        # descriptors. For serial ports, however, we need to sync out-of-band.
+
+    async def _call_connection_lost(self, exc: Exception | None, flush: bool) -> None:
+        LOGGER.debug("Closing connection: err=%r, flush=%r", exc, flush)
+
         try:
-            self._cleanup()
+            assert self._fileno is not None
+            self._loop.remove_reader(self._fileno)
+
+            if flush:
+                LOGGER.debug("Flushing file descriptor %s", self._fileno)
+
+                # Flushing can potentially deadlock
+                try:
+                    async with asyncio_timeout(FLUSH_TIMEOUT_S):
+                        await self._loop.run_in_executor(None, self._flush)
+                except Exception as flush_exc:
+                    LOGGER.debug(
+                        "Error while flushing data on closing transport: %r", flush_exc
+                    )
+
+            LOGGER.debug("Closing file descriptor %s", self._fileno)
+            await self._loop.run_in_executor(None, os.close, self._fileno)
+
+            self._fileno = None
         finally:
             protocol = self._protocol
             self._loop = None  # type: ignore[assignment]
             self._protocol = None  # type: ignore[assignment]
+
+            LOGGER.debug("Calling protocol `connection_lost` with exc=%r", exc)
             protocol.connection_lost(exc)

--- a/serialx/descriptor_transport.py
+++ b/serialx/descriptor_transport.py
@@ -7,20 +7,12 @@ from collections.abc import Coroutine
 import errno
 import logging
 import os
-import sys
 import typing
 from typing import Any
 import warnings
 
-if sys.version_info >= (3, 11):
-    from asyncio import timeout as asyncio_timeout
-else:
-    from async_timeout import timeout as asyncio_timeout
-
 LOGGER = logging.getLogger(__name__)
 LOG_THRESHOLD_FOR_CONNLOST_WRITES = 5
-
-FLUSH_TIMEOUT_S = 10.0
 
 # Prevent tasks from being garbage collected.
 _BACKGROUND_TASKS: set[asyncio.Task] = set()
@@ -90,7 +82,7 @@ class DescriptorTransport(asyncio.Transport):
                 self._closing = True
                 self._loop.remove_reader(self._fileno)
                 self._loop.call_soon(self._protocol.eof_received)
-                _create_background_task(self._call_connection_lost(None, flush=False))
+                _create_background_task(self._call_connection_lost(None))
 
     def pause_reading(self) -> None:
         """Pause reading from the file descriptor."""
@@ -270,9 +262,7 @@ class DescriptorTransport(asyncio.Transport):
                 self._maybe_resume_protocol()  # May append to buffer.
                 if self._closing:
                     self._loop.remove_reader(self._fileno)
-                    _create_background_task(
-                        self._call_connection_lost(None, flush=True)
-                    )
+                    _create_background_task(self._call_connection_lost(None))
                 return
             elif n > 0:
                 del self._buffer[:n]
@@ -289,7 +279,7 @@ class DescriptorTransport(asyncio.Transport):
         self._closing = True
         if not self._buffer:
             self._loop.remove_reader(self._fileno)
-            _create_background_task(self._call_connection_lost(None, flush=True))
+            _create_background_task(self._call_connection_lost(None))
 
     def set_protocol(self, protocol: asyncio.Protocol) -> None:  # type: ignore[override]
         """Set the protocol to use with this transport."""
@@ -340,15 +330,6 @@ class DescriptorTransport(asyncio.Transport):
         """Abort the transport immediately."""
         self._close(None)
 
-    def _abort(self, exc: Exception | None = None) -> None:
-        self._closing = True
-        assert self._fileno is not None
-        if self._buffer:
-            self._loop.remove_writer(self._fileno)
-        self._buffer.clear()
-        self._loop.remove_reader(self._fileno)
-        _create_background_task(self._call_connection_lost(exc, flush=False))
-
     def _close(self, exc: Exception | None = None) -> None:
         self._closing = True
         assert self._fileno is not None
@@ -356,32 +337,18 @@ class DescriptorTransport(asyncio.Transport):
             self._loop.remove_writer(self._fileno)
         self._buffer.clear()
         self._loop.remove_reader(self._fileno)
-        _create_background_task(self._call_connection_lost(exc, flush=True))
+        _create_background_task(self._call_connection_lost(exc))
 
-    def _flush(self) -> None:
-        """Flush the write buffer."""
-        # This function is not necessary to implement when working with normal file
-        # descriptors. For serial ports, however, we need to sync out-of-band.
-
-    async def _call_connection_lost(self, exc: Exception | None, flush: bool) -> None:
-        LOGGER.debug("Closing connection: err=%r, flush=%r", exc, flush)
+    async def _call_connection_lost(self, exc: Exception | None) -> None:
+        LOGGER.debug("Closing connection: %r", exc)
 
         try:
             assert self._fileno is not None
             self._loop.remove_reader(self._fileno)
 
-            if flush:
-                LOGGER.debug("Flushing file descriptor %s", self._fileno)
-
-                # Flushing can potentially deadlock
-                try:
-                    async with asyncio_timeout(FLUSH_TIMEOUT_S):
-                        await self._loop.run_in_executor(None, self._flush)
-                except Exception as flush_exc:
-                    LOGGER.debug(
-                        "Error while flushing data on closing transport: %r", flush_exc
-                    )
-
+            # For serial ports it would make sense to flush here BUT no modern serial
+            # driver requires this: once the data is enqueued, even `os.close` blocks
+            # for the entire transmit duration.
             LOGGER.debug("Closing file descriptor %s", self._fileno)
             await self._loop.run_in_executor(None, os.close, self._fileno)
 

--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -356,6 +356,7 @@ class PosixSerial(BaseSerial):
     def flush(self) -> None:
         """Flush write buffers, waiting until all data is written."""
         assert self._fileno is not None
+        LOGGER.debug("Flushing file descriptor %r", self._fileno)
         termios.tcdrain(self._fileno)
 
     def close(self) -> None:
@@ -446,3 +447,8 @@ class PosixSerialTransport(DescriptorTransport, BaseSerialTransport):
                 await self._loop.run_in_executor(None, self._serial.flush)
         finally:
             self._reset_empty_waiter()
+
+    def _flush(self) -> None:
+        """Flush write buffers, waiting until all data is written."""
+        assert self._serial is not None
+        self._serial.flush()

--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -447,8 +447,3 @@ class PosixSerialTransport(DescriptorTransport, BaseSerialTransport):
                 await self._loop.run_in_executor(None, self._serial.flush)
         finally:
             self._reset_empty_waiter()
-
-    def _flush(self) -> None:
-        """Flush write buffers, waiting until all data is written."""
-        assert self._serial is not None
-        self._serial.flush()

--- a/tests/test_loopback_dual_async.py
+++ b/tests/test_loopback_dual_async.py
@@ -12,11 +12,18 @@ else:
 
 import pytest
 
-from serialx import ModemBits, Parity, SerialTransport, StopBits
+from serialx import (
+    ModemBits,
+    Parity,
+    SerialTransport,
+    StopBits,
+    create_serial_connection,
+)
 from tests.common import (
     DUAL_LOOPBACK_LEFT,
     DUAL_LOOPBACK_RIGHT,
     async_create_dual_loopback,
+    async_create_reader_writer,
 )
 
 pytestmark = pytest.mark.skipif(
@@ -465,3 +472,36 @@ async def test_set_modem_bits_async() -> None:
         modem_bits = await transport.get_modem_bits()
         assert modem_bits.dtr is False
         assert modem_bits.rts is False
+
+
+async def test_fast_open_close() -> None:
+    """Test quickly opening and closing a port."""
+    message = b"Fast write and close test" * 10
+    connection_lost_event = asyncio.Event()
+
+    class FastCloseProtocol(asyncio.Protocol):
+        def connection_made(self, transport: asyncio.BaseTransport) -> None:
+            transport = cast(SerialTransport, transport)
+            transport.write(message)
+            # transport.close()  # Immediately closing after write will not cause data loss
+            transport.abort()
+
+        def connection_lost(self, exc: Exception | None) -> None:
+            connection_lost_event.set()
+
+    async with async_create_reader_writer(DUAL_LOOPBACK_RIGHT, baudrate=300) as (
+        reader,
+        writer,
+    ):
+        read_task = asyncio.create_task(reader.readexactly(len(message)))
+        await asyncio.sleep(0)
+
+        transport, _ = await create_serial_connection(
+            asyncio.get_running_loop(),
+            FastCloseProtocol,
+            DUAL_LOOPBACK_LEFT,
+            baudrate=300,
+        )
+
+        await connection_lost_event.wait()
+        assert await read_task == message

--- a/tests/test_loopback_dual_sync.py
+++ b/tests/test_loopback_dual_sync.py
@@ -428,3 +428,15 @@ def test_deprecated_rts_property_dual() -> None:
         serial.rts = True
         # RTS may be None with socat, just verify no error occurs
         serial.rts = False
+
+
+def test_fast_open_close() -> None:
+    """Test quickly opening and closing a port."""
+
+    message = b"Fast write and close test"
+
+    with Serial(DUAL_LOOPBACK_LEFT, baudrate=300) as serial_left:
+        with Serial(DUAL_LOOPBACK_RIGHT, baudrate=300) as serial_right:
+            serial_right.write(message)
+
+        assert serial_left.readexactly(len(message)) == message


### PR DESCRIPTION
This backports the only major fix from pyserial-asyncio-fast that we really need. Every serial chip that I tested (CP2102N and FTDI clone, waiting for a CH340) exhibits the same behavior: `termios.tcdrain(self._fileno)` completes instantly and `os.close(self._fileno)` blocks. At 300 baud, this can take many seconds to complete, necessitating moving `os.close` into the thread pool executor to avoid locking up the event loop.

We can easily re-add the flushing behavior if necessary but I don't believe it's needed, no test scenario I can come up with causes data loss.