### PR TITLE
Allow configurable HUPCL on POSIX 

### DIFF
--- a/serialx/common.py
+++ b/serialx/common.py
@@ -76,6 +76,7 @@ class BaseSerial(io.RawIOBase):
         *,
         buffer_character_count: int = 1,
         buffer_burst_timeout: float = 0.01,
+        hang_up_on_close: bool = True,
         exclusive: bool = True,
     ) -> None:
         """Initialize serial port configuration."""
@@ -94,6 +95,7 @@ class BaseSerial(io.RawIOBase):
         self._rtscts = rtscts
         self._parity = parity
         self._byte_size = byte_size
+        self._hang_up_on_close = hang_up_on_close
         self._exclusive = exclusive
 
         self._buffer_character_count = buffer_character_count
@@ -149,6 +151,11 @@ class BaseSerial(io.RawIOBase):
     def stopbits(self) -> StopBits:
         """Get the number of stop bits."""
         return self._stopbits
+
+    @property
+    def hang_up_on_close(self) -> bool:
+        """Get the hang up on close setting."""
+        return self._hang_up_on_close
 
     @property
     def exclusive(self) -> bool:
@@ -269,6 +276,12 @@ class BaseSerialTransport(asyncio.Transport):
         """Get the byte size."""
         assert self._serial is not None
         return self._serial.byte_size
+
+    @property
+    def hang_up_on_close(self) -> bool:
+        """Get the hang up on close setting."""
+        assert self._serial is not None
+        return self._serial.hang_up_on_close
 
     @property
     def exclusive(self) -> bool:

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -13,6 +13,13 @@ from typing import Any
 from typing_extensions import Self
 
 
+class UndefinedType:
+    """Sentinel type for undefined values."""
+
+
+UNDEFINED = UndefinedType()
+
+
 class StopBits(Enum):
     """Stop bits configuration."""
 
@@ -76,7 +83,8 @@ class BaseSerial(io.RawIOBase):
         *,
         buffer_character_count: int = 1,
         buffer_burst_timeout: float = 0.01,
-        hang_up_on_close: bool = True,
+        deassert_on_open: bool | UndefinedType = UNDEFINED,
+        hang_up_on_close: bool = False,
         exclusive: bool = True,
     ) -> None:
         """Initialize serial port configuration."""
@@ -95,8 +103,13 @@ class BaseSerial(io.RawIOBase):
         self._rtscts = rtscts
         self._parity = parity
         self._byte_size = byte_size
-        self._hang_up_on_close = hang_up_on_close
         self._exclusive = exclusive
+
+        # Deassert on open when not using hardware flow control
+        if deassert_on_open is UNDEFINED:
+            self._deassert_on_open = not rtscts
+
+        self._hang_up_on_close = hang_up_on_close
 
         self._buffer_character_count = buffer_character_count
         self._buffer_burst_timeout = buffer_burst_timeout

--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -155,7 +155,7 @@ class PosixSerial(BaseSerial):
 
         fcntl.ioctl(self._fileno, TCSETS2, buffer)
 
-    def configure_port(self) -> None:
+    def configure_port(self) -> None:  # noqa: C901
         """Configure the serial port settings."""
         LOGGER.debug("Configuring serial port %r", self._path)
 
@@ -288,6 +288,9 @@ class PosixSerial(BaseSerial):
                     LOGGER.debug("Device is not a serial port, cannot set low latency")
                 else:
                     raise
+
+        if self._deassert_on_open:
+            self.set_modem_bits(ModemBits(dtr=False, rts=False))
 
         # Flush input and output buffers to discard stale data
         termios.tcflush(self._fileno, termios.TCIOFLUSH)

--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -170,6 +170,10 @@ class PosixSerial(BaseSerial):
         # Ignore modem control lines
         cflag |= termios.CLOCAL
 
+        # Lower modem control lines after last process closes the device (hang up)
+        if self._hang_up_on_close:
+            cflag |= termios.HUPCL
+
         # Character size
         if self._byte_size == 5:
             cflag |= termios.CS5


### PR DESCRIPTION
This "hangs up" when closing the serial port. I've also added a `deassert_on_open`, enabled when hardware flow control is _disabled_.