### PR TITLE
Fix `deassert_on_open` and add extensive unit tests

### DIFF
--- a/serialx/__init__.py
+++ b/serialx/__init__.py
@@ -2,7 +2,11 @@
 
 import sys
 
-from .async_serial import create_serial_connection, open_serial_connection
+from .async_serial import (
+    SerialStreamWriter,
+    create_serial_connection,
+    open_serial_connection,
+)
 from .common import ModemBits, Parity, StopBits
 from .platforms import Serial, SerialTransport
 
@@ -12,6 +16,7 @@ __all__ = [
     "ModemBits",
     "Parity",
     "Serial",
+    "SerialStreamWriter",
     "SerialTransport",
     "StopBits",
 ]

--- a/serialx/async_serial.py
+++ b/serialx/async_serial.py
@@ -4,12 +4,24 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from typing import Generic, TypeVar
 import urllib.parse
 
 from .common import Parity, StopBits
 from .platforms import SerialTransport
 
 LOGGER = logging.getLogger(__name__)
+
+_T = TypeVar("_T", bound=asyncio.WriteTransport, default=asyncio.WriteTransport)
+
+
+class SerialStreamWriter(asyncio.StreamWriter, Generic[_T]):
+    """StreamWriter with properly typed transport."""
+
+    @property
+    def transport(self) -> _T:  # type: ignore[override]
+        """Return the underlying transport."""
+        return super().transport  # type: ignore[return-value]
 
 
 async def create_serial_connection(
@@ -56,7 +68,7 @@ async def create_serial_connection(
 
 async def open_serial_connection(
     *args, **kwargs
-) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+) -> tuple[asyncio.StreamReader, SerialStreamWriter[SerialTransport]]:
     """Open a serial port connection using StreamReader and StreamWriter."""
     loop = asyncio.get_running_loop()
 
@@ -65,6 +77,8 @@ async def open_serial_connection(
     transport, _ = await create_serial_connection(
         loop, lambda: protocol, *args, **kwargs
     )
-    writer = asyncio.StreamWriter(transport, protocol, reader, loop)
+    writer: SerialStreamWriter[SerialTransport] = SerialStreamWriter(
+        transport, protocol, reader, loop
+    )
 
     return reader, writer

--- a/serialx/async_serial.py
+++ b/serialx/async_serial.py
@@ -12,7 +12,7 @@ from .platforms import SerialTransport
 
 LOGGER = logging.getLogger(__name__)
 
-_T = TypeVar("_T", bound=asyncio.WriteTransport, default=asyncio.WriteTransport)
+_T = TypeVar("_T", bound=asyncio.WriteTransport)
 
 
 class SerialStreamWriter(asyncio.StreamWriter, Generic[_T]):

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -67,6 +67,27 @@ class ModemBits:
             dsr=False,
         )
 
+    def __repr__(self) -> str:
+        """Return string representation of modem bits."""
+
+        bits = [
+            bit
+            for bit in (
+                "le",
+                "dtr",
+                "rts",
+                "st",
+                "sr",
+                "cts",
+                "car",
+                "rng",
+                "dsr",
+            )
+            if getattr(self, bit)
+        ]
+
+        return f"{self.__class__.__name__}[{' '.join(bits)}]"
+
 
 class BaseSerial(io.RawIOBase):
     """Base class for serial port communication."""

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -108,6 +108,9 @@ class BaseSerial(io.RawIOBase):
         # Deassert on open when not using hardware flow control
         if deassert_on_open is UNDEFINED:
             self._deassert_on_open = not rtscts
+        else:
+            assert isinstance(deassert_on_open, bool)
+            self._deassert_on_open = deassert_on_open
 
         self._hang_up_on_close = hang_up_on_close
 

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -13,13 +13,6 @@ from typing import Any
 from typing_extensions import Self
 
 
-class UndefinedType:
-    """Sentinel type for undefined values."""
-
-
-UNDEFINED = UndefinedType()
-
-
 class StopBits(Enum):
     """Stop bits configuration."""
 
@@ -104,7 +97,7 @@ class BaseSerial(io.RawIOBase):
         *,
         buffer_character_count: int = 1,
         buffer_burst_timeout: float = 0.01,
-        deassert_on_open: bool | UndefinedType = UNDEFINED,
+        deassert_on_open: bool | None = None,
         hang_up_on_close: bool = False,
         exclusive: bool = True,
     ) -> None:
@@ -127,10 +120,9 @@ class BaseSerial(io.RawIOBase):
         self._exclusive = exclusive
 
         # Deassert on open when not using hardware flow control
-        if deassert_on_open is UNDEFINED:
+        if deassert_on_open is None:
             self._deassert_on_open = not rtscts
         else:
-            assert isinstance(deassert_on_open, bool)
             self._deassert_on_open = deassert_on_open
 
         self._hang_up_on_close = hang_up_on_close

--- a/serialx/descriptor_transport.py
+++ b/serialx/descriptor_transport.py
@@ -18,11 +18,13 @@ LOG_THRESHOLD_FOR_CONNLOST_WRITES = 5
 _BACKGROUND_TASKS: set[asyncio.Task] = set()
 
 
-def _create_background_task(coro: Coroutine) -> None:
+def _create_background_task(coro: Coroutine) -> asyncio.Task[None]:
     """Create a background task that will not be garbage collected."""
     task = asyncio.create_task(coro)
     _BACKGROUND_TASKS.add(task)
     task.add_done_callback(_BACKGROUND_TASKS.discard)
+
+    return task
 
 
 class DescriptorTransport(asyncio.Transport):
@@ -51,6 +53,8 @@ class DescriptorTransport(asyncio.Transport):
         self._paused = False
         self._empty_waiter: asyncio.Future | None = None
         self._extra: dict[str, Any] = {}
+
+        self._close_task: asyncio.Task[None] | None = None
 
     async def _open(self, path: os.PathLike) -> None:
         self._fileno = await self._loop.run_in_executor(
@@ -82,7 +86,7 @@ class DescriptorTransport(asyncio.Transport):
                 self._closing = True
                 self._loop.remove_reader(self._fileno)
                 self._loop.call_soon(self._protocol.eof_received)
-                _create_background_task(self._call_connection_lost(None))
+                self._maybe_background_close(None)
 
     def pause_reading(self) -> None:
         """Pause reading from the file descriptor."""
@@ -262,7 +266,7 @@ class DescriptorTransport(asyncio.Transport):
                 self._maybe_resume_protocol()  # May append to buffer.
                 if self._closing:
                     self._loop.remove_reader(self._fileno)
-                    _create_background_task(self._call_connection_lost(None))
+                    self._maybe_background_close(None)
                 return
             elif n > 0:
                 del self._buffer[:n]
@@ -279,7 +283,7 @@ class DescriptorTransport(asyncio.Transport):
         self._closing = True
         if not self._buffer:
             self._loop.remove_reader(self._fileno)
-            _create_background_task(self._call_connection_lost(None))
+            self._maybe_background_close(None)
 
     def set_protocol(self, protocol: asyncio.Protocol) -> None:  # type: ignore[override]
         """Set the protocol to use with this transport."""
@@ -337,7 +341,15 @@ class DescriptorTransport(asyncio.Transport):
             self._loop.remove_writer(self._fileno)
         self._buffer.clear()
         self._loop.remove_reader(self._fileno)
-        _create_background_task(self._call_connection_lost(exc))
+        self._maybe_background_close(exc)
+
+    def _maybe_background_close(self, exc: Exception | None) -> None:
+        """Start background task to close the transport if not already started."""
+        if self._close_task is not None:
+            LOGGER.debug("Close task already exists, not closing again")
+            return
+
+        self._close_task = _create_background_task(self._call_connection_lost(exc))
 
     async def _call_connection_lost(self, exc: Exception | None) -> None:
         LOGGER.debug("Closing connection: %r", exc)
@@ -357,6 +369,7 @@ class DescriptorTransport(asyncio.Transport):
             protocol = self._protocol
             self._loop = None  # type: ignore[assignment]
             self._protocol = None  # type: ignore[assignment]
+            self._close_task = None
 
             LOGGER.debug("Calling protocol `connection_lost` with exc=%r", exc)
             protocol.connection_lost(exc)

--- a/tests/common.py
+++ b/tests/common.py
@@ -82,7 +82,9 @@ async def async_create_socat_pair() -> AsyncIterator[tuple[str, str]]:
 async def async_create_reader_writer(
     port: str | None,
     **kwargs: Any,
-) -> AsyncIterator[tuple[asyncio.StreamReader, asyncio.StreamWriter]]:
+) -> AsyncIterator[
+    tuple[asyncio.StreamReader, serialx.SerialStreamWriter[serialx.SerialTransport]]
+]:
     """Create a single reader/writer pair."""
 
     if port is None:

--- a/tests/test_loopback_dual_async.py
+++ b/tests/test_loopback_dual_async.py
@@ -12,13 +12,7 @@ else:
 
 import pytest
 
-from serialx import (
-    ModemBits,
-    Parity,
-    SerialTransport,
-    StopBits,
-    create_serial_connection,
-)
+from serialx import Parity, SerialTransport, StopBits, create_serial_connection
 from tests.common import (
     DUAL_LOOPBACK_LEFT,
     DUAL_LOOPBACK_RIGHT,
@@ -424,54 +418,6 @@ async def test_read_with_timeout_async() -> None:
         # Reading without data should timeout
         with pytest.raises(asyncio.TimeoutError):
             await asyncio.wait_for(reader_right.readexactly(1), timeout=0.1)
-
-
-async def test_get_modem_bits_async() -> None:
-    """Test reading modem control bits."""
-    async with async_create_dual_loopback(baudrate=115200) as (
-        reader,
-        writer,
-        _,
-        _writer_right,
-    ):
-        transport = cast(SerialTransport, writer.transport)
-        modem_bits = await transport.get_modem_bits()
-
-        # Verify we get a ModemBits object
-        assert isinstance(modem_bits, ModemBits)
-
-        # All modem bits should be either True, False, or None
-        for field in ["le", "dtr", "rts", "st", "sr", "cts", "car", "rng", "dsr"]:
-            value = getattr(modem_bits, field)
-            assert value in (True, False, None)
-
-
-async def test_set_modem_bits_async() -> None:
-    """Test setting modem control bits with dual loopback hardware."""
-    async with async_create_dual_loopback(baudrate=115200) as (
-        reader,
-        writer,
-        _,
-        _writer_right,
-    ):
-        transport = cast(SerialTransport, writer.transport)
-        # With real hardware, modem control signals should work
-        await transport.set_modem_bits(ModemBits(dtr=True, rts=True))
-        modem_bits = await transport.get_modem_bits()
-        assert modem_bits.dtr is True
-        assert modem_bits.rts is True
-
-        # Set DTR low, leave RTS unchanged
-        await transport.set_modem_bits(ModemBits(dtr=False))
-        modem_bits = await transport.get_modem_bits()
-        assert modem_bits.dtr is False
-        assert modem_bits.rts is True
-
-        # Set both low
-        await transport.set_modem_bits(ModemBits(dtr=False, rts=False))
-        modem_bits = await transport.get_modem_bits()
-        assert modem_bits.dtr is False
-        assert modem_bits.rts is False
 
 
 async def test_fast_open_close() -> None:

--- a/tests/test_loopback_dual_async.py
+++ b/tests/test_loopback_dual_async.py
@@ -2,17 +2,17 @@
 
 import asyncio
 import os
-import sys
 from typing import cast
-
-if sys.version_info >= (3, 11):
-    pass
-else:
-    pass
 
 import pytest
 
-from serialx import Parity, SerialTransport, StopBits, create_serial_connection
+from serialx import (
+    ModemBits,
+    Parity,
+    SerialTransport,
+    StopBits,
+    create_serial_connection,
+)
 from tests.common import (
     DUAL_LOOPBACK_LEFT,
     DUAL_LOOPBACK_RIGHT,
@@ -451,3 +451,78 @@ async def test_fast_open_close() -> None:
 
         await connection_lost_event.wait()
         assert await read_task == message
+
+
+async def test_deassert_on_open_async() -> None:
+    """Test DTR/CTS deassertion on open."""
+    async with async_create_reader_writer(DUAL_LOOPBACK_LEFT, baudrate=115200) as (
+        reader_left,
+        writer_left,
+    ):
+        # Open and set DTR/CTS
+        async with async_create_reader_writer(
+            DUAL_LOOPBACK_RIGHT, baudrate=115200, deassert_on_open=False
+        ) as (
+            reader_right,
+            writer_right,
+        ):
+            await writer_right.transport.set_modem_bits(ModemBits(dtr=True))
+            assert (await writer_left.transport.get_modem_bits()).cts is True
+
+        # It persists
+        assert (await writer_left.transport.get_modem_bits()).cts is True
+
+        # When we deassert on open, it should clear
+        async with async_create_reader_writer(
+            DUAL_LOOPBACK_RIGHT, baudrate=115200, deassert_on_open=True
+        ) as (
+            reader_right,
+            writer_right,
+        ):
+            assert (await writer_left.transport.get_modem_bits()).cts is False
+            await writer_right.transport.set_modem_bits(ModemBits(dtr=True))
+
+        # And stay cleared
+        assert (await writer_left.transport.get_modem_bits()).cts is True
+
+
+async def test_hang_up_on_close_async() -> None:
+    """Test DTR/CTS hang up on close."""
+    async with async_create_reader_writer(DUAL_LOOPBACK_LEFT, baudrate=115200) as (
+        reader_left,
+        writer_left,
+    ):
+        # Open and set DTR/CTS
+        async with async_create_reader_writer(
+            DUAL_LOOPBACK_RIGHT, baudrate=115200, hang_up_on_close=False
+        ) as (
+            reader_right,
+            writer_right,
+        ):
+            await writer_right.transport.set_modem_bits(ModemBits(dtr=True))
+            assert (await writer_left.transport.get_modem_bits()).cts is True
+
+        # It persists
+        assert (await writer_left.transport.get_modem_bits()).cts is True
+
+        # Without hang up on close, it still persists
+        async with async_create_reader_writer(
+            DUAL_LOOPBACK_RIGHT, baudrate=115200, hang_up_on_close=False
+        ) as (
+            reader_right,
+            writer_right,
+        ):
+            assert (await writer_left.transport.get_modem_bits()).cts is True
+
+        assert (await writer_left.transport.get_modem_bits()).cts is True
+
+        # When we hang up on close, it should clear
+        async with async_create_reader_writer(
+            DUAL_LOOPBACK_RIGHT, baudrate=115200, hang_up_on_close=True
+        ) as (
+            reader_right,
+            writer_right,
+        ):
+            assert (await writer_left.transport.get_modem_bits()).cts is True
+
+        assert (await writer_left.transport.get_modem_bits()).cts is False

--- a/tests/test_loopback_dual_async.py
+++ b/tests/test_loopback_dual_async.py
@@ -494,7 +494,10 @@ async def test_hang_up_on_close_async() -> None:
     ):
         # Open and set DTR/CTS
         async with async_create_reader_writer(
-            DUAL_LOOPBACK_RIGHT, baudrate=115200, hang_up_on_close=False
+            DUAL_LOOPBACK_RIGHT,
+            baudrate=115200,
+            hang_up_on_close=False,
+            deassert_on_open=False,
         ) as (
             reader_right,
             writer_right,
@@ -507,7 +510,10 @@ async def test_hang_up_on_close_async() -> None:
 
         # Without hang up on close, it still persists
         async with async_create_reader_writer(
-            DUAL_LOOPBACK_RIGHT, baudrate=115200, hang_up_on_close=False
+            DUAL_LOOPBACK_RIGHT,
+            baudrate=115200,
+            hang_up_on_close=False,
+            deassert_on_open=False,
         ) as (
             reader_right,
             writer_right,
@@ -518,7 +524,10 @@ async def test_hang_up_on_close_async() -> None:
 
         # When we hang up on close, it should clear
         async with async_create_reader_writer(
-            DUAL_LOOPBACK_RIGHT, baudrate=115200, hang_up_on_close=True
+            DUAL_LOOPBACK_RIGHT,
+            baudrate=115200,
+            hang_up_on_close=True,
+            deassert_on_open=False,
         ) as (
             reader_right,
             writer_right,

--- a/tests/test_loopback_dual_async.py
+++ b/tests/test_loopback_dual_async.py
@@ -482,7 +482,7 @@ async def test_deassert_on_open_async() -> None:
             assert (await writer_left.transport.get_modem_bits()).cts is False
             await writer_right.transport.set_modem_bits(ModemBits(dtr=True))
 
-        # And stay cleared
+        # Nothing changes on close
         assert (await writer_left.transport.get_modem_bits()).cts is True
 
 

--- a/tests/test_loopback_dual_async.py
+++ b/tests/test_loopback_dual_async.py
@@ -526,3 +526,51 @@ async def test_hang_up_on_close_async() -> None:
             assert (await writer_left.transport.get_modem_bits()).cts is True
 
         assert (await writer_left.transport.get_modem_bits()).cts is False
+
+
+@pytest.mark.parametrize(
+    ("rtscts", "deassert_on_open", "expected_state"),
+    [
+        (False, None, False),  # No flow control, auto-detect -> clear pins
+        (False, False, True),  # No flow control, preserve pins (explicit override)
+        (False, True, False),  # No flow control, clear pins (explicit, matches auto)
+        (True, None, True),  # Flow control, auto-detect -> preserve pins
+        (True, False, True),  # Flow control, preserve pins (explicit, matches auto)
+        (True, True, False),  # Flow control, clear pins (explicit override)
+    ],
+)
+async def test_deassert_on_open_with_rtscts_async(
+    rtscts: bool, deassert_on_open: bool | None, expected_state: bool
+) -> None:
+    """Test interaction of deassert_on_open with rtscts."""
+    async with async_create_reader_writer(DUAL_LOOPBACK_LEFT, baudrate=115200) as (
+        reader_left,
+        writer_left,
+    ):
+        # Set DTR on right side, verify CTS appears on left
+        async with async_create_reader_writer(
+            DUAL_LOOPBACK_RIGHT,
+            baudrate=115200,
+            rtscts=False,
+            deassert_on_open=False,
+        ) as (
+            reader_right,
+            writer_right,
+        ):
+            await writer_right.transport.set_modem_bits(ModemBits(dtr=True))
+            assert (await writer_left.transport.get_modem_bits()).cts is True
+
+        # DTR persists after close
+        assert (await writer_left.transport.get_modem_bits()).cts is True
+
+        # Open with test parameters
+        async with async_create_reader_writer(
+            DUAL_LOOPBACK_RIGHT,
+            baudrate=115200,
+            rtscts=rtscts,
+            deassert_on_open=deassert_on_open,
+        ) as (
+            reader_right,
+            writer_right,
+        ):
+            assert (await writer_left.transport.get_modem_bits()).cts is expected_state

--- a/tests/test_loopback_dual_sync.py
+++ b/tests/test_loopback_dual_sync.py
@@ -441,7 +441,7 @@ def test_deassert_on_open() -> None:
             assert serial_left.get_modem_bits().cts is False
             serial_right.set_modem_bits(ModemBits(dtr=True))
 
-        # And stay cleared
+        # Nothing changes on close
         assert serial_left.get_modem_bits().cts is True
 
 

--- a/tests/test_loopback_dual_sync.py
+++ b/tests/test_loopback_dual_sync.py
@@ -473,3 +473,42 @@ def test_hang_up_on_close() -> None:
             assert serial_left.get_modem_bits().cts is True
 
         assert serial_left.get_modem_bits().cts is False
+
+
+@pytest.mark.parametrize(
+    ("rtscts", "deassert_on_open", "expected_state"),
+    [
+        (False, None, False),  # No flow control, auto-detect -> clear pins
+        (False, False, True),  # No flow control, preserve pins (explicit override)
+        (False, True, False),  # No flow control, clear pins (explicit, matches auto)
+        (True, None, True),  # Flow control, auto-detect -> preserve pins
+        (True, False, True),  # Flow control, preserve pins (explicit, matches auto)
+        (True, True, False),  # Flow control, clear pins (explicit override)
+    ],
+)
+def test_deassert_on_open_with_rtscts(
+    rtscts: bool, deassert_on_open: bool | None, expected_state: bool
+) -> None:
+    """Test interaction of deassert_on_open with rtscts."""
+    with Serial(DUAL_LOOPBACK_LEFT, baudrate=115200) as serial_left:
+        # Set DTR on right side, verify CTS appears on left
+        with Serial(
+            DUAL_LOOPBACK_RIGHT,
+            baudrate=115200,
+            rtscts=False,
+            deassert_on_open=False,
+        ) as serial_right:
+            serial_right.set_modem_bits(ModemBits(dtr=True))
+            assert serial_left.get_modem_bits().cts is True
+
+        # DTR persists after close
+        assert serial_left.get_modem_bits().cts is True
+
+        # Open with test parameters
+        with Serial(
+            DUAL_LOOPBACK_RIGHT,
+            baudrate=115200,
+            rtscts=rtscts,
+            deassert_on_open=deassert_on_open,
+        ) as serial_right:
+            assert serial_left.get_modem_bits().cts is expected_state

--- a/tests/test_loopback_dual_sync.py
+++ b/tests/test_loopback_dual_sync.py
@@ -450,7 +450,10 @@ def test_hang_up_on_close() -> None:
     with Serial(DUAL_LOOPBACK_LEFT, baudrate=115200) as serial_left:
         # Open and set DTR/CTS
         with Serial(
-            DUAL_LOOPBACK_RIGHT, baudrate=115200, hang_up_on_close=False
+            DUAL_LOOPBACK_RIGHT,
+            baudrate=115200,
+            hang_up_on_close=False,
+            deassert_on_open=False,
         ) as serial_right:
             serial_right.set_modem_bits(ModemBits(dtr=True))
             assert serial_left.get_modem_bits().cts is True
@@ -460,7 +463,10 @@ def test_hang_up_on_close() -> None:
 
         # Without hang up on close, it still persists
         with Serial(
-            DUAL_LOOPBACK_RIGHT, baudrate=115200, hang_up_on_close=False
+            DUAL_LOOPBACK_RIGHT,
+            baudrate=115200,
+            hang_up_on_close=False,
+            deassert_on_open=False,
         ) as serial_right:
             assert serial_left.get_modem_bits().cts is True
 
@@ -468,7 +474,10 @@ def test_hang_up_on_close() -> None:
 
         # When we hang up on close, it should clear
         with Serial(
-            DUAL_LOOPBACK_RIGHT, baudrate=115200, hang_up_on_close=True
+            DUAL_LOOPBACK_RIGHT,
+            baudrate=115200,
+            hang_up_on_close=True,
+            deassert_on_open=False,
         ) as serial_right:
             assert serial_left.get_modem_bits().cts is True
 

--- a/tests/test_loopback_dual_sync.py
+++ b/tests/test_loopback_dual_sync.py
@@ -419,3 +419,57 @@ def test_dtr_cts_dual() -> None:
 
         serial_right.set_modem_bits(ModemBits(dtr=False))
         assert serial_left.get_modem_bits().cts is False
+
+
+def test_deassert_on_open() -> None:
+    """Test DTR/CTS deassertion on open."""
+    with Serial(DUAL_LOOPBACK_LEFT, baudrate=115200) as serial_left:
+        # Open and set DTR/CTS
+        with Serial(
+            DUAL_LOOPBACK_RIGHT, baudrate=115200, deassert_on_open=False
+        ) as serial_right:
+            serial_right.set_modem_bits(ModemBits(dtr=True))
+            assert serial_left.get_modem_bits().cts is True
+
+        # It persists
+        assert serial_left.get_modem_bits().cts is True
+
+        # When we deassert on open, it should clear
+        with Serial(
+            DUAL_LOOPBACK_RIGHT, baudrate=115200, deassert_on_open=True
+        ) as serial_right:
+            assert serial_left.get_modem_bits().cts is False
+            serial_right.set_modem_bits(ModemBits(dtr=True))
+
+        # And stay cleared
+        assert serial_left.get_modem_bits().cts is True
+
+
+def test_hang_up_on_close() -> None:
+    """Test DTR/CTS hang up on close."""
+    with Serial(DUAL_LOOPBACK_LEFT, baudrate=115200) as serial_left:
+        # Open and set DTR/CTS
+        with Serial(
+            DUAL_LOOPBACK_RIGHT, baudrate=115200, hang_up_on_close=False
+        ) as serial_right:
+            serial_right.set_modem_bits(ModemBits(dtr=True))
+            assert serial_left.get_modem_bits().cts is True
+
+        # It persists
+        assert serial_left.get_modem_bits().cts is True
+
+        # Without hang up on close, it still persists
+        with Serial(
+            DUAL_LOOPBACK_RIGHT, baudrate=115200, hang_up_on_close=False
+        ) as serial_right:
+            assert serial_left.get_modem_bits().cts is True
+
+        assert serial_left.get_modem_bits().cts is True
+
+        # When we hang up on close, it should clear
+        with Serial(
+            DUAL_LOOPBACK_RIGHT, baudrate=115200, hang_up_on_close=True
+        ) as serial_right:
+            assert serial_left.get_modem_bits().cts is True
+
+        assert serial_left.get_modem_bits().cts is False

--- a/tests/test_loopback_dual_sync.py
+++ b/tests/test_loopback_dual_sync.py
@@ -377,59 +377,6 @@ def test_multiple_flush_calls_dual() -> None:
         assert result == data
 
 
-def test_get_modem_bits_dual() -> None:
-    """Test reading modem control bits with loopback adapter."""
-    with Serial(DUAL_LOOPBACK_LEFT, baudrate=115200) as serial:
-        modem_bits = serial.get_modem_bits()
-
-        # Verify we get a ModemBits object
-        assert isinstance(modem_bits, ModemBits)
-
-        # All modem bits should be either True, False, or None
-        for field in ["le", "dtr", "rts", "st", "sr", "cts", "car", "rng", "dsr"]:
-            value = getattr(modem_bits, field)
-            assert value in (True, False, None)
-
-
-def test_set_modem_bits_dual() -> None:
-    """Test setting modem control bits with socat pair."""
-    with Serial(DUAL_LOOPBACK_LEFT, baudrate=115200) as serial:
-        # Note: socat pairs don't support modem control signals properly
-        # These calls should not raise errors, but values may be None
-        serial.set_modem_bits(ModemBits(dtr=True, rts=True))
-        modem_bits = serial.get_modem_bits()
-        # Verify we get a ModemBits object, values may be None with socat
-        assert isinstance(modem_bits, ModemBits)
-
-        serial.set_modem_bits(ModemBits(dtr=False))
-        modem_bits = serial.get_modem_bits()
-        assert isinstance(modem_bits, ModemBits)
-
-        serial.set_modem_bits(ModemBits(dtr=False, rts=False))
-        modem_bits = serial.get_modem_bits()
-        assert isinstance(modem_bits, ModemBits)
-
-
-def test_deprecated_dtr_property_dual() -> None:
-    """Test DTR property (deprecated alias) with socat pair."""
-    with Serial(DUAL_LOOPBACK_LEFT, baudrate=115200) as serial:
-        # Note: socat pairs don't support modem control signals properly
-        # These calls should not raise errors, but values may be None with socat
-        serial.dtr = True
-        # DTR may be None with socat, just verify no error occurs
-        serial.dtr = False
-
-
-def test_deprecated_rts_property_dual() -> None:
-    """Test RTS property (deprecated alias) with socat pair."""
-    with Serial(DUAL_LOOPBACK_LEFT, baudrate=115200) as serial:
-        # Note: socat pairs don't support modem control signals properly
-        # These calls should not raise errors, but values may be None with socat
-        serial.rts = True
-        # RTS may be None with socat, just verify no error occurs
-        serial.rts = False
-
-
 def test_fast_open_close() -> None:
     """Test quickly opening and closing a port."""
 
@@ -440,3 +387,35 @@ def test_fast_open_close() -> None:
             serial_right.write(message)
 
         assert serial_left.readexactly(len(message)) == message
+
+
+def test_deprecated_dtr_cts_dual() -> None:
+    """Test DTR and CTS properties (deprecated alias)."""
+    with create_dual_loopback(baudrate=115200) as (serial_left, serial_right):
+        serial_left.dtr = True
+        assert serial_right.get_modem_bits().cts is True
+
+        serial_right.dtr = True
+        assert serial_left.get_modem_bits().cts is True
+
+        serial_left.dtr = False
+        assert serial_right.get_modem_bits().cts is False
+
+        serial_right.dtr = False
+        assert serial_left.get_modem_bits().cts is False
+
+
+def test_dtr_cts_dual() -> None:
+    """Test DTR and CTS."""
+    with create_dual_loopback(baudrate=115200) as (serial_left, serial_right):
+        serial_left.set_modem_bits(ModemBits(dtr=True))
+        assert serial_right.get_modem_bits().cts is True
+
+        serial_right.set_modem_bits(ModemBits(dtr=True))
+        assert serial_left.get_modem_bits().cts is True
+
+        serial_left.set_modem_bits(ModemBits(dtr=False))
+        assert serial_right.get_modem_bits().cts is False
+
+        serial_right.set_modem_bits(ModemBits(dtr=False))
+        assert serial_left.get_modem_bits().cts is False


### PR DESCRIPTION
I've modified `deassert_on_open` to be a `bool | None = None`, with the default based on inverted `rtscts`. Extensive unit tests have been added to test all of these cases.