### PR TITLE
Consolidate startup and shutdown pin state, change `rtsdtr_on_open` default

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ with serialx.Serial("/dev/serial/by-id/port", baudrate=115200) as serial:
     data = serial.readexactly(5)
     serial.write(b"test")
 
-    serial.set_modem_bits(rts=True, dtr=True)
-    bits = serial.get_modem_bits()
-    assert bits.rts is True
-    assert bits.dtr is True
+    serial.set_modem_pins(rts=True, dtr=True)
+    pins = serial.get_modem_pins()
+    assert pins.rts is True
+    assert pins.dtr is True
 ```
 
 A high-level asynchronous serial `(reader, writer)` pair:
@@ -73,5 +73,5 @@ async def main():
 	    baudrate=115200
 	)
 
-	await transport.set_modem_bits(rts=True, dtr=True)
+	await transport.set_modem_pins(rts=True, dtr=True)
 ```

--- a/serialx/__init__.py
+++ b/serialx/__init__.py
@@ -7,7 +7,7 @@ from .async_serial import (
     create_serial_connection,
     open_serial_connection,
 )
-from .common import ModemPins, Parity, StopBits
+from .common import ModemPins, Parity, PinState, StopBits
 from .platforms import Serial, SerialTransport
 
 __all__ = [
@@ -15,6 +15,7 @@ __all__ = [
     "open_serial_connection",
     "ModemPins",
     "Parity",
+    "PinState",
     "Serial",
     "SerialStreamWriter",
     "SerialTransport",

--- a/serialx/__init__.py
+++ b/serialx/__init__.py
@@ -7,13 +7,13 @@ from .async_serial import (
     create_serial_connection,
     open_serial_connection,
 )
-from .common import ModemBits, Parity, StopBits
+from .common import ModemPins, Parity, StopBits
 from .platforms import Serial, SerialTransport
 
 __all__ = [
     "create_serial_connection",
     "open_serial_connection",
-    "ModemBits",
+    "ModemPins",
     "Parity",
     "Serial",
     "SerialStreamWriter",

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -97,7 +97,7 @@ class BaseSerial(io.RawIOBase):
         *,
         buffer_character_count: int = 1,
         buffer_burst_timeout: float = 0.01,
-        deassert_on_open: bool | None = None,
+        rtsdtr_on_open: bool | None = True,
         hang_up_on_close: bool = False,
         exclusive: bool = True,
     ) -> None:
@@ -119,12 +119,7 @@ class BaseSerial(io.RawIOBase):
         self._byte_size = byte_size
         self._exclusive = exclusive
 
-        # Deassert on open when not using hardware flow control
-        if deassert_on_open is None:
-            self._deassert_on_open = not rtscts
-        else:
-            self._deassert_on_open = deassert_on_open
-
+        self._rtsdtr_on_open = rtsdtr_on_open
         self._hang_up_on_close = hang_up_on_close
 
         self._buffer_character_count = buffer_character_count

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -32,7 +32,7 @@ class Parity(Enum):
 
 
 @dataclasses.dataclass(frozen=True)
-class ModemBits:
+class ModemPins:
     """Modem control bits."""
 
     le: bool | None = None
@@ -61,7 +61,7 @@ class ModemBits:
         )
 
     def __repr__(self) -> str:
-        """Return string representation of modem bits."""
+        """Return string representation of modem pins."""
 
         bits = []
 
@@ -142,13 +142,13 @@ class BaseSerial(io.RawIOBase):
         """Configure the serial port settings."""
         raise NotImplementedError
 
-    def get_modem_bits(self) -> ModemBits:
+    def get_modem_pins(self) -> ModemPins:
         """Get modem control bits, internal."""
-        return self._get_modem_bits()
+        return self._get_modem_pins()
 
-    def set_modem_bits(
+    def set_modem_pins(
         self,
-        modem_bits: ModemBits | None = None,
+        modem_pins: ModemPins | None = None,
         *,
         le: bool | None = None,
         dtr: bool | None = None,
@@ -161,8 +161,8 @@ class BaseSerial(io.RawIOBase):
         dsr: bool | None = None,
     ) -> None:
         """Set modem control bits, internal."""
-        if modem_bits is None:
-            modem_bits = ModemBits(
+        if modem_pins is None:
+            modem_pins = ModemPins(
                 le=le,
                 dtr=dtr,
                 rts=rts,
@@ -174,15 +174,15 @@ class BaseSerial(io.RawIOBase):
                 dsr=dsr,
             )
 
-        return self._set_modem_bits(modem_bits)
+        return self._set_modem_pins(modem_pins)
 
     @abstractmethod
-    def _get_modem_bits(self) -> ModemBits:
+    def _get_modem_pins(self) -> ModemPins:
         """Get modem control bits, internal."""
         raise NotImplementedError
 
     @abstractmethod
-    def _set_modem_bits(self, modem_bits: ModemBits) -> None:
+    def _set_modem_pins(self, modem_pins: ModemPins) -> None:
         """Set modem control bits, internal."""
         raise NotImplementedError
 
@@ -230,25 +230,25 @@ class BaseSerial(io.RawIOBase):
     @property
     def dtr(self) -> bool | None:
         """Get DTR modem bit."""
-        return self.get_modem_bits().dtr
+        return self.get_modem_pins().dtr
 
     # Deprecated alias
     @dtr.setter
     def dtr(self, value) -> None:
         """Set DTR modem bit."""
-        self.set_modem_bits(dtr=bool(value))
+        self.set_modem_pins(dtr=bool(value))
 
     # Deprecated alias
     @property
     def rts(self) -> bool | None:
         """Get RTS modem bit."""
-        return self.get_modem_bits().rts
+        return self.get_modem_pins().rts
 
     # Deprecated alias
     @rts.setter
     def rts(self, value) -> None:
         """Set RTS modem bit."""
-        self.set_modem_bits(rts=bool(value))
+        self.set_modem_pins(rts=bool(value))
 
     def readexactly(self, n: int) -> bytes:
         """Read exactly n bytes."""
@@ -362,14 +362,14 @@ class BaseSerialTransport(asyncio.Transport):
         """Connect to serial port."""
         return await self._connect(**kwargs)
 
-    async def get_modem_bits(self) -> ModemBits:
+    async def get_modem_pins(self) -> ModemPins:
         """Get modem control bits."""
         assert self._serial is not None
-        return await self._loop.run_in_executor(None, self._serial.get_modem_bits)
+        return await self._loop.run_in_executor(None, self._serial.get_modem_pins)
 
-    async def set_modem_bits(
+    async def set_modem_pins(
         self,
-        modem_bits: ModemBits | None = None,
+        modem_pins: ModemPins | None = None,
         *,
         le: bool | None = None,
         dtr: bool | None = None,
@@ -387,8 +387,8 @@ class BaseSerialTransport(asyncio.Transport):
             lambda: (
                 None
                 if self._serial is None
-                else self._serial.set_modem_bits(
-                    modem_bits,
+                else self._serial.set_modem_pins(
+                    modem_pins,
                     le=le,
                     dtr=dtr,
                     rts=rts,

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -63,21 +63,27 @@ class ModemBits:
     def __repr__(self) -> str:
         """Return string representation of modem bits."""
 
-        bits = [
-            bit
-            for bit in (
-                "le",
-                "dtr",
-                "rts",
-                "st",
-                "sr",
-                "cts",
-                "car",
-                "rng",
-                "dsr",
-            )
-            if getattr(self, bit)
-        ]
+        bits = []
+
+        for bit in (
+            "le",
+            "dtr",
+            "rts",
+            "st",
+            "sr",
+            "cts",
+            "car",
+            "rng",
+            "dsr",
+        ):
+            value = getattr(self, bit)
+
+            if value is None:
+                continue
+            elif value:
+                bits.append(bit)
+            else:
+                bits.append(f"!{bit}")
 
         return f"{self.__class__.__name__}[{' '.join(bits)}]"
 

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -245,12 +245,12 @@ class BaseSerial(io.RawIOBase):
 
     @property
     def rtsdtr_on_open(self) -> PinState:
-        """Get the hang up on open setting."""
+        """Get the RTS/DTR pin state (on open) setting."""
         return self._rtsdtr_on_open
 
     @property
     def rtsdtr_on_close(self) -> PinState:
-        """Get the hang up on close setting."""
+        """Get the RTS/DTR pin state (on close) setting."""
         return self._rtsdtr_on_close
 
     @property

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -318,7 +318,7 @@ class BaseSerial(io.RawIOBase):
 
     def __del__(self) -> None:
         """Cleanup on deletion."""
-        if self._auto_close:
+        if getattr(self, "_auto_close", False):
             self.close()
 
 

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -31,33 +31,60 @@ class Parity(Enum):
     SPACE = 4
 
 
+class PinState(Enum):
+    """Pin state."""
+
+    UNDEFINED = None
+    LOW = 0
+    HIGH = 1
+
+    @classmethod
+    def convert(cls, value: PinState | bool | None) -> PinState:
+        """Create PinState from boolean."""
+        if isinstance(value, cls):
+            return value
+
+        if value is None:
+            return cls.UNDEFINED
+
+        return cls.HIGH if value else cls.LOW
+
+    def to_bool(self) -> bool | None:
+        """Convert PinState to boolean."""
+        return self.value
+        if self is PinState.UNDEFINED:
+            return None
+
+        return self is PinState.HIGH
+
+
 @dataclasses.dataclass(frozen=True)
 class ModemPins:
     """Modem control bits."""
 
-    le: bool | None = None
-    dtr: bool | None = None
-    rts: bool | None = None
-    st: bool | None = None
-    sr: bool | None = None
-    cts: bool | None = None
-    car: bool | None = None
-    rng: bool | None = None
-    dsr: bool | None = None
+    le: PinState = PinState.UNDEFINED
+    dtr: PinState = PinState.UNDEFINED
+    rts: PinState = PinState.UNDEFINED
+    st: PinState = PinState.UNDEFINED
+    sr: PinState = PinState.UNDEFINED
+    cts: PinState = PinState.UNDEFINED
+    car: PinState = PinState.UNDEFINED
+    rng: PinState = PinState.UNDEFINED
+    dsr: PinState = PinState.UNDEFINED
 
     @classmethod
     def all_off(cls) -> Self:
         """Create instance with all bits set to off."""
         return cls(
-            le=False,
-            dtr=False,
-            rts=False,
-            st=False,
-            sr=False,
-            cts=False,
-            car=False,
-            rng=False,
-            dsr=False,
+            le=PinState.LOW,
+            dtr=PinState.LOW,
+            rts=PinState.LOW,
+            st=PinState.LOW,
+            sr=PinState.LOW,
+            cts=PinState.LOW,
+            car=PinState.LOW,
+            rng=PinState.LOW,
+            dsr=PinState.LOW,
         )
 
     def __repr__(self) -> str:
@@ -78,9 +105,9 @@ class ModemPins:
         ):
             value = getattr(self, bit)
 
-            if value is None:
+            if value is PinState.UNDEFINED:
                 continue
-            elif value:
+            elif value is PinState.HIGH:
                 bits.append(bit)
             else:
                 bits.append(f"!{bit}")
@@ -103,8 +130,8 @@ class BaseSerial(io.RawIOBase):
         *,
         buffer_character_count: int = 1,
         buffer_burst_timeout: float = 0.01,
-        rtsdtr_on_open: bool | None = True,
-        hang_up_on_close: bool = False,
+        rtsdtr_on_open: PinState = PinState.HIGH,
+        rtsdtr_on_close: PinState = PinState.LOW,
         exclusive: bool = True,
     ) -> None:
         """Initialize serial port configuration."""
@@ -126,7 +153,7 @@ class BaseSerial(io.RawIOBase):
         self._exclusive = exclusive
 
         self._rtsdtr_on_open = rtsdtr_on_open
-        self._hang_up_on_close = hang_up_on_close
+        self._rtsdtr_on_close = rtsdtr_on_close
 
         self._buffer_character_count = buffer_character_count
         self._buffer_burst_timeout = buffer_burst_timeout
@@ -150,28 +177,28 @@ class BaseSerial(io.RawIOBase):
         self,
         modem_pins: ModemPins | None = None,
         *,
-        le: bool | None = None,
-        dtr: bool | None = None,
-        rts: bool | None = None,
-        st: bool | None = None,
-        sr: bool | None = None,
-        cts: bool | None = None,
-        car: bool | None = None,
-        rng: bool | None = None,
-        dsr: bool | None = None,
+        le: PinState | bool | None = PinState.UNDEFINED,
+        dtr: PinState | bool | None = PinState.UNDEFINED,
+        rts: PinState | bool | None = PinState.UNDEFINED,
+        st: PinState | bool | None = PinState.UNDEFINED,
+        sr: PinState | bool | None = PinState.UNDEFINED,
+        cts: PinState | bool | None = PinState.UNDEFINED,
+        car: PinState | bool | None = PinState.UNDEFINED,
+        rng: PinState | bool | None = PinState.UNDEFINED,
+        dsr: PinState | bool | None = PinState.UNDEFINED,
     ) -> None:
         """Set modem control bits, internal."""
         if modem_pins is None:
             modem_pins = ModemPins(
-                le=le,
-                dtr=dtr,
-                rts=rts,
-                st=st,
-                sr=sr,
-                cts=cts,
-                car=car,
-                rng=rng,
-                dsr=dsr,
+                le=PinState.convert(le),
+                dtr=PinState.convert(dtr),
+                rts=PinState.convert(rts),
+                st=PinState.convert(st),
+                sr=PinState.convert(sr),
+                cts=PinState.convert(cts),
+                car=PinState.convert(car),
+                rng=PinState.convert(rng),
+                dsr=PinState.convert(dsr),
             )
 
         return self._set_modem_pins(modem_pins)
@@ -217,9 +244,14 @@ class BaseSerial(io.RawIOBase):
         return self._stopbits
 
     @property
-    def hang_up_on_close(self) -> bool:
+    def rtsdtr_on_open(self) -> PinState:
+        """Get the hang up on open setting."""
+        return self._rtsdtr_on_open
+
+    @property
+    def rtsdtr_on_close(self) -> PinState:
         """Get the hang up on close setting."""
-        return self._hang_up_on_close
+        return self._rtsdtr_on_close
 
     @property
     def exclusive(self) -> bool:
@@ -230,11 +262,11 @@ class BaseSerial(io.RawIOBase):
     @property
     def dtr(self) -> bool | None:
         """Get DTR modem bit."""
-        return self.get_modem_pins().dtr
+        return self.get_modem_pins().dtr.to_bool()
 
     # Deprecated alias
     @dtr.setter
-    def dtr(self, value) -> None:
+    def dtr(self, value: bool) -> None:
         """Set DTR modem bit."""
         self.set_modem_pins(dtr=bool(value))
 
@@ -242,11 +274,11 @@ class BaseSerial(io.RawIOBase):
     @property
     def rts(self) -> bool | None:
         """Get RTS modem bit."""
-        return self.get_modem_pins().rts
+        return self.get_modem_pins().rts.to_bool()
 
     # Deprecated alias
     @rts.setter
-    def rts(self, value) -> None:
+    def rts(self, value: bool) -> None:
         """Set RTS modem bit."""
         self.set_modem_pins(rts=bool(value))
 
@@ -340,12 +372,6 @@ class BaseSerialTransport(asyncio.Transport):
         """Get the byte size."""
         assert self._serial is not None
         return self._serial.byte_size
-
-    @property
-    def hang_up_on_close(self) -> bool:
-        """Get the hang up on close setting."""
-        assert self._serial is not None
-        return self._serial.hang_up_on_close
 
     @property
     def exclusive(self) -> bool:

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -141,14 +141,48 @@ class BaseSerial(io.RawIOBase):
         """Configure the serial port settings."""
         raise NotImplementedError
 
-    @abstractmethod
     def get_modem_bits(self) -> ModemBits:
-        """Get modem control bits."""
+        """Get modem control bits, internal."""
+        return self._get_modem_bits()
+
+    def set_modem_bits(
+        self,
+        modem_bits: ModemBits | None = None,
+        *,
+        le: bool | None = None,
+        dtr: bool | None = None,
+        rts: bool | None = None,
+        st: bool | None = None,
+        sr: bool | None = None,
+        cts: bool | None = None,
+        car: bool | None = None,
+        rng: bool | None = None,
+        dsr: bool | None = None,
+    ) -> None:
+        """Set modem control bits, internal."""
+        if modem_bits is None:
+            modem_bits = ModemBits(
+                le=le,
+                dtr=dtr,
+                rts=rts,
+                st=st,
+                sr=sr,
+                cts=cts,
+                car=car,
+                rng=rng,
+                dsr=dsr,
+            )
+
+        return self._set_modem_bits(modem_bits)
+
+    @abstractmethod
+    def _get_modem_bits(self) -> ModemBits:
+        """Get modem control bits, internal."""
         raise NotImplementedError
 
     @abstractmethod
-    def set_modem_bits(self, modem_bits: ModemBits) -> None:
-        """Set modem control bits."""
+    def _set_modem_bits(self, modem_bits: ModemBits) -> None:
+        """Set modem control bits, internal."""
         raise NotImplementedError
 
     @abstractmethod
@@ -201,7 +235,7 @@ class BaseSerial(io.RawIOBase):
     @dtr.setter
     def dtr(self, value) -> None:
         """Set DTR modem bit."""
-        self.set_modem_bits(ModemBits(dtr=bool(value)))
+        self.set_modem_bits(dtr=bool(value))
 
     # Deprecated alias
     @property
@@ -213,7 +247,7 @@ class BaseSerial(io.RawIOBase):
     @rts.setter
     def rts(self, value) -> None:
         """Set RTS modem bit."""
-        self.set_modem_bits(ModemBits(rts=bool(value)))
+        self.set_modem_bits(rts=bool(value))
 
     def readexactly(self, n: int) -> bytes:
         """Read exactly n bytes."""
@@ -332,10 +366,40 @@ class BaseSerialTransport(asyncio.Transport):
         assert self._serial is not None
         return await self._loop.run_in_executor(None, self._serial.get_modem_bits)
 
-    async def set_modem_bits(self, modem_bits: ModemBits) -> None:
+    async def set_modem_bits(
+        self,
+        modem_bits: ModemBits | None = None,
+        *,
+        le: bool | None = None,
+        dtr: bool | None = None,
+        rts: bool | None = None,
+        st: bool | None = None,
+        sr: bool | None = None,
+        cts: bool | None = None,
+        car: bool | None = None,
+        rng: bool | None = None,
+        dsr: bool | None = None,
+    ) -> None:
         """Set modem control bits."""
-        assert self._serial is not None
-        await self._loop.run_in_executor(None, self._serial.set_modem_bits, modem_bits)
+        await self._loop.run_in_executor(
+            None,
+            lambda: (
+                None
+                if self._serial is None
+                else self._serial.set_modem_bits(
+                    modem_bits,
+                    le=le,
+                    dtr=dtr,
+                    rts=rts,
+                    st=st,
+                    sr=sr,
+                    cts=cts,
+                    car=car,
+                    rng=rng,
+                    dsr=dsr,
+                )
+            ),
+        )
 
     async def flush(self) -> None:
         """Flush write buffers, waiting until all data is written."""

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -51,7 +51,6 @@ class PinState(Enum):
 
     def to_bool(self) -> bool | None:
         """Convert PinState to boolean."""
-        return self.value
         if self is PinState.UNDEFINED:
             return None
 

--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -289,8 +289,7 @@ class PosixSerial(BaseSerial):
                 else:
                     raise
 
-        if self._deassert_on_open:
-            self.set_modem_bits(dtr=False, rts=False)
+        self.set_modem_bits(dtr=self._rtsdtr_on_open, rts=self._rtsdtr_on_open)
 
         # Flush input and output buffers to discard stale data
         termios.tcflush(self._fileno, termios.TCIOFLUSH)

--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -20,7 +20,14 @@ else:
 
 from typing_extensions import Buffer
 
-from ..common import BaseSerial, BaseSerialTransport, ModemPins, Parity, StopBits
+from ..common import (
+    BaseSerial,
+    BaseSerialTransport,
+    ModemPins,
+    Parity,
+    PinState,
+    StopBits,
+)
 from ..descriptor_transport import DescriptorTransport
 
 LOGGER = logging.getLogger(__name__)
@@ -171,7 +178,11 @@ class PosixSerial(BaseSerial):
         cflag |= termios.CLOCAL
 
         # Lower modem control lines after last process closes the device (hang up)
-        if self._hang_up_on_close:
+        if self._rtsdtr_on_close is PinState.UNDEFINED:
+            pass
+        elif self._rtsdtr_on_close is PinState.HIGH:
+            LOGGER.warning("POSIX only supports setting RTS/DTR to LOW on close")
+        else:
             cflag |= termios.HUPCL
 
         # Character size
@@ -329,7 +340,10 @@ class PosixSerial(BaseSerial):
 
         n = int.from_bytes(buffer, "little")
         return ModemPins(
-            **{name: bool(n & bit) for name, bit in MODEM_BIT_MAPPING.items()}
+            **{
+                name: PinState.HIGH if n & bit else PinState.LOW
+                for name, bit in MODEM_BIT_MAPPING.items()
+            }
         )
 
     def _set_modem_pins(self, modem_pins: ModemPins) -> None:

--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -11,7 +11,6 @@ import os
 import sys
 import termios
 import time
-from typing import Literal
 
 if sys.version_info >= (3, 11):
     from asyncio import timeout as asyncio_timeout
@@ -72,16 +71,14 @@ POSIX_CHARACTER_SIZE_MAPPING = {
 }
 
 
-def modem_pins_mask_of_value(
-    modem_pins: ModemPins, mask: Literal[True, False, None]
-) -> int:
+def modem_pins_mask_of_value(modem_pins: ModemPins, mask: PinState) -> int:
     """Get modem bit mask for bits matching the specified value."""
     result = 0x00000000
 
     for name, bit in MODEM_BIT_MAPPING.items():
         value = getattr(modem_pins, name)
 
-        if value == mask:
+        if value is mask:
             result |= bit
 
     return result
@@ -353,26 +350,27 @@ class PosixSerial(BaseSerial):
         LOGGER.debug("Setting modem pins: %r", modem_pins)
 
         all_pins_set = all(
-            getattr(modem_pins, name) is not None for name in MODEM_BIT_MAPPING
+            getattr(modem_pins, name) is not PinState.UNDEFINED
+            for name in MODEM_BIT_MAPPING
         )
 
         try:
             if all_pins_set:
                 value = modem_pins_as_int(modem_pins)
-                LOGGER.debug("Setting all modem pins: 0x%08X", value)
+                LOGGER.debug("Setting all with TIOCMSET: 0x%08X", value)
                 fcntl.ioctl(self._fileno, termios.TIOCMSET, value.to_bytes(4, "little"))
             else:
-                to_set = modem_pins_mask_of_value(modem_pins, True)
-                to_clear = modem_pins_mask_of_value(modem_pins, False)
+                to_set = modem_pins_mask_of_value(modem_pins, PinState.HIGH)
+                to_clear = modem_pins_mask_of_value(modem_pins, PinState.LOW)
 
                 if to_set:
-                    LOGGER.debug("Setting modem pins: 0x%08X", to_set)
+                    LOGGER.debug("Setting TIOCMBIS: 0x%08X", to_set)
                     fcntl.ioctl(
                         self._fileno, termios.TIOCMBIS, to_set.to_bytes(4, "little")
                     )
 
                 if to_clear:
-                    LOGGER.debug("Clearing modem pins: 0x%08X", to_clear)
+                    LOGGER.debug("TIOCMBIC: 0x%08X", to_clear)
                     fcntl.ioctl(
                         self._fileno, termios.TIOCMBIC, to_clear.to_bytes(4, "little")
                     )

--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -290,7 +290,7 @@ class PosixSerial(BaseSerial):
                     raise
 
         if self._deassert_on_open:
-            self.set_modem_bits(ModemBits(dtr=False, rts=False))
+            self.set_modem_bits(dtr=False, rts=False)
 
         # Flush input and output buffers to discard stale data
         termios.tcflush(self._fileno, termios.TCIOFLUSH)
@@ -314,7 +314,7 @@ class PosixSerial(BaseSerial):
 
         fcntl.ioctl(self._fileno, TIOCSSERIAL, buffer)
 
-    def get_modem_bits(self) -> ModemBits:
+    def _get_modem_bits(self) -> ModemBits:
         """Get current modem control bits."""
         assert self._fileno is not None
 
@@ -333,7 +333,7 @@ class PosixSerial(BaseSerial):
             **{name: bool(n & bit) for name, bit in MODEM_BIT_MAPPING.items()}
         )
 
-    def set_modem_bits(self, modem_bits: ModemBits) -> None:
+    def _set_modem_bits(self, modem_bits: ModemBits) -> None:
         """Set modem control bits."""
         assert self._fileno is not None
 

--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -20,7 +20,7 @@ else:
 
 from typing_extensions import Buffer
 
-from ..common import BaseSerial, BaseSerialTransport, ModemBits, Parity, StopBits
+from ..common import BaseSerial, BaseSerialTransport, ModemPins, Parity, StopBits
 from ..descriptor_transport import DescriptorTransport
 
 LOGGER = logging.getLogger(__name__)
@@ -55,7 +55,7 @@ MODEM_BIT_MAPPING = {
     "rng": termios.TIOCM_RNG,
     "dsr": termios.TIOCM_DSR,
 }
-assert MODEM_BIT_MAPPING.keys() == ModemBits.__annotations__.keys()
+assert MODEM_BIT_MAPPING.keys() == ModemPins.__annotations__.keys()
 
 POSIX_CHARACTER_SIZE_MAPPING = {
     5: termios.CS5,
@@ -65,14 +65,14 @@ POSIX_CHARACTER_SIZE_MAPPING = {
 }
 
 
-def modem_bits_mask_of_value(
-    modem_bits: ModemBits, mask: Literal[True, False, None]
+def modem_pins_mask_of_value(
+    modem_pins: ModemPins, mask: Literal[True, False, None]
 ) -> int:
     """Get modem bit mask for bits matching the specified value."""
     result = 0x00000000
 
     for name, bit in MODEM_BIT_MAPPING.items():
-        value = getattr(modem_bits, name)
+        value = getattr(modem_pins, name)
 
         if value == mask:
             result |= bit
@@ -80,12 +80,12 @@ def modem_bits_mask_of_value(
     return result
 
 
-def modem_bits_as_int(modem_bits: ModemBits) -> int:
-    """Convert modem bits to integer."""
+def modem_pins_as_int(modem_pins: ModemPins) -> int:
+    """Convert modem pins to integer."""
     result = 0x00000000
 
     for name, bit in MODEM_BIT_MAPPING.items():
-        result |= bit if getattr(modem_bits, name) else 0x00000000
+        result |= bit if getattr(modem_pins, name) else 0x00000000
 
     return result
 
@@ -289,7 +289,7 @@ class PosixSerial(BaseSerial):
                 else:
                     raise
 
-        self.set_modem_bits(dtr=self._rtsdtr_on_open, rts=self._rtsdtr_on_open)
+        self.set_modem_pins(dtr=self._rtsdtr_on_open, rts=self._rtsdtr_on_open)
 
         # Flush input and output buffers to discard stale data
         termios.tcflush(self._fileno, termios.TCIOFLUSH)
@@ -313,7 +313,7 @@ class PosixSerial(BaseSerial):
 
         fcntl.ioctl(self._fileno, TIOCSSERIAL, buffer)
 
-    def _get_modem_bits(self) -> ModemBits:
+    def _get_modem_pins(self) -> ModemPins:
         """Get current modem control bits."""
         assert self._fileno is not None
 
@@ -324,47 +324,47 @@ class PosixSerial(BaseSerial):
             fcntl.ioctl(self._fileno, termios.TIOCMGET, buffer)
         except OSError as exc:
             if exc.errno == errno.ENOTTY:
-                LOGGER.debug("Device is not a serial port, cannot get modem bits")
-                return ModemBits()
+                LOGGER.debug("Device is not a serial port, cannot get modem pins")
+                return ModemPins()
 
         n = int.from_bytes(buffer, "little")
-        return ModemBits(
+        return ModemPins(
             **{name: bool(n & bit) for name, bit in MODEM_BIT_MAPPING.items()}
         )
 
-    def _set_modem_bits(self, modem_bits: ModemBits) -> None:
+    def _set_modem_pins(self, modem_pins: ModemPins) -> None:
         """Set modem control bits."""
         assert self._fileno is not None
 
-        LOGGER.debug("Setting modem bits: %r", modem_bits)
+        LOGGER.debug("Setting modem pins: %r", modem_pins)
 
-        all_bits_set = all(
-            getattr(modem_bits, name) is not None for name in MODEM_BIT_MAPPING
+        all_pins_set = all(
+            getattr(modem_pins, name) is not None for name in MODEM_BIT_MAPPING
         )
 
         try:
-            if all_bits_set:
-                value = modem_bits_as_int(modem_bits)
-                LOGGER.debug("Setting all modem bits: 0x%08X", value)
+            if all_pins_set:
+                value = modem_pins_as_int(modem_pins)
+                LOGGER.debug("Setting all modem pins: 0x%08X", value)
                 fcntl.ioctl(self._fileno, termios.TIOCMSET, value.to_bytes(4, "little"))
             else:
-                to_set = modem_bits_mask_of_value(modem_bits, True)
-                to_clear = modem_bits_mask_of_value(modem_bits, False)
+                to_set = modem_pins_mask_of_value(modem_pins, True)
+                to_clear = modem_pins_mask_of_value(modem_pins, False)
 
                 if to_set:
-                    LOGGER.debug("Setting modem bits: 0x%08X", to_set)
+                    LOGGER.debug("Setting modem pins: 0x%08X", to_set)
                     fcntl.ioctl(
                         self._fileno, termios.TIOCMBIS, to_set.to_bytes(4, "little")
                     )
 
                 if to_clear:
-                    LOGGER.debug("Clearing modem bits: 0x%08X", to_clear)
+                    LOGGER.debug("Clearing modem pins: 0x%08X", to_clear)
                     fcntl.ioctl(
                         self._fileno, termios.TIOCMBIC, to_clear.to_bytes(4, "little")
                     )
         except OSError as exc:
             if exc.errno == errno.ENOTTY:
-                LOGGER.debug("Device is not a serial port, cannot set modem bits")
+                LOGGER.debug("Device is not a serial port, cannot set modem pins")
 
     def flush(self) -> None:
         """Flush write buffers, waiting until all data is written."""

--- a/serialx/platforms/serial_win32.py
+++ b/serialx/platforms/serial_win32.py
@@ -49,7 +49,7 @@ from win32file import (
 )
 from winerror import ERROR_IO_PENDING
 
-from ..common import BaseSerial, BaseSerialTransport, ModemBits, Parity, StopBits
+from ..common import BaseSerial, BaseSerialTransport, ModemPins, Parity, StopBits
 
 # Constants missing from win32con
 MS_CTS_ON = 0x0010
@@ -209,24 +209,24 @@ class Win32Serial(BaseSerial):
             CloseHandle(self._overlapped_write.hEvent)
             self._overlapped_write.hEvent = None
 
-    def _get_modem_bits(self) -> ModemBits:
+    def _get_modem_pins(self) -> ModemPins:
         """Get the current modem control bits."""
         stat = GetCommModemStatus(self._handle)
-        return ModemBits(
+        return ModemPins(
             cts=bool(stat & MS_CTS_ON),
             dsr=bool(stat & MS_DSR_ON),
             rng=bool(stat & MS_RING_ON),
             car=bool(stat & MS_RLSD_ON),
         )
 
-    def _set_modem_bits(self, modem_bits: ModemBits) -> None:
+    def _set_modem_pins(self, modem_pins: ModemPins) -> None:
         """Set the modem control bits."""
-        if modem_bits.rts is not None:
-            func = SETRTS if modem_bits.rts else CLRRTS
+        if modem_pins.rts is not None:
+            func = SETRTS if modem_pins.rts else CLRRTS
             EscapeCommFunction(self._handle, func)
 
-        if modem_bits.dtr is not None:
-            func = SETDTR if modem_bits.dtr else CLRDTR
+        if modem_pins.dtr is not None:
+            func = SETDTR if modem_pins.dtr else CLRDTR
             EscapeCommFunction(self._handle, func)
 
     def flush(self) -> None:

--- a/serialx/platforms/serial_win32.py
+++ b/serialx/platforms/serial_win32.py
@@ -49,7 +49,14 @@ from win32file import (
 )
 from winerror import ERROR_IO_PENDING
 
-from ..common import BaseSerial, BaseSerialTransport, ModemPins, Parity, StopBits
+from ..common import (
+    BaseSerial,
+    BaseSerialTransport,
+    ModemPins,
+    Parity,
+    PinState,
+    StopBits,
+)
 
 # Constants missing from win32con
 MS_CTS_ON = 0x0010
@@ -186,6 +193,8 @@ class Win32Serial(BaseSerial):
 
             SetCommState(self._handle, dcb)
 
+            self.set_modem_pins(dtr=self._rtsdtr_on_open, rts=self._rtsdtr_on_open)
+
             # Clear any errors
             ClearCommError(self._handle)
         except pywintypes.error as e:
@@ -197,6 +206,10 @@ class Win32Serial(BaseSerial):
 
     def close(self):
         """Close the serial port and release all handles."""
+        if self._handle is not None:
+            # Windows has no way to automatically do this on close, we do it manually
+            self.set_modem_pins(dtr=self._rtsdtr_on_close, rts=self._rtsdtr_on_close)
+
         if self._handle is not None:
             CloseHandle(self._handle)
             self._handle = None
@@ -213,10 +226,10 @@ class Win32Serial(BaseSerial):
         """Get the current modem control bits."""
         stat = GetCommModemStatus(self._handle)
         return ModemPins(
-            cts=bool(stat & MS_CTS_ON),
-            dsr=bool(stat & MS_DSR_ON),
-            rng=bool(stat & MS_RING_ON),
-            car=bool(stat & MS_RLSD_ON),
+            cts=PinState.HIGH if stat & MS_CTS_ON else PinState.LOW,
+            dsr=PinState.HIGH if stat & MS_DSR_ON else PinState.LOW,
+            rng=PinState.HIGH if stat & MS_RING_ON else PinState.LOW,
+            car=PinState.HIGH if stat & MS_RLSD_ON else PinState.LOW,
         )
 
     def _set_modem_pins(self, modem_pins: ModemPins) -> None:

--- a/serialx/platforms/serial_win32.py
+++ b/serialx/platforms/serial_win32.py
@@ -209,7 +209,7 @@ class Win32Serial(BaseSerial):
             CloseHandle(self._overlapped_write.hEvent)
             self._overlapped_write.hEvent = None
 
-    def get_modem_bits(self) -> ModemBits:
+    def _get_modem_bits(self) -> ModemBits:
         """Get the current modem control bits."""
         stat = GetCommModemStatus(self._handle)
         return ModemBits(
@@ -219,7 +219,7 @@ class Win32Serial(BaseSerial):
             car=bool(stat & MS_RLSD_ON),
         )
 
-    def set_modem_bits(self, modem_bits: ModemBits) -> None:
+    def _set_modem_bits(self, modem_bits: ModemBits) -> None:
         """Set the modem control bits."""
         if modem_bits.rts is not None:
             func = SETRTS if modem_bits.rts else CLRRTS

--- a/tests/common.py
+++ b/tests/common.py
@@ -107,9 +107,9 @@ async def async_create_reader_writer_pair(
 ) -> AsyncIterator[
     tuple[
         asyncio.StreamReader,
-        asyncio.StreamWriter,
+        serialx.SerialStreamWriter[serialx.SerialTransport],
         asyncio.StreamReader,
-        asyncio.StreamWriter,
+        serialx.SerialStreamWriter[serialx.SerialTransport],
     ]
 ]:
     """Create reader/writer pairs for both sides of a socat connection.
@@ -134,9 +134,9 @@ async def async_create_dual_loopback(
 ) -> AsyncIterator[
     tuple[
         asyncio.StreamReader,
-        asyncio.StreamWriter,
+        serialx.SerialStreamWriter[serialx.SerialTransport],
         asyncio.StreamReader,
-        asyncio.StreamWriter,
+        serialx.SerialStreamWriter[serialx.SerialTransport],
     ]
 ]:
     """Create reader/writer pairs for dual loopback configuration.

--- a/tests/test_loopback_async.py
+++ b/tests/test_loopback_async.py
@@ -381,19 +381,19 @@ async def test_set_modem_bits_loopback_async() -> None:
     ):
         transport = cast(SerialTransport, writer.transport)
         # With a real loopback adapter, modem control signals should work
-        await transport.set_modem_bits(ModemBits(dtr=True, rts=True))
+        await transport.set_modem_bits(dtr=True, rts=True)
         modem_bits = await transport.get_modem_bits()
         assert modem_bits.dtr is True
         assert modem_bits.rts is True
 
         # Set DTR low, leave RTS unchanged
-        await transport.set_modem_bits(ModemBits(dtr=False))
+        await transport.set_modem_bits(dtr=False)
         modem_bits = await transport.get_modem_bits()
         assert modem_bits.dtr is False
         assert modem_bits.rts is True
 
         # Set both low
-        await transport.set_modem_bits(ModemBits(dtr=False, rts=False))
+        await transport.set_modem_bits(dtr=False, rts=False)
         modem_bits = await transport.get_modem_bits()
         assert modem_bits.dtr is False
         assert modem_bits.rts is False

--- a/tests/test_loopback_async.py
+++ b/tests/test_loopback_async.py
@@ -6,7 +6,7 @@ from typing import cast
 
 import pytest
 
-from serialx import ModemBits, Parity, SerialTransport, StopBits
+from serialx import ModemPins, Parity, SerialTransport, StopBits
 from tests.common import LOOPBACK_ADAPTER, async_create_reader_writer
 
 pytestmark = pytest.mark.skipif(
@@ -355,25 +355,25 @@ async def test_read_with_timeout_loopback_async() -> None:
             await asyncio.wait_for(reader.readexactly(1), timeout=0.1)
 
 
-async def test_get_modem_bits_loopback_async() -> None:
+async def test_get_modem_pins_loopback_async() -> None:
     """Test reading modem control bits."""
     async with async_create_reader_writer(LOOPBACK_ADAPTER, baudrate=115200) as (
         reader,
         writer,
     ):
         transport = cast(SerialTransport, writer.transport)
-        modem_bits = await transport.get_modem_bits()
+        modem_pins = await transport.get_modem_pins()
 
-        # Verify we get a ModemBits object
-        assert isinstance(modem_bits, ModemBits)
+        # Verify we get a ModemPins object
+        assert isinstance(modem_pins, ModemPins)
 
-        # All modem bits should be either True, False, or None
+        # All modem pins should be either True, False, or None
         for field in ["le", "dtr", "rts", "st", "sr", "cts", "car", "rng", "dsr"]:
-            value = getattr(modem_bits, field)
+            value = getattr(modem_pins, field)
             assert value in (True, False, None)
 
 
-async def test_set_modem_bits_loopback_async() -> None:
+async def test_set_modem_pins_loopback_async() -> None:
     """Test setting modem control bits with loopback adapter."""
     async with async_create_reader_writer(LOOPBACK_ADAPTER, baudrate=115200) as (
         reader,
@@ -381,19 +381,19 @@ async def test_set_modem_bits_loopback_async() -> None:
     ):
         transport = cast(SerialTransport, writer.transport)
         # With a real loopback adapter, modem control signals should work
-        await transport.set_modem_bits(dtr=True, rts=True)
-        modem_bits = await transport.get_modem_bits()
-        assert modem_bits.dtr is True
-        assert modem_bits.rts is True
+        await transport.set_modem_pins(dtr=True, rts=True)
+        modem_pins = await transport.get_modem_pins()
+        assert modem_pins.dtr is True
+        assert modem_pins.rts is True
 
         # Set DTR low, leave RTS unchanged
-        await transport.set_modem_bits(dtr=False)
-        modem_bits = await transport.get_modem_bits()
-        assert modem_bits.dtr is False
-        assert modem_bits.rts is True
+        await transport.set_modem_pins(dtr=False)
+        modem_pins = await transport.get_modem_pins()
+        assert modem_pins.dtr is False
+        assert modem_pins.rts is True
 
         # Set both low
-        await transport.set_modem_bits(dtr=False, rts=False)
-        modem_bits = await transport.get_modem_bits()
-        assert modem_bits.dtr is False
-        assert modem_bits.rts is False
+        await transport.set_modem_pins(dtr=False, rts=False)
+        modem_pins = await transport.get_modem_pins()
+        assert modem_pins.dtr is False
+        assert modem_pins.rts is False

--- a/tests/test_loopback_async.py
+++ b/tests/test_loopback_async.py
@@ -6,7 +6,7 @@ from typing import cast
 
 import pytest
 
-from serialx import ModemPins, Parity, SerialTransport, StopBits
+from serialx import Parity, PinState, SerialTransport, StopBits
 from tests.common import LOOPBACK_ADAPTER, async_create_reader_writer
 
 pytestmark = pytest.mark.skipif(
@@ -355,24 +355,6 @@ async def test_read_with_timeout_loopback_async() -> None:
             await asyncio.wait_for(reader.readexactly(1), timeout=0.1)
 
 
-async def test_get_modem_pins_loopback_async() -> None:
-    """Test reading modem control bits."""
-    async with async_create_reader_writer(LOOPBACK_ADAPTER, baudrate=115200) as (
-        reader,
-        writer,
-    ):
-        transport = cast(SerialTransport, writer.transport)
-        modem_pins = await transport.get_modem_pins()
-
-        # Verify we get a ModemPins object
-        assert isinstance(modem_pins, ModemPins)
-
-        # All modem pins should be either True, False, or None
-        for field in ["le", "dtr", "rts", "st", "sr", "cts", "car", "rng", "dsr"]:
-            value = getattr(modem_pins, field)
-            assert value in (True, False, None)
-
-
 async def test_set_modem_pins_loopback_async() -> None:
     """Test setting modem control bits with loopback adapter."""
     async with async_create_reader_writer(LOOPBACK_ADAPTER, baudrate=115200) as (
@@ -383,17 +365,17 @@ async def test_set_modem_pins_loopback_async() -> None:
         # With a real loopback adapter, modem control signals should work
         await transport.set_modem_pins(dtr=True, rts=True)
         modem_pins = await transport.get_modem_pins()
-        assert modem_pins.dtr is True
-        assert modem_pins.rts is True
+        assert modem_pins.dtr is PinState.HIGH
+        assert modem_pins.rts is PinState.HIGH
 
         # Set DTR low, leave RTS unchanged
         await transport.set_modem_pins(dtr=False)
         modem_pins = await transport.get_modem_pins()
-        assert modem_pins.dtr is False
-        assert modem_pins.rts is True
+        assert modem_pins.dtr is PinState.LOW
+        assert modem_pins.rts is PinState.HIGH
 
         # Set both low
         await transport.set_modem_pins(dtr=False, rts=False)
         modem_pins = await transport.get_modem_pins()
-        assert modem_pins.dtr is False
-        assert modem_pins.rts is False
+        assert modem_pins.dtr is PinState.LOW
+        assert modem_pins.rts is PinState.LOW

--- a/tests/test_loopback_dual_async.py
+++ b/tests/test_loopback_dual_async.py
@@ -460,11 +460,11 @@ async def test_deassert_on_open_async() -> None:
             reader_right,
             writer_right,
         ):
-            await writer_right.transport.set_modem_bits(dtr=True)
-            assert (await writer_left.transport.get_modem_bits()).cts is True
+            await writer_right.transport.set_modem_pins(dtr=True)
+            assert (await writer_left.transport.get_modem_pins()).cts is True
 
         # It persists
-        assert (await writer_left.transport.get_modem_bits()).cts is True
+        assert (await writer_left.transport.get_modem_pins()).cts is True
 
         # When we deassert on open, it should clear
         async with async_create_reader_writer(
@@ -473,11 +473,11 @@ async def test_deassert_on_open_async() -> None:
             reader_right,
             writer_right,
         ):
-            assert (await writer_left.transport.get_modem_bits()).cts is False
-            await writer_right.transport.set_modem_bits(dtr=True)
+            assert (await writer_left.transport.get_modem_pins()).cts is False
+            await writer_right.transport.set_modem_pins(dtr=True)
 
         # Nothing changes on close
-        assert (await writer_left.transport.get_modem_bits()).cts is True
+        assert (await writer_left.transport.get_modem_pins()).cts is True
 
 
 async def test_hang_up_on_close_async() -> None:
@@ -496,11 +496,11 @@ async def test_hang_up_on_close_async() -> None:
             reader_right,
             writer_right,
         ):
-            await writer_right.transport.set_modem_bits(dtr=True)
-            assert (await writer_left.transport.get_modem_bits()).cts is True
+            await writer_right.transport.set_modem_pins(dtr=True)
+            assert (await writer_left.transport.get_modem_pins()).cts is True
 
         # It persists
-        assert (await writer_left.transport.get_modem_bits()).cts is True
+        assert (await writer_left.transport.get_modem_pins()).cts is True
 
         # Without hang up on close, it still persists
         async with async_create_reader_writer(
@@ -512,9 +512,9 @@ async def test_hang_up_on_close_async() -> None:
             reader_right,
             writer_right,
         ):
-            assert (await writer_left.transport.get_modem_bits()).cts is True
+            assert (await writer_left.transport.get_modem_pins()).cts is True
 
-        assert (await writer_left.transport.get_modem_bits()).cts is True
+        assert (await writer_left.transport.get_modem_pins()).cts is True
 
         # When we hang up on close, it should clear
         async with async_create_reader_writer(
@@ -526,9 +526,9 @@ async def test_hang_up_on_close_async() -> None:
             reader_right,
             writer_right,
         ):
-            assert (await writer_left.transport.get_modem_bits()).cts is True
+            assert (await writer_left.transport.get_modem_pins()).cts is True
 
-        assert (await writer_left.transport.get_modem_bits()).cts is False
+        assert (await writer_left.transport.get_modem_pins()).cts is False
 
 
 @pytest.mark.parametrize(
@@ -560,11 +560,11 @@ async def test_deassert_on_open_with_rtscts_async(
             reader_right,
             writer_right,
         ):
-            await writer_right.transport.set_modem_bits(dtr=True)
-            assert (await writer_left.transport.get_modem_bits()).cts is True
+            await writer_right.transport.set_modem_pins(dtr=True)
+            assert (await writer_left.transport.get_modem_pins()).cts is True
 
         # DTR persists after close
-        assert (await writer_left.transport.get_modem_bits()).cts is True
+        assert (await writer_left.transport.get_modem_pins()).cts is True
 
         # Open with test parameters
         async with async_create_reader_writer(
@@ -576,4 +576,4 @@ async def test_deassert_on_open_with_rtscts_async(
             reader_right,
             writer_right,
         ):
-            assert (await writer_left.transport.get_modem_bits()).cts is expected_state
+            assert (await writer_left.transport.get_modem_pins()).cts is expected_state

--- a/tests/test_loopback_dual_async.py
+++ b/tests/test_loopback_dual_async.py
@@ -2,17 +2,10 @@
 
 import asyncio
 import os
-from typing import cast
 
 import pytest
 
-from serialx import (
-    Parity,
-    PinState,
-    SerialTransport,
-    StopBits,
-    create_serial_connection,
-)
+from serialx import Parity, PinState, StopBits, create_serial_connection
 from tests.common import (
     DUAL_LOOPBACK_LEFT,
     DUAL_LOOPBACK_RIGHT,
@@ -284,8 +277,7 @@ async def test_valid_baudrates_async(baudrate: int) -> None:
         _writer_right,
     ):
         # Verify baudrate was set (check transport)
-        transport = cast(SerialTransport, writer.transport)
-        assert transport.baudrate == baudrate
+        assert writer.transport.baudrate == baudrate
         writer.write(b"test")
 
 
@@ -301,8 +293,7 @@ async def test_valid_parity_async(parity: Parity) -> None:
         _,
         _writer_right,
     ):
-        transport = cast(SerialTransport, writer.transport)
-        assert transport.parity == parity
+        assert writer.transport.parity == parity
         writer.write(b"test")
 
 
@@ -328,8 +319,7 @@ async def test_valid_stopbits_async(
         _,
         _writer_right,
     ):
-        transport = cast(SerialTransport, writer.transport)
-        assert transport.stopbits == expected
+        assert writer.transport.stopbits == expected
         writer.write(b"test")
 
 
@@ -427,10 +417,9 @@ async def test_fast_open_close() -> None:
 
     class FastCloseProtocol(asyncio.Protocol):
         def connection_made(self, transport: asyncio.BaseTransport) -> None:
-            transport = cast(SerialTransport, transport)
-            transport.write(message)
-            # transport.close()  # Immediately closing after write will not cause data loss
-            transport.abort()
+            writer.transport.write(message)
+            # writer.transport.close()  # Immediately closing after write will not cause data loss
+            writer.transport.abort()
 
         def connection_lost(self, exc: Exception | None) -> None:
             connection_lost_event.set()

--- a/tests/test_loopback_dual_async.py
+++ b/tests/test_loopback_dual_async.py
@@ -6,7 +6,13 @@ from typing import cast
 
 import pytest
 
-from serialx import Parity, SerialTransport, StopBits, create_serial_connection
+from serialx import (
+    Parity,
+    PinState,
+    SerialTransport,
+    StopBits,
+    create_serial_connection,
+)
 from tests.common import (
     DUAL_LOOPBACK_LEFT,
     DUAL_LOOPBACK_RIGHT,
@@ -455,29 +461,35 @@ async def test_deassert_on_open_async() -> None:
     ):
         # Open and set DTR/CTS
         async with async_create_reader_writer(
-            DUAL_LOOPBACK_RIGHT, baudrate=115200, deassert_on_open=False
+            DUAL_LOOPBACK_RIGHT,
+            baudrate=115200,
+            rtsdtr_on_open=PinState.HIGH,
+            rtsdtr_on_close=PinState.HIGH,
         ) as (
             reader_right,
             writer_right,
         ):
             await writer_right.transport.set_modem_pins(dtr=True)
-            assert (await writer_left.transport.get_modem_pins()).cts is True
+            assert (await writer_left.transport.get_modem_pins()).cts is PinState.HIGH
 
         # It persists
-        assert (await writer_left.transport.get_modem_pins()).cts is True
+        assert (await writer_left.transport.get_modem_pins()).cts is PinState.HIGH
 
         # When we deassert on open, it should clear
         async with async_create_reader_writer(
-            DUAL_LOOPBACK_RIGHT, baudrate=115200, deassert_on_open=True
+            DUAL_LOOPBACK_RIGHT,
+            baudrate=115200,
+            rtsdtr_on_open=PinState.LOW,
+            rtsdtr_on_close=PinState.HIGH,
         ) as (
             reader_right,
             writer_right,
         ):
-            assert (await writer_left.transport.get_modem_pins()).cts is False
+            assert (await writer_left.transport.get_modem_pins()).cts is PinState.LOW
             await writer_right.transport.set_modem_pins(dtr=True)
 
         # Nothing changes on close
-        assert (await writer_left.transport.get_modem_pins()).cts is True
+        assert (await writer_left.transport.get_modem_pins()).cts is PinState.HIGH
 
 
 async def test_hang_up_on_close_async() -> None:
@@ -490,62 +502,60 @@ async def test_hang_up_on_close_async() -> None:
         async with async_create_reader_writer(
             DUAL_LOOPBACK_RIGHT,
             baudrate=115200,
-            hang_up_on_close=False,
-            deassert_on_open=False,
+            rtsdtr_on_close=PinState.HIGH,
+            rtsdtr_on_open=PinState.HIGH,
         ) as (
             reader_right,
             writer_right,
         ):
             await writer_right.transport.set_modem_pins(dtr=True)
-            assert (await writer_left.transport.get_modem_pins()).cts is True
+            assert (await writer_left.transport.get_modem_pins()).cts is PinState.HIGH
 
         # It persists
-        assert (await writer_left.transport.get_modem_pins()).cts is True
+        assert (await writer_left.transport.get_modem_pins()).cts is PinState.HIGH
 
         # Without hang up on close, it still persists
         async with async_create_reader_writer(
             DUAL_LOOPBACK_RIGHT,
             baudrate=115200,
-            hang_up_on_close=False,
-            deassert_on_open=False,
+            rtsdtr_on_close=PinState.HIGH,
+            rtsdtr_on_open=PinState.HIGH,
         ) as (
             reader_right,
             writer_right,
         ):
-            assert (await writer_left.transport.get_modem_pins()).cts is True
+            assert (await writer_left.transport.get_modem_pins()).cts is PinState.HIGH
 
-        assert (await writer_left.transport.get_modem_pins()).cts is True
+        assert (await writer_left.transport.get_modem_pins()).cts is PinState.HIGH
 
         # When we hang up on close, it should clear
         async with async_create_reader_writer(
             DUAL_LOOPBACK_RIGHT,
             baudrate=115200,
-            hang_up_on_close=True,
-            deassert_on_open=False,
+            rtsdtr_on_close=PinState.LOW,
+            rtsdtr_on_open=PinState.HIGH,
         ) as (
             reader_right,
             writer_right,
         ):
-            assert (await writer_left.transport.get_modem_pins()).cts is True
+            assert (await writer_left.transport.get_modem_pins()).cts is PinState.HIGH
 
-        assert (await writer_left.transport.get_modem_pins()).cts is False
+        assert (await writer_left.transport.get_modem_pins()).cts is PinState.LOW
 
 
 @pytest.mark.parametrize(
-    ("rtscts", "deassert_on_open", "expected_state"),
+    ("rtscts", "rtsdtr_on_open", "expected_state"),
     [
-        (False, None, False),  # No flow control, auto-detect -> clear pins
-        (False, False, True),  # No flow control, preserve pins (explicit override)
-        (False, True, False),  # No flow control, clear pins (explicit, matches auto)
-        (True, None, True),  # Flow control, auto-detect -> preserve pins
-        (True, False, True),  # Flow control, preserve pins (explicit, matches auto)
-        (True, True, False),  # Flow control, clear pins (explicit override)
+        (False, PinState.HIGH, PinState.HIGH),  # No flow control, preserve pins
+        (False, PinState.LOW, PinState.LOW),  # No flow control, clear pins
+        (True, PinState.HIGH, PinState.HIGH),  # Flow control, preserve pins
+        (True, PinState.LOW, PinState.LOW),  # Flow control, clear pins
     ],
 )
 async def test_deassert_on_open_with_rtscts_async(
-    rtscts: bool, deassert_on_open: bool | None, expected_state: bool
+    rtscts: bool, rtsdtr_on_open: PinState, expected_state: PinState
 ) -> None:
-    """Test interaction of deassert_on_open with rtscts."""
+    """Test interaction of rtsdtr_on_open with rtscts."""
     async with async_create_reader_writer(DUAL_LOOPBACK_LEFT, baudrate=115200) as (
         reader_left,
         writer_left,
@@ -555,23 +565,23 @@ async def test_deassert_on_open_with_rtscts_async(
             DUAL_LOOPBACK_RIGHT,
             baudrate=115200,
             rtscts=False,
-            deassert_on_open=False,
+            rtsdtr_on_open=PinState.HIGH,
         ) as (
             reader_right,
             writer_right,
         ):
             await writer_right.transport.set_modem_pins(dtr=True)
-            assert (await writer_left.transport.get_modem_pins()).cts is True
+            assert (await writer_left.transport.get_modem_pins()).cts is PinState.HIGH
 
         # DTR persists after close
-        assert (await writer_left.transport.get_modem_pins()).cts is True
+        assert (await writer_left.transport.get_modem_pins()).cts is PinState.HIGH
 
         # Open with test parameters
         async with async_create_reader_writer(
             DUAL_LOOPBACK_RIGHT,
             baudrate=115200,
             rtscts=rtscts,
-            deassert_on_open=deassert_on_open,
+            rtsdtr_on_open=rtsdtr_on_open,
         ) as (
             reader_right,
             writer_right,

--- a/tests/test_loopback_dual_async.py
+++ b/tests/test_loopback_dual_async.py
@@ -6,13 +6,7 @@ from typing import cast
 
 import pytest
 
-from serialx import (
-    ModemBits,
-    Parity,
-    SerialTransport,
-    StopBits,
-    create_serial_connection,
-)
+from serialx import Parity, SerialTransport, StopBits, create_serial_connection
 from tests.common import (
     DUAL_LOOPBACK_LEFT,
     DUAL_LOOPBACK_RIGHT,
@@ -466,7 +460,7 @@ async def test_deassert_on_open_async() -> None:
             reader_right,
             writer_right,
         ):
-            await writer_right.transport.set_modem_bits(ModemBits(dtr=True))
+            await writer_right.transport.set_modem_bits(dtr=True)
             assert (await writer_left.transport.get_modem_bits()).cts is True
 
         # It persists
@@ -480,7 +474,7 @@ async def test_deassert_on_open_async() -> None:
             writer_right,
         ):
             assert (await writer_left.transport.get_modem_bits()).cts is False
-            await writer_right.transport.set_modem_bits(ModemBits(dtr=True))
+            await writer_right.transport.set_modem_bits(dtr=True)
 
         # Nothing changes on close
         assert (await writer_left.transport.get_modem_bits()).cts is True
@@ -502,7 +496,7 @@ async def test_hang_up_on_close_async() -> None:
             reader_right,
             writer_right,
         ):
-            await writer_right.transport.set_modem_bits(ModemBits(dtr=True))
+            await writer_right.transport.set_modem_bits(dtr=True)
             assert (await writer_left.transport.get_modem_bits()).cts is True
 
         # It persists
@@ -566,7 +560,7 @@ async def test_deassert_on_open_with_rtscts_async(
             reader_right,
             writer_right,
         ):
-            await writer_right.transport.set_modem_bits(ModemBits(dtr=True))
+            await writer_right.transport.set_modem_bits(dtr=True)
             assert (await writer_left.transport.get_modem_bits()).cts is True
 
         # DTR persists after close

--- a/tests/test_loopback_dual_sync.py
+++ b/tests/test_loopback_dual_sync.py
@@ -393,32 +393,32 @@ def test_deprecated_dtr_cts_dual() -> None:
     """Test DTR and CTS properties (deprecated alias)."""
     with create_dual_loopback(baudrate=115200) as (serial_left, serial_right):
         serial_left.dtr = True
-        assert serial_right.get_modem_bits().cts is True
+        assert serial_right.get_modem_pins().cts is True
 
         serial_right.dtr = True
-        assert serial_left.get_modem_bits().cts is True
+        assert serial_left.get_modem_pins().cts is True
 
         serial_left.dtr = False
-        assert serial_right.get_modem_bits().cts is False
+        assert serial_right.get_modem_pins().cts is False
 
         serial_right.dtr = False
-        assert serial_left.get_modem_bits().cts is False
+        assert serial_left.get_modem_pins().cts is False
 
 
 def test_dtr_cts_dual() -> None:
     """Test DTR and CTS."""
     with create_dual_loopback(baudrate=115200) as (serial_left, serial_right):
-        serial_left.set_modem_bits(dtr=True)
-        assert serial_right.get_modem_bits().cts is True
+        serial_left.set_modem_pins(dtr=True)
+        assert serial_right.get_modem_pins().cts is True
 
-        serial_right.set_modem_bits(dtr=True)
-        assert serial_left.get_modem_bits().cts is True
+        serial_right.set_modem_pins(dtr=True)
+        assert serial_left.get_modem_pins().cts is True
 
-        serial_left.set_modem_bits(dtr=False)
-        assert serial_right.get_modem_bits().cts is False
+        serial_left.set_modem_pins(dtr=False)
+        assert serial_right.get_modem_pins().cts is False
 
-        serial_right.set_modem_bits(dtr=False)
-        assert serial_left.get_modem_bits().cts is False
+        serial_right.set_modem_pins(dtr=False)
+        assert serial_left.get_modem_pins().cts is False
 
 
 def test_deassert_on_open() -> None:
@@ -428,21 +428,21 @@ def test_deassert_on_open() -> None:
         with Serial(
             DUAL_LOOPBACK_RIGHT, baudrate=115200, deassert_on_open=False
         ) as serial_right:
-            serial_right.set_modem_bits(dtr=True)
-            assert serial_left.get_modem_bits().cts is True
+            serial_right.set_modem_pins(dtr=True)
+            assert serial_left.get_modem_pins().cts is True
 
         # It persists
-        assert serial_left.get_modem_bits().cts is True
+        assert serial_left.get_modem_pins().cts is True
 
         # When we deassert on open, it should clear
         with Serial(
             DUAL_LOOPBACK_RIGHT, baudrate=115200, deassert_on_open=True
         ) as serial_right:
-            assert serial_left.get_modem_bits().cts is False
-            serial_right.set_modem_bits(dtr=True)
+            assert serial_left.get_modem_pins().cts is False
+            serial_right.set_modem_pins(dtr=True)
 
         # Nothing changes on close
-        assert serial_left.get_modem_bits().cts is True
+        assert serial_left.get_modem_pins().cts is True
 
 
 def test_hang_up_on_close() -> None:
@@ -455,11 +455,11 @@ def test_hang_up_on_close() -> None:
             hang_up_on_close=False,
             deassert_on_open=False,
         ) as serial_right:
-            serial_right.set_modem_bits(dtr=True)
-            assert serial_left.get_modem_bits().cts is True
+            serial_right.set_modem_pins(dtr=True)
+            assert serial_left.get_modem_pins().cts is True
 
         # It persists
-        assert serial_left.get_modem_bits().cts is True
+        assert serial_left.get_modem_pins().cts is True
 
         # Without hang up on close, it still persists
         with Serial(
@@ -468,9 +468,9 @@ def test_hang_up_on_close() -> None:
             hang_up_on_close=False,
             deassert_on_open=False,
         ) as serial_right:
-            assert serial_left.get_modem_bits().cts is True
+            assert serial_left.get_modem_pins().cts is True
 
-        assert serial_left.get_modem_bits().cts is True
+        assert serial_left.get_modem_pins().cts is True
 
         # When we hang up on close, it should clear
         with Serial(
@@ -479,9 +479,9 @@ def test_hang_up_on_close() -> None:
             hang_up_on_close=True,
             deassert_on_open=False,
         ) as serial_right:
-            assert serial_left.get_modem_bits().cts is True
+            assert serial_left.get_modem_pins().cts is True
 
-        assert serial_left.get_modem_bits().cts is False
+        assert serial_left.get_modem_pins().cts is False
 
 
 @pytest.mark.parametrize(
@@ -507,11 +507,11 @@ def test_deassert_on_open_with_rtscts(
             rtscts=False,
             deassert_on_open=False,
         ) as serial_right:
-            serial_right.set_modem_bits(dtr=True)
-            assert serial_left.get_modem_bits().cts is True
+            serial_right.set_modem_pins(dtr=True)
+            assert serial_left.get_modem_pins().cts is True
 
         # DTR persists after close
-        assert serial_left.get_modem_bits().cts is True
+        assert serial_left.get_modem_pins().cts is True
 
         # Open with test parameters
         with Serial(
@@ -520,4 +520,4 @@ def test_deassert_on_open_with_rtscts(
             rtscts=rtscts,
             deassert_on_open=deassert_on_open,
         ) as serial_right:
-            assert serial_left.get_modem_bits().cts is expected_state
+            assert serial_left.get_modem_pins().cts is expected_state

--- a/tests/test_loopback_dual_sync.py
+++ b/tests/test_loopback_dual_sync.py
@@ -4,7 +4,7 @@ import os
 
 import pytest
 
-from serialx import ModemBits, Parity, Serial, StopBits
+from serialx import Parity, Serial, StopBits
 from tests.common import DUAL_LOOPBACK_LEFT, DUAL_LOOPBACK_RIGHT, create_dual_loopback
 
 pytestmark = pytest.mark.skipif(
@@ -408,16 +408,16 @@ def test_deprecated_dtr_cts_dual() -> None:
 def test_dtr_cts_dual() -> None:
     """Test DTR and CTS."""
     with create_dual_loopback(baudrate=115200) as (serial_left, serial_right):
-        serial_left.set_modem_bits(ModemBits(dtr=True))
+        serial_left.set_modem_bits(dtr=True)
         assert serial_right.get_modem_bits().cts is True
 
-        serial_right.set_modem_bits(ModemBits(dtr=True))
+        serial_right.set_modem_bits(dtr=True)
         assert serial_left.get_modem_bits().cts is True
 
-        serial_left.set_modem_bits(ModemBits(dtr=False))
+        serial_left.set_modem_bits(dtr=False)
         assert serial_right.get_modem_bits().cts is False
 
-        serial_right.set_modem_bits(ModemBits(dtr=False))
+        serial_right.set_modem_bits(dtr=False)
         assert serial_left.get_modem_bits().cts is False
 
 
@@ -428,7 +428,7 @@ def test_deassert_on_open() -> None:
         with Serial(
             DUAL_LOOPBACK_RIGHT, baudrate=115200, deassert_on_open=False
         ) as serial_right:
-            serial_right.set_modem_bits(ModemBits(dtr=True))
+            serial_right.set_modem_bits(dtr=True)
             assert serial_left.get_modem_bits().cts is True
 
         # It persists
@@ -439,7 +439,7 @@ def test_deassert_on_open() -> None:
             DUAL_LOOPBACK_RIGHT, baudrate=115200, deassert_on_open=True
         ) as serial_right:
             assert serial_left.get_modem_bits().cts is False
-            serial_right.set_modem_bits(ModemBits(dtr=True))
+            serial_right.set_modem_bits(dtr=True)
 
         # Nothing changes on close
         assert serial_left.get_modem_bits().cts is True
@@ -455,7 +455,7 @@ def test_hang_up_on_close() -> None:
             hang_up_on_close=False,
             deassert_on_open=False,
         ) as serial_right:
-            serial_right.set_modem_bits(ModemBits(dtr=True))
+            serial_right.set_modem_bits(dtr=True)
             assert serial_left.get_modem_bits().cts is True
 
         # It persists
@@ -507,7 +507,7 @@ def test_deassert_on_open_with_rtscts(
             rtscts=False,
             deassert_on_open=False,
         ) as serial_right:
-            serial_right.set_modem_bits(ModemBits(dtr=True))
+            serial_right.set_modem_bits(dtr=True)
             assert serial_left.get_modem_bits().cts is True
 
         # DTR persists after close

--- a/tests/test_loopback_dual_sync.py
+++ b/tests/test_loopback_dual_sync.py
@@ -4,7 +4,7 @@ import os
 
 import pytest
 
-from serialx import Parity, Serial, StopBits
+from serialx import Parity, PinState, Serial, StopBits
 from tests.common import DUAL_LOOPBACK_LEFT, DUAL_LOOPBACK_RIGHT, create_dual_loopback
 
 pytestmark = pytest.mark.skipif(
@@ -393,32 +393,32 @@ def test_deprecated_dtr_cts_dual() -> None:
     """Test DTR and CTS properties (deprecated alias)."""
     with create_dual_loopback(baudrate=115200) as (serial_left, serial_right):
         serial_left.dtr = True
-        assert serial_right.get_modem_pins().cts is True
+        assert serial_right.get_modem_pins().cts is PinState.HIGH
 
         serial_right.dtr = True
-        assert serial_left.get_modem_pins().cts is True
+        assert serial_left.get_modem_pins().cts is PinState.HIGH
 
         serial_left.dtr = False
-        assert serial_right.get_modem_pins().cts is False
+        assert serial_right.get_modem_pins().cts is PinState.LOW
 
         serial_right.dtr = False
-        assert serial_left.get_modem_pins().cts is False
+        assert serial_left.get_modem_pins().cts is PinState.LOW
 
 
 def test_dtr_cts_dual() -> None:
     """Test DTR and CTS."""
     with create_dual_loopback(baudrate=115200) as (serial_left, serial_right):
         serial_left.set_modem_pins(dtr=True)
-        assert serial_right.get_modem_pins().cts is True
+        assert serial_right.get_modem_pins().cts is PinState.HIGH
 
         serial_right.set_modem_pins(dtr=True)
-        assert serial_left.get_modem_pins().cts is True
+        assert serial_left.get_modem_pins().cts is PinState.HIGH
 
         serial_left.set_modem_pins(dtr=False)
-        assert serial_right.get_modem_pins().cts is False
+        assert serial_right.get_modem_pins().cts is PinState.LOW
 
         serial_right.set_modem_pins(dtr=False)
-        assert serial_left.get_modem_pins().cts is False
+        assert serial_left.get_modem_pins().cts is PinState.LOW
 
 
 def test_deassert_on_open() -> None:
@@ -426,23 +426,29 @@ def test_deassert_on_open() -> None:
     with Serial(DUAL_LOOPBACK_LEFT, baudrate=115200) as serial_left:
         # Open and set DTR/CTS
         with Serial(
-            DUAL_LOOPBACK_RIGHT, baudrate=115200, deassert_on_open=False
+            DUAL_LOOPBACK_RIGHT,
+            baudrate=115200,
+            rtsdtr_on_open=PinState.HIGH,
+            rtsdtr_on_close=PinState.HIGH,
         ) as serial_right:
             serial_right.set_modem_pins(dtr=True)
-            assert serial_left.get_modem_pins().cts is True
+            assert serial_left.get_modem_pins().cts is PinState.HIGH
 
         # It persists
-        assert serial_left.get_modem_pins().cts is True
+        assert serial_left.get_modem_pins().cts is PinState.HIGH
 
         # When we deassert on open, it should clear
         with Serial(
-            DUAL_LOOPBACK_RIGHT, baudrate=115200, deassert_on_open=True
+            DUAL_LOOPBACK_RIGHT,
+            baudrate=115200,
+            rtsdtr_on_open=PinState.LOW,
+            rtsdtr_on_close=PinState.HIGH,
         ) as serial_right:
-            assert serial_left.get_modem_pins().cts is False
+            assert serial_left.get_modem_pins().cts is PinState.LOW
             serial_right.set_modem_pins(dtr=True)
 
         # Nothing changes on close
-        assert serial_left.get_modem_pins().cts is True
+        assert serial_left.get_modem_pins().cts is PinState.HIGH
 
 
 def test_hang_up_on_close() -> None:
@@ -452,72 +458,70 @@ def test_hang_up_on_close() -> None:
         with Serial(
             DUAL_LOOPBACK_RIGHT,
             baudrate=115200,
-            hang_up_on_close=False,
-            deassert_on_open=False,
+            rtsdtr_on_close=PinState.HIGH,
+            rtsdtr_on_open=PinState.HIGH,
         ) as serial_right:
             serial_right.set_modem_pins(dtr=True)
-            assert serial_left.get_modem_pins().cts is True
+            assert serial_left.get_modem_pins().cts is PinState.HIGH
 
         # It persists
-        assert serial_left.get_modem_pins().cts is True
+        assert serial_left.get_modem_pins().cts is PinState.HIGH
 
         # Without hang up on close, it still persists
         with Serial(
             DUAL_LOOPBACK_RIGHT,
             baudrate=115200,
-            hang_up_on_close=False,
-            deassert_on_open=False,
+            rtsdtr_on_close=PinState.HIGH,
+            rtsdtr_on_open=PinState.HIGH,
         ) as serial_right:
-            assert serial_left.get_modem_pins().cts is True
+            assert serial_left.get_modem_pins().cts is PinState.HIGH
 
-        assert serial_left.get_modem_pins().cts is True
+        assert serial_left.get_modem_pins().cts is PinState.HIGH
 
         # When we hang up on close, it should clear
         with Serial(
             DUAL_LOOPBACK_RIGHT,
             baudrate=115200,
-            hang_up_on_close=True,
-            deassert_on_open=False,
+            rtsdtr_on_close=PinState.LOW,
+            rtsdtr_on_open=PinState.HIGH,
         ) as serial_right:
-            assert serial_left.get_modem_pins().cts is True
+            assert serial_left.get_modem_pins().cts is PinState.HIGH
 
-        assert serial_left.get_modem_pins().cts is False
+        assert serial_left.get_modem_pins().cts is PinState.LOW
 
 
 @pytest.mark.parametrize(
-    ("rtscts", "deassert_on_open", "expected_state"),
+    ("rtscts", "rtsdtr_on_open", "expected_state"),
     [
-        (False, None, False),  # No flow control, auto-detect -> clear pins
-        (False, False, True),  # No flow control, preserve pins (explicit override)
-        (False, True, False),  # No flow control, clear pins (explicit, matches auto)
-        (True, None, True),  # Flow control, auto-detect -> preserve pins
-        (True, False, True),  # Flow control, preserve pins (explicit, matches auto)
-        (True, True, False),  # Flow control, clear pins (explicit override)
+        (False, PinState.HIGH, PinState.HIGH),  # No flow control, preserve pins
+        (False, PinState.LOW, PinState.LOW),  # No flow control, clear pins
+        (True, PinState.HIGH, PinState.HIGH),  # Flow control, preserve pins
+        (True, PinState.LOW, PinState.LOW),  # Flow control, clear pins
     ],
 )
 def test_deassert_on_open_with_rtscts(
-    rtscts: bool, deassert_on_open: bool | None, expected_state: bool
+    rtscts: bool, rtsdtr_on_open: PinState, expected_state: PinState
 ) -> None:
-    """Test interaction of deassert_on_open with rtscts."""
+    """Test interaction of rtsdtr_on_open with rtscts."""
     with Serial(DUAL_LOOPBACK_LEFT, baudrate=115200) as serial_left:
         # Set DTR on right side, verify CTS appears on left
         with Serial(
             DUAL_LOOPBACK_RIGHT,
             baudrate=115200,
             rtscts=False,
-            deassert_on_open=False,
+            rtsdtr_on_open=PinState.HIGH,
         ) as serial_right:
             serial_right.set_modem_pins(dtr=True)
-            assert serial_left.get_modem_pins().cts is True
+            assert serial_left.get_modem_pins().cts is PinState.HIGH
 
         # DTR persists after close
-        assert serial_left.get_modem_pins().cts is True
+        assert serial_left.get_modem_pins().cts is PinState.HIGH
 
         # Open with test parameters
         with Serial(
             DUAL_LOOPBACK_RIGHT,
             baudrate=115200,
             rtscts=rtscts,
-            deassert_on_open=deassert_on_open,
+            rtsdtr_on_open=rtsdtr_on_open,
         ) as serial_right:
             assert serial_left.get_modem_pins().cts is expected_state

--- a/tests/test_loopback_sync.py
+++ b/tests/test_loopback_sync.py
@@ -4,7 +4,7 @@ import os
 
 import pytest
 
-from serialx import ModemPins, Parity, Serial, StopBits
+from serialx import Parity, PinState, Serial, StopBits
 from tests.common import LOOPBACK_ADAPTER
 
 # All tests here use a real adapter, skip if not configured
@@ -356,42 +356,28 @@ def test_multiple_flush_calls_loopback() -> None:
         assert result == data
 
 
-def test_get_modem_pins_loopback() -> None:
-    """Test reading modem control bits with loopback adapter."""
-    with Serial(LOOPBACK_ADAPTER, baudrate=115200) as serial:
-        modem_pins = serial.get_modem_pins()
-
-        # Verify we get a ModemPins object
-        assert isinstance(modem_pins, ModemPins)
-
-        # All modem pins should be either True, False, or None
-        for field in ["le", "dtr", "rts", "st", "sr", "cts", "car", "rng", "dsr"]:
-            value = getattr(modem_pins, field)
-            assert value in (True, False, None)
-
-
 def test_set_modem_pins_loopback() -> None:
     """Test setting modem control bits with loopback adapter."""
     with Serial(LOOPBACK_ADAPTER, baudrate=115200) as serial:
         serial.set_modem_pins(dtr=True, rts=True)
 
         modem_pins = serial.get_modem_pins()
-        assert modem_pins.dtr is True
-        assert modem_pins.rts is True
+        assert modem_pins.dtr is PinState.HIGH
+        assert modem_pins.rts is PinState.HIGH
 
         # Set DTR low, leave RTS unchanged
         serial.set_modem_pins(dtr=False)
 
         modem_pins = serial.get_modem_pins()
-        assert modem_pins.dtr is False
-        assert modem_pins.rts is True
+        assert modem_pins.dtr is PinState.LOW
+        assert modem_pins.rts is PinState.HIGH
 
         # Set both low
         serial.set_modem_pins(dtr=False, rts=False)
 
         modem_pins = serial.get_modem_pins()
-        assert modem_pins.dtr is False
-        assert modem_pins.rts is False
+        assert modem_pins.dtr is PinState.LOW
+        assert modem_pins.rts is PinState.LOW
 
 
 def test_deprecated_dtr_property_loopback() -> None:

--- a/tests/test_loopback_sync.py
+++ b/tests/test_loopback_sync.py
@@ -373,21 +373,21 @@ def test_get_modem_bits_loopback() -> None:
 def test_set_modem_bits_loopback() -> None:
     """Test setting modem control bits with loopback adapter."""
     with Serial(LOOPBACK_ADAPTER, baudrate=115200) as serial:
-        serial.set_modem_bits(ModemBits(dtr=True, rts=True))
+        serial.set_modem_bits(dtr=True, rts=True)
 
         modem_bits = serial.get_modem_bits()
         assert modem_bits.dtr is True
         assert modem_bits.rts is True
 
         # Set DTR low, leave RTS unchanged
-        serial.set_modem_bits(ModemBits(dtr=False))
+        serial.set_modem_bits(dtr=False)
 
         modem_bits = serial.get_modem_bits()
         assert modem_bits.dtr is False
         assert modem_bits.rts is True
 
         # Set both low
-        serial.set_modem_bits(ModemBits(dtr=False, rts=False))
+        serial.set_modem_bits(dtr=False, rts=False)
 
         modem_bits = serial.get_modem_bits()
         assert modem_bits.dtr is False

--- a/tests/test_loopback_sync.py
+++ b/tests/test_loopback_sync.py
@@ -4,7 +4,7 @@ import os
 
 import pytest
 
-from serialx import ModemBits, Parity, Serial, StopBits
+from serialx import ModemPins, Parity, Serial, StopBits
 from tests.common import LOOPBACK_ADAPTER
 
 # All tests here use a real adapter, skip if not configured
@@ -356,42 +356,42 @@ def test_multiple_flush_calls_loopback() -> None:
         assert result == data
 
 
-def test_get_modem_bits_loopback() -> None:
+def test_get_modem_pins_loopback() -> None:
     """Test reading modem control bits with loopback adapter."""
     with Serial(LOOPBACK_ADAPTER, baudrate=115200) as serial:
-        modem_bits = serial.get_modem_bits()
+        modem_pins = serial.get_modem_pins()
 
-        # Verify we get a ModemBits object
-        assert isinstance(modem_bits, ModemBits)
+        # Verify we get a ModemPins object
+        assert isinstance(modem_pins, ModemPins)
 
-        # All modem bits should be either True, False, or None
+        # All modem pins should be either True, False, or None
         for field in ["le", "dtr", "rts", "st", "sr", "cts", "car", "rng", "dsr"]:
-            value = getattr(modem_bits, field)
+            value = getattr(modem_pins, field)
             assert value in (True, False, None)
 
 
-def test_set_modem_bits_loopback() -> None:
+def test_set_modem_pins_loopback() -> None:
     """Test setting modem control bits with loopback adapter."""
     with Serial(LOOPBACK_ADAPTER, baudrate=115200) as serial:
-        serial.set_modem_bits(dtr=True, rts=True)
+        serial.set_modem_pins(dtr=True, rts=True)
 
-        modem_bits = serial.get_modem_bits()
-        assert modem_bits.dtr is True
-        assert modem_bits.rts is True
+        modem_pins = serial.get_modem_pins()
+        assert modem_pins.dtr is True
+        assert modem_pins.rts is True
 
         # Set DTR low, leave RTS unchanged
-        serial.set_modem_bits(dtr=False)
+        serial.set_modem_pins(dtr=False)
 
-        modem_bits = serial.get_modem_bits()
-        assert modem_bits.dtr is False
-        assert modem_bits.rts is True
+        modem_pins = serial.get_modem_pins()
+        assert modem_pins.dtr is False
+        assert modem_pins.rts is True
 
         # Set both low
-        serial.set_modem_bits(dtr=False, rts=False)
+        serial.set_modem_pins(dtr=False, rts=False)
 
-        modem_bits = serial.get_modem_bits()
-        assert modem_bits.dtr is False
-        assert modem_bits.rts is False
+        modem_pins = serial.get_modem_pins()
+        assert modem_pins.dtr is False
+        assert modem_pins.rts is False
 
 
 def test_deprecated_dtr_property_loopback() -> None:

--- a/tests/test_socat_async.py
+++ b/tests/test_socat_async.py
@@ -13,7 +13,7 @@ else:
 import pytest
 
 from serialx import (
-    ModemBits,
+    ModemPins,
     Parity,
     SerialTransport,
     StopBits,
@@ -459,25 +459,25 @@ async def test_read_with_timeout_async() -> None:
             await asyncio.wait_for(reader_right.readexactly(1), timeout=0.1)
 
 
-async def test_get_modem_bits_async() -> None:
+async def test_get_modem_pins_async() -> None:
     """Test reading modem control bits."""
     async with (
         async_create_socat_pair() as (left, right),
         async_create_reader_writer(left, baudrate=115200) as (reader, writer),
     ):
         transport = cast(SerialTransport, writer.transport)
-        modem_bits = await transport.get_modem_bits()
+        modem_pins = await transport.get_modem_pins()
 
-        # Verify we get a ModemBits object
-        assert isinstance(modem_bits, ModemBits)
+        # Verify we get a ModemPins object
+        assert isinstance(modem_pins, ModemPins)
 
-        # All modem bits should be either True, False, or None
+        # All modem pins should be either True, False, or None
         for field in ["le", "dtr", "rts", "st", "sr", "cts", "car", "rng", "dsr"]:
-            value = getattr(modem_bits, field)
+            value = getattr(modem_pins, field)
             assert value in (True, False, None)
 
 
-async def test_set_modem_bits_async() -> None:
+async def test_set_modem_pins_async() -> None:
     """Test setting modem control bits with socat pair."""
     async with (
         async_create_socat_pair() as (left, right),
@@ -486,18 +486,18 @@ async def test_set_modem_bits_async() -> None:
         transport = cast(SerialTransport, writer.transport)
         # Note: socat pairs don't support modem control signals properly
         # These calls should not raise errors, but values may be None
-        await transport.set_modem_bits(dtr=True, rts=True)
-        modem_bits = await transport.get_modem_bits()
-        # Verify we get a ModemBits object, values may be None with socat
-        assert isinstance(modem_bits, ModemBits)
+        await transport.set_modem_pins(dtr=True, rts=True)
+        modem_pins = await transport.get_modem_pins()
+        # Verify we get a ModemPins object, values may be None with socat
+        assert isinstance(modem_pins, ModemPins)
 
-        await transport.set_modem_bits(dtr=False)
-        modem_bits = await transport.get_modem_bits()
-        assert isinstance(modem_bits, ModemBits)
+        await transport.set_modem_pins(dtr=False)
+        modem_pins = await transport.get_modem_pins()
+        assert isinstance(modem_pins, ModemPins)
 
-        await transport.set_modem_bits(dtr=False, rts=False)
-        modem_bits = await transport.get_modem_bits()
-        assert isinstance(modem_bits, ModemBits)
+        await transport.set_modem_pins(dtr=False, rts=False)
+        modem_pins = await transport.get_modem_pins()
+        assert isinstance(modem_pins, ModemPins)
 
 
 # Source: https://github.com/home-assistant-libs/pyserial-asyncio-fast/pull/36

--- a/tests/test_socat_async.py
+++ b/tests/test_socat_async.py
@@ -3,7 +3,6 @@
 import asyncio
 import os
 import sys
-from typing import cast
 
 if sys.version_info >= (3, 11):
     from asyncio import timeout as asyncio_timeout
@@ -313,8 +312,7 @@ async def test_valid_baudrates_async(baudrate: int) -> None:
         async_create_reader_writer(left, baudrate=baudrate) as (reader, writer),
     ):
         # Verify baudrate was set (check transport)
-        transport = cast(SerialTransport, writer.transport)
-        assert transport.baudrate == baudrate
+        assert writer.transport.baudrate == baudrate
         writer.write(b"test")
 
 
@@ -331,8 +329,7 @@ async def test_valid_parity_async(parity: Parity) -> None:
             writer,
         ),
     ):
-        transport = cast(SerialTransport, writer.transport)
-        assert transport.parity == parity
+        assert writer.transport.parity == parity
         writer.write(b"test")
 
 
@@ -359,8 +356,7 @@ async def test_valid_stopbits_async(
             writer,
         ),
     ):
-        transport = cast(SerialTransport, writer.transport)
-        assert transport.stopbits == expected
+        assert writer.transport.stopbits == expected
         writer.write(b"test")
 
 
@@ -466,8 +462,7 @@ async def test_get_modem_pins_async() -> None:
         async_create_socat_pair() as (left, right),
         async_create_reader_writer(left, baudrate=115200) as (reader, writer),
     ):
-        transport = cast(SerialTransport, writer.transport)
-        modem_pins = await transport.get_modem_pins()
+        modem_pins = await writer.transport.get_modem_pins()
 
         # Verify we get a ModemPins object
         assert isinstance(modem_pins, ModemPins)
@@ -484,20 +479,19 @@ async def test_set_modem_pins_async() -> None:
         async_create_socat_pair() as (left, right),
         async_create_reader_writer(left, baudrate=115200) as (reader, writer),
     ):
-        transport = cast(SerialTransport, writer.transport)
         # Note: socat pairs don't support modem control signals properly
         # These calls should not raise errors, but values may be None
-        await transport.set_modem_pins(dtr=True, rts=True)
-        modem_pins = await transport.get_modem_pins()
+        await writer.transport.set_modem_pins(dtr=True, rts=True)
+        modem_pins = await writer.transport.get_modem_pins()
         # Verify we get a ModemPins object, values may be None with socat
         assert isinstance(modem_pins, ModemPins)
 
-        await transport.set_modem_pins(dtr=False)
-        modem_pins = await transport.get_modem_pins()
+        await writer.transport.set_modem_pins(dtr=False)
+        modem_pins = await writer.transport.get_modem_pins()
         assert isinstance(modem_pins, ModemPins)
 
-        await transport.set_modem_pins(dtr=False, rts=False)
-        modem_pins = await transport.get_modem_pins()
+        await writer.transport.set_modem_pins(dtr=False, rts=False)
+        modem_pins = await writer.transport.get_modem_pins()
         assert isinstance(modem_pins, ModemPins)
 
 

--- a/tests/test_socat_async.py
+++ b/tests/test_socat_async.py
@@ -486,16 +486,16 @@ async def test_set_modem_bits_async() -> None:
         transport = cast(SerialTransport, writer.transport)
         # Note: socat pairs don't support modem control signals properly
         # These calls should not raise errors, but values may be None
-        await transport.set_modem_bits(ModemBits(dtr=True, rts=True))
+        await transport.set_modem_bits(dtr=True, rts=True)
         modem_bits = await transport.get_modem_bits()
         # Verify we get a ModemBits object, values may be None with socat
         assert isinstance(modem_bits, ModemBits)
 
-        await transport.set_modem_bits(ModemBits(dtr=False))
+        await transport.set_modem_bits(dtr=False)
         modem_bits = await transport.get_modem_bits()
         assert isinstance(modem_bits, ModemBits)
 
-        await transport.set_modem_bits(ModemBits(dtr=False, rts=False))
+        await transport.set_modem_bits(dtr=False, rts=False)
         modem_bits = await transport.get_modem_bits()
         assert isinstance(modem_bits, ModemBits)
 

--- a/tests/test_socat_async.py
+++ b/tests/test_socat_async.py
@@ -15,6 +15,7 @@ import pytest
 from serialx import (
     ModemPins,
     Parity,
+    PinState,
     SerialTransport,
     StopBits,
     create_serial_connection,
@@ -471,10 +472,10 @@ async def test_get_modem_pins_async() -> None:
         # Verify we get a ModemPins object
         assert isinstance(modem_pins, ModemPins)
 
-        # All modem pins should be either True, False, or None
+        # All modem pins should be PinState enum values
         for field in ["le", "dtr", "rts", "st", "sr", "cts", "car", "rng", "dsr"]:
             value = getattr(modem_pins, field)
-            assert value in (True, False, None)
+            assert value in (PinState.HIGH, PinState.LOW, PinState.UNDEFINED)
 
 
 async def test_set_modem_pins_async() -> None:

--- a/tests/test_socat_sync.py
+++ b/tests/test_socat_sync.py
@@ -4,7 +4,7 @@ import os
 
 import pytest
 
-from serialx import ModemBits, Parity, Serial, StopBits
+from serialx import ModemPins, Parity, Serial, StopBits
 from tests.common import SOCAT_BINARY, create_socat_pair
 
 pytestmark = pytest.mark.skipif(
@@ -441,24 +441,24 @@ def test_multiple_flush_calls_socat() -> None:
         assert result == data
 
 
-def test_get_modem_bits_socat() -> None:
+def test_get_modem_pins_socat() -> None:
     """Test reading modem control bits with loopback adapter."""
     with (
         create_socat_pair() as (left, right),
         Serial(left, baudrate=115200) as serial,
     ):
-        modem_bits = serial.get_modem_bits()
+        modem_pins = serial.get_modem_pins()
 
-        # Verify we get a ModemBits object
-        assert isinstance(modem_bits, ModemBits)
+        # Verify we get a ModemPins object
+        assert isinstance(modem_pins, ModemPins)
 
-        # All modem bits should be either True, False, or None
+        # All modem pins should be either True, False, or None
         for field in ["le", "dtr", "rts", "st", "sr", "cts", "car", "rng", "dsr"]:
-            value = getattr(modem_bits, field)
+            value = getattr(modem_pins, field)
             assert value in (True, False, None)
 
 
-def test_set_modem_bits_socat() -> None:
+def test_set_modem_pins_socat() -> None:
     """Test setting modem control bits with socat pair."""
     with (
         create_socat_pair() as (left, right),
@@ -466,18 +466,18 @@ def test_set_modem_bits_socat() -> None:
     ):
         # Note: socat pairs don't support modem control signals properly
         # These calls should not raise errors, but values may be None
-        serial.set_modem_bits(dtr=True, rts=True)
-        modem_bits = serial.get_modem_bits()
-        # Verify we get a ModemBits object, values may be None with socat
-        assert isinstance(modem_bits, ModemBits)
+        serial.set_modem_pins(dtr=True, rts=True)
+        modem_pins = serial.get_modem_pins()
+        # Verify we get a ModemPins object, values may be None with socat
+        assert isinstance(modem_pins, ModemPins)
 
-        serial.set_modem_bits(dtr=False)
-        modem_bits = serial.get_modem_bits()
-        assert isinstance(modem_bits, ModemBits)
+        serial.set_modem_pins(dtr=False)
+        modem_pins = serial.get_modem_pins()
+        assert isinstance(modem_pins, ModemPins)
 
-        serial.set_modem_bits(dtr=False, rts=False)
-        modem_bits = serial.get_modem_bits()
-        assert isinstance(modem_bits, ModemBits)
+        serial.set_modem_pins(dtr=False, rts=False)
+        modem_pins = serial.get_modem_pins()
+        assert isinstance(modem_pins, ModemPins)
 
 
 def test_deprecated_dtr_property_socat() -> None:

--- a/tests/test_socat_sync.py
+++ b/tests/test_socat_sync.py
@@ -466,16 +466,16 @@ def test_set_modem_bits_socat() -> None:
     ):
         # Note: socat pairs don't support modem control signals properly
         # These calls should not raise errors, but values may be None
-        serial.set_modem_bits(ModemBits(dtr=True, rts=True))
+        serial.set_modem_bits(dtr=True, rts=True)
         modem_bits = serial.get_modem_bits()
         # Verify we get a ModemBits object, values may be None with socat
         assert isinstance(modem_bits, ModemBits)
 
-        serial.set_modem_bits(ModemBits(dtr=False))
+        serial.set_modem_bits(dtr=False)
         modem_bits = serial.get_modem_bits()
         assert isinstance(modem_bits, ModemBits)
 
-        serial.set_modem_bits(ModemBits(dtr=False, rts=False))
+        serial.set_modem_bits(dtr=False, rts=False)
         modem_bits = serial.get_modem_bits()
         assert isinstance(modem_bits, ModemBits)
 

--- a/tests/test_socat_sync.py
+++ b/tests/test_socat_sync.py
@@ -4,7 +4,7 @@ import os
 
 import pytest
 
-from serialx import ModemPins, Parity, Serial, StopBits
+from serialx import ModemPins, Parity, PinState, Serial, StopBits
 from tests.common import SOCAT_BINARY, create_socat_pair
 
 pytestmark = pytest.mark.skipif(
@@ -452,10 +452,10 @@ def test_get_modem_pins_socat() -> None:
         # Verify we get a ModemPins object
         assert isinstance(modem_pins, ModemPins)
 
-        # All modem pins should be either True, False, or None
+        # All modem pins should be PinState enum values
         for field in ["le", "dtr", "rts", "st", "sr", "cts", "car", "rng", "dsr"]:
             value = getattr(modem_pins, field)
-            assert value in (True, False, None)
+            assert value in (PinState.HIGH, PinState.LOW, PinState.UNDEFINED)
 
 
 def test_set_modem_pins_socat() -> None:


### PR DESCRIPTION
- `hang_up_on_close` and `deassert_on_open` are now `rtsdtr_on_open` and `rtsdtr_on_close`.
- Pin states are now renamed to `PinState.HIGH`, `PinState.LOW`, or `PinState.UNDEFINED` (instead of `True`, `False`, and `None`).

To maintain compatibility with existing config where flow control is disabled but a connection is being made to an adapter with hardware flow control, `rtsdtr_on_open` has been changed from `not rtscts` (i.e. `LOW` if flow control is not in use, `HIGH` if it is) to `HIGH`.