### PR TITLE
Use pytest CLI arguments for testing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,13 +12,13 @@ repos:
         args: ["--toml", "pyproject.toml"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.18.2
+    rev: v1.19.0
     hooks:
       - id: mypy
   
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.4
+    rev: v0.14.7
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
       - id: ruff-format

--- a/README.md
+++ b/README.md
@@ -75,3 +75,28 @@ async def main():
 
 	await transport.set_modem_pins(rts=True, dtr=True)
 ```
+
+# Development
+All development dependencies are listed in `pyproject.toml`. To install them, use:
+```bash
+uv pip install '.[dev]'
+```
+
+Set up pre-commit hooks with `pre-commit install`. Your code will then be type checked
+and auto-formatted when you run `git commit`. You can do this on-demand with
+`pre-commit run`.
+
+Serialx relies on automated testing. We do not have a custom GitHub Actions runners with
+real hardware (yet) so GitHub Actions CI will only run `socat` tests.
+
+To run tests locally with loopback adapters and pairs of real adapters, pass CLI flags
+to `pytest`:
+
+```bash
+pytest --loopback-adapter=/dev/serial/by-id/my-loopback-adapter \
+       --adapter-pair=/dev/serial/by-id/left1:/dev/serial/by-id/right1 \
+       --adapter-pair=/dev/serial/by-id/left2:/dev/serial/by-id/right2
+```
+
+By default, this will run tests in parallel across all adapter pairs. You can disable
+this by passing `-n 0` to `pytest`, which will execute the tests sequentially.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
 dev = [
     "ruff",
     "pytest",
+    "pre-commit",
     "pytest-asyncio",
     "pytest-timeout",
     "pytest-xdist",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dev = [
     "pytest",
     "pytest-asyncio",
     "pytest-timeout",
+    "pytest-xdist",
 ]
 
 [tool.setuptools.packages.find]
@@ -33,7 +34,7 @@ exclude = ["tests", "tests.*"]
 enabled = true
 
 [tool.pytest.ini_options]
-addopts = "--showlocals --verbose"
+addopts = "--showlocals --verbose -n auto --dist loadgroup"
 testpaths = ["tests"]
 timeout = 20
 log_format = "%(asctime)s.%(msecs)03d %(levelname)s %(message)s"

--- a/tests/common.py
+++ b/tests/common.py
@@ -14,9 +14,6 @@ import pytest
 
 import serialx
 
-LOOPBACK_ADAPTER = os.environ.get("SERIALX_LOOPBACK_PORT")
-DUAL_LOOPBACK_LEFT = os.environ.get("SERIALX_DUAL_LOOPBACK_LEFT")
-DUAL_LOOPBACK_RIGHT = os.environ.get("SERIALX_DUAL_LOOPBACK_RIGHT")
 SOCAT_BINARY = shutil.which("socat")
 
 
@@ -130,6 +127,8 @@ async def async_create_reader_writer_pair(
 
 @contextlib.asynccontextmanager
 async def async_create_dual_loopback(
+    left_port: str,
+    right_port: str,
     **kwargs: Any,
 ) -> AsyncIterator[
     tuple[
@@ -141,17 +140,13 @@ async def async_create_dual_loopback(
 ]:
     """Create reader/writer pairs for dual loopback configuration.
 
-    Uses DUAL_LOOPBACK_LEFT and DUAL_LOOPBACK_RIGHT environment variables.
     Returns (reader_left, writer_left, reader_right, writer_right).
     """
-    if DUAL_LOOPBACK_LEFT is None or DUAL_LOOPBACK_RIGHT is None:
-        pytest.skip("Dual loopback ports not configured")
-
     reader_left, writer_left = await serialx.open_serial_connection(
-        DUAL_LOOPBACK_LEFT, **kwargs
+        left_port, **kwargs
     )
     reader_right, writer_right = await serialx.open_serial_connection(
-        DUAL_LOOPBACK_RIGHT, **kwargs
+        right_port, **kwargs
     )
 
     try:
@@ -190,18 +185,16 @@ def create_connected_pair(
 
 @contextlib.contextmanager
 def create_dual_loopback(
+    left_port: str,
+    right_port: str,
     **kwargs: Any,
 ) -> Iterator[tuple[serialx.Serial, serialx.Serial]]:
     """Create a connected pair of serial ports with dual loopback hardware.
 
-    Uses DUAL_LOOPBACK_LEFT and DUAL_LOOPBACK_RIGHT environment variables.
     Returns (serial_left, serial_right).
     """
-    if DUAL_LOOPBACK_LEFT is None or DUAL_LOOPBACK_RIGHT is None:
-        pytest.skip("Dual loopback ports not configured")
-
     with (
-        serialx.Serial(DUAL_LOOPBACK_LEFT, **kwargs) as serial_left,
-        serialx.Serial(DUAL_LOOPBACK_RIGHT, **kwargs) as serial_right,
+        serialx.Serial(left_port, **kwargs) as serial_left,
+        serialx.Serial(right_port, **kwargs) as serial_right,
     ):
         yield (serial_left, serial_right)

--- a/tests/common.py
+++ b/tests/common.py
@@ -142,9 +142,7 @@ async def async_create_dual_loopback(
 
     Returns (reader_left, writer_left, reader_right, writer_right).
     """
-    reader_left, writer_left = await serialx.open_serial_connection(
-        left_port, **kwargs
-    )
+    reader_left, writer_left = await serialx.open_serial_connection(left_port, **kwargs)
     reader_right, writer_right = await serialx.open_serial_connection(
         right_port, **kwargs
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,15 +54,14 @@ def pytest_generate_tests(metafunc):
     if "loopback_adapter" in metafunc.fixturenames:
         adapters = _get_loopback_adapters(metafunc.config)
         if adapters:
-            # For pytest-xdist: group tests by adapter so same adapter doesn't run in parallel
-            # Use adapter path as the group ID to ensure tests using the same adapter are sequential
-            ids = []
+            #  Create marks for each adapter value
+            argvalues = []
             for adapter in adapters:
-                # Create a short, filesystem-safe ID for the group
-                # Use the adapter path itself as the group ID
-                ids.append(adapter)
+                # Create a parametrize mark with xdist_group for this specific adapter
+                mark = pytest.mark.xdist_group(name=f"adapter:{adapter}")
+                argvalues.append(pytest.param(adapter, marks=[mark], id=adapter))
 
-            metafunc.parametrize("loopback_adapter", adapters, ids=ids)
+            metafunc.parametrize("loopback_adapter", argvalues)
         else:
             # No adapters configured, skip all tests requiring loopback_adapter
             pytest.skip("No loopback adapters configured via --loopback-adapter")
@@ -71,30 +70,15 @@ def pytest_generate_tests(metafunc):
     if "adapter_pair" in metafunc.fixturenames:
         pairs = _get_adapter_pairs(metafunc.config)
         if pairs:
-            # For pytest-xdist: group tests by adapter pair
-            # Use both adapters in the group to ensure no conflicts
-            ids = []
+            argvalues = []
             for left, right in pairs:
-                ids.append(f"{left}:{right}")
+                group_name = f"pair:{left}:{right}"
+                mark = pytest.mark.xdist_group(name=group_name)
+                argvalues.append(
+                    pytest.param((left, right), marks=[mark], id=f"{left}:{right}")
+                )
 
-            metafunc.parametrize("adapter_pair", pairs, ids=ids)
+            metafunc.parametrize("adapter_pair", argvalues)
         else:
             # No pairs configured, skip all tests requiring adapter_pair
             pytest.skip("No adapter pairs configured via --adapter-pair")
-
-
-def pytest_collection_modifyitems(items):
-    """Add xdist_group marks to tests based on their adapter parameters."""
-    for item in items:
-        # Check if this test uses loopback_adapter parameter
-        if hasattr(item, "callspec") and "loopback_adapter" in item.callspec.params:
-            adapter = item.callspec.params["loopback_adapter"]
-            # Add xdist_group mark with the adapter path as the group name
-            item.add_marker(pytest.mark.xdist_group(name=f"adapter:{adapter}"))
-
-        # Check if this test uses adapter_pair parameter
-        elif hasattr(item, "callspec") and "adapter_pair" in item.callspec.params:
-            left, right = item.callspec.params["adapter_pair"]
-            # Group by both adapters to ensure no conflicts
-            # Tests using the same pair will be in the same group
-            item.add_marker(pytest.mark.xdist_group(name=f"pair:{left}:{right}"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,61 @@
+"""Pytest configuration for serialx tests."""
+
+import os
+
+import pytest
+
+
+def pytest_addoption(parser):
+    """Add custom command line options for serial adapter configuration."""
+    parser.addoption(
+        "--loopback-adapter",
+        action="append",
+        default=[],
+        help="Serial loopback adapter device path (can be specified multiple times)",
+    )
+    parser.addoption(
+        "--adapter-pair",
+        action="append",
+        default=[],
+        help="Pair of serial adapters in format LEFT:RIGHT (can be specified multiple times)",
+    )
+
+
+def _get_loopback_adapters(config):
+    """Get list of loopback adapters from config."""
+    return config.getoption("--loopback-adapter")
+
+
+def _get_adapter_pairs(config):
+    """Get list of adapter pairs from config."""
+    pairs_raw = config.getoption("--adapter-pair")
+    pairs = []
+
+    for pair in pairs_raw:
+        parts = pair.split(":")
+        if len(parts) != 2:
+            raise ValueError(f"Invalid adapter pair format: {pair}. Expected LEFT:RIGHT")
+        pairs.append((parts[0], parts[1]))
+
+    return pairs
+
+
+def pytest_generate_tests(metafunc):
+    """Parametrize tests based on configured adapters."""
+    # Check if this test function needs a loopback adapter
+    if "loopback_adapter" in metafunc.fixturenames:
+        adapters = _get_loopback_adapters(metafunc.config)
+        if adapters:
+            metafunc.parametrize("loopback_adapter", adapters)
+        else:
+            # No adapters configured, skip all tests requiring loopback_adapter
+            pytest.skip("No loopback adapters configured via --loopback-adapter")
+
+    # Check if this test function needs an adapter pair
+    if "adapter_pair" in metafunc.fixturenames:
+        pairs = _get_adapter_pairs(metafunc.config)
+        if pairs:
+            metafunc.parametrize("adapter_pair", pairs)
+        else:
+            # No pairs configured, skip all tests requiring adapter_pair
+            pytest.skip("No adapter pairs configured via --adapter-pair")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,14 @@
 """Pytest configuration for serialx tests."""
 
-import os
-
 import pytest
+
+
+def pytest_configure(config):
+    """Register custom markers."""
+    config.addinivalue_line(
+        "markers",
+        "xdist_group(name): group tests for pytest-xdist parallel execution control",
+    )
 
 
 def pytest_addoption(parser):
@@ -34,7 +40,9 @@ def _get_adapter_pairs(config):
     for pair in pairs_raw:
         parts = pair.split(":")
         if len(parts) != 2:
-            raise ValueError(f"Invalid adapter pair format: {pair}. Expected LEFT:RIGHT")
+            raise ValueError(
+                f"Invalid adapter pair format: {pair}. Expected LEFT:RIGHT"
+            )
         pairs.append((parts[0], parts[1]))
 
     return pairs
@@ -46,7 +54,15 @@ def pytest_generate_tests(metafunc):
     if "loopback_adapter" in metafunc.fixturenames:
         adapters = _get_loopback_adapters(metafunc.config)
         if adapters:
-            metafunc.parametrize("loopback_adapter", adapters)
+            # For pytest-xdist: group tests by adapter so same adapter doesn't run in parallel
+            # Use adapter path as the group ID to ensure tests using the same adapter are sequential
+            ids = []
+            for adapter in adapters:
+                # Create a short, filesystem-safe ID for the group
+                # Use the adapter path itself as the group ID
+                ids.append(adapter)
+
+            metafunc.parametrize("loopback_adapter", adapters, ids=ids)
         else:
             # No adapters configured, skip all tests requiring loopback_adapter
             pytest.skip("No loopback adapters configured via --loopback-adapter")
@@ -55,7 +71,30 @@ def pytest_generate_tests(metafunc):
     if "adapter_pair" in metafunc.fixturenames:
         pairs = _get_adapter_pairs(metafunc.config)
         if pairs:
-            metafunc.parametrize("adapter_pair", pairs)
+            # For pytest-xdist: group tests by adapter pair
+            # Use both adapters in the group to ensure no conflicts
+            ids = []
+            for left, right in pairs:
+                ids.append(f"{left}:{right}")
+
+            metafunc.parametrize("adapter_pair", pairs, ids=ids)
         else:
             # No pairs configured, skip all tests requiring adapter_pair
             pytest.skip("No adapter pairs configured via --adapter-pair")
+
+
+def pytest_collection_modifyitems(items):
+    """Add xdist_group marks to tests based on their adapter parameters."""
+    for item in items:
+        # Check if this test uses loopback_adapter parameter
+        if hasattr(item, "callspec") and "loopback_adapter" in item.callspec.params:
+            adapter = item.callspec.params["loopback_adapter"]
+            # Add xdist_group mark with the adapter path as the group name
+            item.add_marker(pytest.mark.xdist_group(name=f"adapter:{adapter}"))
+
+        # Check if this test uses adapter_pair parameter
+        elif hasattr(item, "callspec") and "adapter_pair" in item.callspec.params:
+            left, right = item.callspec.params["adapter_pair"]
+            # Group by both adapters to ensure no conflicts
+            # Tests using the same pair will be in the same group
+            item.add_marker(pytest.mark.xdist_group(name=f"pair:{left}:{right}"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@
 import pytest
 
 
-def pytest_configure(config):
+def pytest_configure(config: pytest.Config) -> None:
     """Register custom markers."""
     config.addinivalue_line(
         "markers",
@@ -11,7 +11,7 @@ def pytest_configure(config):
     )
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser: pytest.Parser) -> None:
     """Add custom command line options for serial adapter configuration."""
     parser.addoption(
         "--loopback-adapter",
@@ -27,58 +27,61 @@ def pytest_addoption(parser):
     )
 
 
-def _get_loopback_adapters(config):
+def _get_loopback_adapters(config: pytest.Config) -> list[str]:
     """Get list of loopback adapters from config."""
     return config.getoption("--loopback-adapter")
 
 
-def _get_adapter_pairs(config):
+def _get_adapter_pairs(config: pytest.Config) -> list[tuple[str, str]]:
     """Get list of adapter pairs from config."""
-    pairs_raw = config.getoption("--adapter-pair")
     pairs = []
 
-    for pair in pairs_raw:
+    for pair in config.getoption("--adapter-pair"):
         parts = pair.split(":")
         if len(parts) != 2:
             raise ValueError(
                 f"Invalid adapter pair format: {pair}. Expected LEFT:RIGHT"
             )
-        pairs.append((parts[0], parts[1]))
+
+        pairs.append(tuple(parts))
 
     return pairs
 
 
-def pytest_generate_tests(metafunc):
+def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     """Parametrize tests based on configured adapters."""
-    # Check if this test function needs a loopback adapter
     if "loopback_adapter" in metafunc.fixturenames:
         adapters = _get_loopback_adapters(metafunc.config)
-        if adapters:
-            #  Create marks for each adapter value
-            argvalues = []
-            for adapter in adapters:
-                # Create a parametrize mark with xdist_group for this specific adapter
-                mark = pytest.mark.xdist_group(name=f"adapter:{adapter}")
-                argvalues.append(pytest.param(adapter, marks=[mark], id=adapter))
 
-            metafunc.parametrize("loopback_adapter", argvalues)
+        if adapters:
+            metafunc.parametrize(
+                "loopback_adapter",
+                [
+                    pytest.param(
+                        adapter,
+                        marks=[pytest.mark.xdist_group(name=f"adapter:{adapter}")],
+                        id=f"{adapter}",
+                    )
+                    for adapter in adapters
+                ],
+            )
         else:
-            # No adapters configured, skip all tests requiring loopback_adapter
             pytest.skip("No loopback adapters configured via --loopback-adapter")
 
-    # Check if this test function needs an adapter pair
     if "adapter_pair" in metafunc.fixturenames:
         pairs = _get_adapter_pairs(metafunc.config)
-        if pairs:
-            argvalues = []
-            for left, right in pairs:
-                group_name = f"pair:{left}:{right}"
-                mark = pytest.mark.xdist_group(name=group_name)
-                argvalues.append(
-                    pytest.param((left, right), marks=[mark], id=f"{left}:{right}")
-                )
 
-            metafunc.parametrize("adapter_pair", argvalues)
+        if pairs:
+            metafunc.parametrize(
+                "adapter_pair",
+                [
+                    pytest.param(
+                        (left, right),
+                        marks=[pytest.mark.xdist_group(name=f"pair:{left}:{right}")],
+                        id=f"{left}:{right}",
+                    )
+                    for left, right in pairs
+                ],
+            )
         else:
-            # No pairs configured, skip all tests requiring adapter_pair
             pytest.skip("No adapter pairs configured via --adapter-pair")

--- a/tests/test_loopback_async.py
+++ b/tests/test_loopback_async.py
@@ -7,16 +7,12 @@ from typing import cast
 import pytest
 
 from serialx import Parity, PinState, SerialTransport, StopBits
-from tests.common import LOOPBACK_ADAPTER, async_create_reader_writer
-
-pytestmark = pytest.mark.skipif(
-    not LOOPBACK_ADAPTER, reason="SERIALX_LOOPBACK_PORT not set"
-)
+from tests.common import async_create_reader_writer
 
 
-async def test_all_bytes_loopback_async() -> None:
+async def test_all_bytes_loopback_async(loopback_adapter: str) -> None:
     """Test that all bytes 0-255 can be transmitted."""
-    async with async_create_reader_writer(LOOPBACK_ADAPTER, baudrate=115200) as (
+    async with async_create_reader_writer(loopback_adapter, baudrate=115200) as (
         reader,
         writer,
     ):
@@ -29,9 +25,9 @@ async def test_all_bytes_loopback_async() -> None:
         assert result == data
 
 
-async def test_segmented_binary_data_loopback_async() -> None:
+async def test_segmented_binary_data_loopback_async(loopback_adapter: str) -> None:
     """Test binary data sent in segments."""
-    async with async_create_reader_writer(LOOPBACK_ADAPTER, baudrate=115200) as (
+    async with async_create_reader_writer(loopback_adapter, baudrate=115200) as (
         reader,
         writer,
     ):
@@ -52,7 +48,7 @@ async def test_segmented_binary_data_loopback_async() -> None:
 )
 async def test_binary_payload_sizes_loopback_async(size: int) -> None:
     """Test various binary payload sizes."""
-    async with async_create_reader_writer(LOOPBACK_ADAPTER, baudrate=115200) as (
+    async with async_create_reader_writer(loopback_adapter, baudrate=115200) as (
         reader,
         writer,
     ):
@@ -65,9 +61,9 @@ async def test_binary_payload_sizes_loopback_async(size: int) -> None:
         assert result == data
 
 
-async def test_null_bytes_loopback_async() -> None:
+async def test_null_bytes_loopback_async(loopback_adapter: str) -> None:
     """Test that null bytes (0x00) can be transmitted."""
-    async with async_create_reader_writer(LOOPBACK_ADAPTER, baudrate=115200) as (
+    async with async_create_reader_writer(loopback_adapter, baudrate=115200) as (
         reader,
         writer,
     ):
@@ -80,9 +76,9 @@ async def test_null_bytes_loopback_async() -> None:
         assert result == null_data
 
 
-async def test_overlapping_read_write_loopback_async() -> None:
+async def test_overlapping_read_write_loopback_async(loopback_adapter: str) -> None:
     """Test that read and write can overlap, data is buffered."""
-    async with async_create_reader_writer(LOOPBACK_ADAPTER, baudrate=115200) as (
+    async with async_create_reader_writer(loopback_adapter, baudrate=115200) as (
         reader,
         writer,
     ):
@@ -116,7 +112,7 @@ async def test_overlapping_read_write_loopback_async() -> None:
 )
 async def test_random_large_loopback_async(baudrate: int, chunk_size: int) -> None:
     """Test random read/write at various speeds."""
-    async with async_create_reader_writer(LOOPBACK_ADAPTER, baudrate=baudrate) as (
+    async with async_create_reader_writer(loopback_adapter, baudrate=baudrate) as (
         reader,
         writer,
     ):
@@ -133,7 +129,7 @@ async def test_random_large_loopback_async(baudrate: int, chunk_size: int) -> No
 )
 async def test_repeated_write_read_cycles_loopback_async(iterations: int) -> None:
     """Test repeated write/read cycles."""
-    async with async_create_reader_writer(LOOPBACK_ADAPTER, baudrate=115200) as (
+    async with async_create_reader_writer(loopback_adapter, baudrate=115200) as (
         reader,
         writer,
     ):
@@ -145,9 +141,9 @@ async def test_repeated_write_read_cycles_loopback_async(iterations: int) -> Non
             assert result == data
 
 
-async def test_buffered_writes_then_read_loopback_async() -> None:
+async def test_buffered_writes_then_read_loopback_async(loopback_adapter: str) -> None:
     """Test multiple writes followed by a single read."""
-    async with async_create_reader_writer(LOOPBACK_ADAPTER, baudrate=115200) as (
+    async with async_create_reader_writer(loopback_adapter, baudrate=115200) as (
         reader,
         writer,
     ):
@@ -173,7 +169,7 @@ async def test_buffered_writes_then_read_loopback_async() -> None:
 )
 async def test_large_payload_loopback_async(payload_size: int) -> None:
     """Test large payload transmission."""
-    async with async_create_reader_writer(LOOPBACK_ADAPTER, baudrate=921600) as (
+    async with async_create_reader_writer(loopback_adapter, baudrate=921600) as (
         reader,
         writer,
     ):
@@ -185,9 +181,9 @@ async def test_large_payload_loopback_async(payload_size: int) -> None:
         assert result == data
 
 
-async def test_rapid_small_writes_loopback_async() -> None:
+async def test_rapid_small_writes_loopback_async(loopback_adapter: str) -> None:
     """Test rapid succession of small writes."""
-    async with async_create_reader_writer(LOOPBACK_ADAPTER, baudrate=115200) as (
+    async with async_create_reader_writer(loopback_adapter, baudrate=115200) as (
         reader,
         writer,
     ):
@@ -218,7 +214,7 @@ async def test_sustained_throughput_loopback_async(
     baudrate: int, iterations: int
 ) -> None:
     """Test sustained data throughput at various baudrates."""
-    async with async_create_reader_writer(LOOPBACK_ADAPTER, baudrate=baudrate) as (
+    async with async_create_reader_writer(loopback_adapter, baudrate=baudrate) as (
         reader,
         writer,
     ):
@@ -236,7 +232,7 @@ async def test_sustained_throughput_loopback_async(
 )
 async def test_valid_baudrates_loopback_async(baudrate: int) -> None:
     """Test that valid baudrates are accepted."""
-    async with async_create_reader_writer(LOOPBACK_ADAPTER, baudrate=baudrate) as (
+    async with async_create_reader_writer(loopback_adapter, baudrate=baudrate) as (
         reader,
         writer,
     ):
@@ -253,7 +249,7 @@ async def test_valid_baudrates_loopback_async(baudrate: int) -> None:
 async def test_valid_parity_loopback_async(parity: Parity) -> None:
     """Test that valid parity settings are accepted."""
     async with async_create_reader_writer(
-        LOOPBACK_ADAPTER, baudrate=115200, parity=parity
+        loopback_adapter, baudrate=115200, parity=parity
     ) as (
         reader,
         writer,
@@ -288,7 +284,7 @@ async def test_valid_stopbits_loopback_async(
 ) -> None:
     """Test that valid stopbits settings are accepted."""
     async with async_create_reader_writer(
-        LOOPBACK_ADAPTER, baudrate=115200, stopbits=stopbits
+        loopback_adapter, baudrate=115200, stopbits=stopbits
     ) as (
         reader,
         writer,
@@ -302,7 +298,7 @@ async def test_valid_stopbits_loopback_async(
 async def test_valid_byte_size_loopback_async(byte_size: int) -> None:
     """Test that valid byte sizes are accepted."""
     async with async_create_reader_writer(
-        LOOPBACK_ADAPTER, baudrate=115200, byte_size=byte_size
+        loopback_adapter, baudrate=115200, byte_size=byte_size
     ) as (
         reader,
         writer,
@@ -314,7 +310,7 @@ async def test_valid_byte_size_loopback_async(byte_size: int) -> None:
 async def test_xonxoff_setting_loopback_async(xonxoff: bool) -> None:
     """Test that xonxoff setting is accepted."""
     async with async_create_reader_writer(
-        LOOPBACK_ADAPTER, baudrate=115200, xonxoff=xonxoff
+        loopback_adapter, baudrate=115200, xonxoff=xonxoff
     ) as (
         reader,
         writer,
@@ -329,7 +325,7 @@ async def test_xonxoff_setting_loopback_async(xonxoff: bool) -> None:
 async def test_rtscts_setting_loopback_async(rtscts: bool) -> None:
     """Test that rtscts setting is accepted."""
     async with async_create_reader_writer(
-        LOOPBACK_ADAPTER, baudrate=115200, rtscts=rtscts
+        loopback_adapter, baudrate=115200, rtscts=rtscts
     ) as (
         reader,
         writer,
@@ -337,9 +333,9 @@ async def test_rtscts_setting_loopback_async(rtscts: bool) -> None:
         writer.write(b"test")
 
 
-async def test_read_with_timeout_loopback_async() -> None:
+async def test_read_with_timeout_loopback_async(loopback_adapter: str) -> None:
     """Test reading with timeout."""
-    async with async_create_reader_writer(LOOPBACK_ADAPTER, baudrate=115200) as (
+    async with async_create_reader_writer(loopback_adapter, baudrate=115200) as (
         reader,
         writer,
     ):
@@ -355,9 +351,9 @@ async def test_read_with_timeout_loopback_async() -> None:
             await asyncio.wait_for(reader.readexactly(1), timeout=0.1)
 
 
-async def test_set_modem_pins_loopback_async() -> None:
+async def test_set_modem_pins_loopback_async(loopback_adapter: str) -> None:
     """Test setting modem control bits with loopback adapter."""
-    async with async_create_reader_writer(LOOPBACK_ADAPTER, baudrate=115200) as (
+    async with async_create_reader_writer(loopback_adapter, baudrate=115200) as (
         reader,
         writer,
     ):

--- a/tests/test_loopback_async.py
+++ b/tests/test_loopback_async.py
@@ -46,7 +46,9 @@ async def test_segmented_binary_data_loopback_async(loopback_adapter: str) -> No
     "size",
     [1, 16, 64, 256, 512, 1024],
 )
-async def test_binary_payload_sizes_loopback_async(size: int) -> None:
+async def test_binary_payload_sizes_loopback_async(
+    loopback_adapter: str, size: int
+) -> None:
     """Test various binary payload sizes."""
     async with async_create_reader_writer(loopback_adapter, baudrate=115200) as (
         reader,
@@ -110,7 +112,9 @@ async def test_overlapping_read_write_loopback_async(loopback_adapter: str) -> N
         (921600, 1024),
     ],
 )
-async def test_random_large_loopback_async(baudrate: int, chunk_size: int) -> None:
+async def test_random_large_loopback_async(
+    loopback_adapter: str, baudrate: int, chunk_size: int
+) -> None:
     """Test random read/write at various speeds."""
     async with async_create_reader_writer(loopback_adapter, baudrate=baudrate) as (
         reader,
@@ -127,7 +131,9 @@ async def test_random_large_loopback_async(baudrate: int, chunk_size: int) -> No
     "iterations",
     [16, 32, 64],
 )
-async def test_repeated_write_read_cycles_loopback_async(iterations: int) -> None:
+async def test_repeated_write_read_cycles_loopback_async(
+    loopback_adapter: str, iterations: int
+) -> None:
     """Test repeated write/read cycles."""
     async with async_create_reader_writer(loopback_adapter, baudrate=115200) as (
         reader,
@@ -167,7 +173,9 @@ async def test_buffered_writes_then_read_loopback_async(loopback_adapter: str) -
     "payload_size",
     [1024, 2048],  # Kernel buffers are typically ~4KB, stay well below that
 )
-async def test_large_payload_loopback_async(payload_size: int) -> None:
+async def test_large_payload_loopback_async(
+    loopback_adapter: str, payload_size: int
+) -> None:
     """Test large payload transmission."""
     async with async_create_reader_writer(loopback_adapter, baudrate=921600) as (
         reader,
@@ -211,7 +219,7 @@ async def test_rapid_small_writes_loopback_async(loopback_adapter: str) -> None:
     ],
 )
 async def test_sustained_throughput_loopback_async(
-    baudrate: int, iterations: int
+    loopback_adapter: str, baudrate: int, iterations: int
 ) -> None:
     """Test sustained data throughput at various baudrates."""
     async with async_create_reader_writer(loopback_adapter, baudrate=baudrate) as (
@@ -230,7 +238,9 @@ async def test_sustained_throughput_loopback_async(
     "baudrate",
     [9600, 19200, 38400, 57600, 115200, 230400, 460800, 921600],
 )
-async def test_valid_baudrates_loopback_async(baudrate: int) -> None:
+async def test_valid_baudrates_loopback_async(
+    loopback_adapter: str, baudrate: int
+) -> None:
     """Test that valid baudrates are accepted."""
     async with async_create_reader_writer(loopback_adapter, baudrate=baudrate) as (
         reader,
@@ -246,7 +256,9 @@ async def test_valid_baudrates_loopback_async(baudrate: int) -> None:
     "parity",
     [Parity.NONE, Parity.ODD, Parity.EVEN, Parity.MARK, Parity.SPACE],
 )
-async def test_valid_parity_loopback_async(parity: Parity) -> None:
+async def test_valid_parity_loopback_async(
+    loopback_adapter: str, parity: Parity
+) -> None:
     """Test that valid parity settings are accepted."""
     async with async_create_reader_writer(
         loopback_adapter, baudrate=115200, parity=parity
@@ -279,6 +291,7 @@ async def test_valid_parity_loopback_async(parity: Parity) -> None:
     ],
 )
 async def test_valid_stopbits_loopback_async(
+    loopback_adapter: str,
     stopbits: StopBits | int | float,
     expected: StopBits,
 ) -> None:
@@ -295,7 +308,9 @@ async def test_valid_stopbits_loopback_async(
 
 
 @pytest.mark.parametrize("byte_size", [5, 6, 7, 8])
-async def test_valid_byte_size_loopback_async(byte_size: int) -> None:
+async def test_valid_byte_size_loopback_async(
+    loopback_adapter: str, byte_size: int
+) -> None:
     """Test that valid byte sizes are accepted."""
     async with async_create_reader_writer(
         loopback_adapter, baudrate=115200, byte_size=byte_size
@@ -307,7 +322,9 @@ async def test_valid_byte_size_loopback_async(byte_size: int) -> None:
 
 
 @pytest.mark.parametrize("xonxoff", [True, False])
-async def test_xonxoff_setting_loopback_async(xonxoff: bool) -> None:
+async def test_xonxoff_setting_loopback_async(
+    loopback_adapter: str, xonxoff: bool
+) -> None:
     """Test that xonxoff setting is accepted."""
     async with async_create_reader_writer(
         loopback_adapter, baudrate=115200, xonxoff=xonxoff
@@ -322,7 +339,9 @@ async def test_xonxoff_setting_loopback_async(xonxoff: bool) -> None:
     "rtscts",
     [True, False],
 )
-async def test_rtscts_setting_loopback_async(rtscts: bool) -> None:
+async def test_rtscts_setting_loopback_async(
+    loopback_adapter: str, rtscts: bool
+) -> None:
     """Test that rtscts setting is accepted."""
     async with async_create_reader_writer(
         loopback_adapter, baudrate=115200, rtscts=rtscts

--- a/tests/test_loopback_dual_async.py
+++ b/tests/test_loopback_dual_async.py
@@ -7,21 +7,16 @@ import pytest
 
 from serialx import Parity, PinState, StopBits, create_serial_connection
 from tests.common import (
-    DUAL_LOOPBACK_LEFT,
-    DUAL_LOOPBACK_RIGHT,
     async_create_dual_loopback,
     async_create_reader_writer,
 )
 
-pytestmark = pytest.mark.skipif(
-    not DUAL_LOOPBACK_LEFT or not DUAL_LOOPBACK_RIGHT,
-    reason="SERIALX_DUAL_LOOPBACK_LEFT and SERIALX_DUAL_LOOPBACK_RIGHT not set",
-)
 
 
-async def test_all_bytes_async() -> None:
+
+async def test_all_bytes_async(adapter_pair: tuple[str, str]) -> None:
     """Test that all bytes 0-255 can be transmitted."""
-    async with async_create_dual_loopback(baudrate=115200) as (
+    async with async_create_dual_loopback(adapter_pair[0], adapter_pair[1], baudrate=115200) as (
         reader_left,
         writer_left,
         reader_right,
@@ -36,9 +31,9 @@ async def test_all_bytes_async() -> None:
         assert result == data
 
 
-async def test_segmented_binary_data_async() -> None:
+async def test_segmented_binary_data_async(adapter_pair: tuple[str, str]) -> None:
     """Test binary data sent in segments."""
-    async with async_create_dual_loopback(baudrate=115200) as (
+    async with async_create_dual_loopback(adapter_pair[0], adapter_pair[1], baudrate=115200) as (
         reader_left,
         writer_left,
         reader_right,
@@ -59,9 +54,9 @@ async def test_segmented_binary_data_async() -> None:
     "size",
     [1, 16, 64, 256, 512, 1024],
 )
-async def test_binary_payload_sizes_async(size: int) -> None:
+async def test_binary_payload_sizes_async(adapter_pair: tuple[str, str], size: int) -> None:
     """Test various binary payload sizes."""
-    async with async_create_dual_loopback(baudrate=115200) as (
+    async with async_create_dual_loopback(adapter_pair[0], adapter_pair[1], baudrate=115200) as (
         reader_left,
         writer_left,
         reader_right,
@@ -76,9 +71,9 @@ async def test_binary_payload_sizes_async(size: int) -> None:
         assert result == data
 
 
-async def test_null_bytes_async() -> None:
+async def test_null_bytes_async(adapter_pair: tuple[str, str]) -> None:
     """Test that null bytes (0x00) can be transmitted."""
-    async with async_create_dual_loopback(baudrate=115200) as (
+    async with async_create_dual_loopback(adapter_pair[0], adapter_pair[1], baudrate=115200) as (
         reader_left,
         writer_left,
         reader_right,
@@ -93,9 +88,9 @@ async def test_null_bytes_async() -> None:
         assert result == null_data
 
 
-async def test_overlapping_read_write_async() -> None:
+async def test_overlapping_read_write_async(adapter_pair: tuple[str, str]) -> None:
     """Test that read and write can overlap, data is buffered."""
-    async with async_create_dual_loopback(baudrate=115200) as (
+    async with async_create_dual_loopback(adapter_pair[0], adapter_pair[1], baudrate=115200) as (
         reader_left,
         writer_left,
         reader_right,
@@ -129,9 +124,9 @@ async def test_overlapping_read_write_async() -> None:
         # (921600, 1024),
     ],
 )
-async def test_random_large_async(baudrate: int, chunk_size: int) -> None:
+async def test_random_large_async(adapter_pair: tuple[str, str], baudrate: int, chunk_size: int) -> None:
     """Test random read/write at various speeds."""
-    async with async_create_dual_loopback(baudrate=baudrate) as (
+    async with async_create_dual_loopback(adapter_pair[0], adapter_pair[1], baudrate=baudrate) as (
         reader_left,
         writer_left,
         reader_right,
@@ -148,9 +143,9 @@ async def test_random_large_async(baudrate: int, chunk_size: int) -> None:
     "iterations",
     [16, 32, 64],
 )
-async def test_repeated_write_read_cycles_async(iterations: int) -> None:
+async def test_repeated_write_read_cycles_async(adapter_pair: tuple[str, str], iterations: int) -> None:
     """Test repeated write/read cycles."""
-    async with async_create_dual_loopback(baudrate=115200) as (
+    async with async_create_dual_loopback(adapter_pair[0], adapter_pair[1], baudrate=115200) as (
         reader_left,
         writer_left,
         reader_right,
@@ -164,9 +159,9 @@ async def test_repeated_write_read_cycles_async(iterations: int) -> None:
             assert result == data
 
 
-async def test_buffered_writes_then_read_async() -> None:
+async def test_buffered_writes_then_read_async(adapter_pair: tuple[str, str]) -> None:
     """Test multiple writes followed by a single read."""
-    async with async_create_dual_loopback(baudrate=115200) as (
+    async with async_create_dual_loopback(adapter_pair[0], adapter_pair[1], baudrate=115200) as (
         reader_left,
         writer_left,
         reader_right,
@@ -192,9 +187,9 @@ async def test_buffered_writes_then_read_async() -> None:
     "payload_size",
     [1024, 2048],  # Kernel buffers are typically ~4KB, stay well below that
 )
-async def test_large_payload_async(payload_size: int) -> None:
+async def test_large_payload_async(adapter_pair: tuple[str, str], payload_size: int) -> None:
     """Test large payload transmission."""
-    async with async_create_dual_loopback(baudrate=460800) as (
+    async with async_create_dual_loopback(adapter_pair[0], adapter_pair[1], baudrate=460800) as (
         reader_left,
         writer_left,
         reader_right,
@@ -208,9 +203,9 @@ async def test_large_payload_async(payload_size: int) -> None:
         assert result == data
 
 
-async def test_rapid_small_writes_async() -> None:
+async def test_rapid_small_writes_async(adapter_pair: tuple[str, str]) -> None:
     """Test rapid succession of small writes."""
-    async with async_create_dual_loopback(baudrate=115200) as (
+    async with async_create_dual_loopback(adapter_pair[0], adapter_pair[1], baudrate=115200) as (
         reader_left,
         writer_left,
         reader_right,
@@ -239,9 +234,9 @@ async def test_rapid_small_writes_async() -> None:
         # (921600, 512),  # Hardware can't reliably handle 921600 with dual loopback
     ],
 )
-async def test_sustained_throughput_async(baudrate: int, iterations: int) -> None:
+async def test_sustained_throughput_async(adapter_pair: tuple[str, str], baudrate: int, iterations: int) -> None:
     """Test sustained data throughput at various baudrates."""
-    async with async_create_dual_loopback(baudrate=baudrate) as (
+    async with async_create_dual_loopback(adapter_pair[0], adapter_pair[1], baudrate=baudrate) as (
         reader_left,
         writer_left,
         reader_right,
@@ -268,9 +263,9 @@ async def test_sustained_throughput_async(baudrate: int, iterations: int) -> Non
         # 921600,  # Hardware can't reliably handle 921600 with dual loopback
     ],
 )
-async def test_valid_baudrates_async(baudrate: int) -> None:
+async def test_valid_baudrates_async(adapter_pair: tuple[str, str], baudrate: int) -> None:
     """Test that valid baudrates are accepted."""
-    async with async_create_dual_loopback(baudrate=baudrate) as (
+    async with async_create_dual_loopback(adapter_pair[0], adapter_pair[1], baudrate=baudrate) as (
         reader,
         writer,
         _,
@@ -285,9 +280,9 @@ async def test_valid_baudrates_async(baudrate: int) -> None:
     "parity",
     [Parity.NONE, Parity.ODD, Parity.EVEN, Parity.MARK, Parity.SPACE],
 )
-async def test_valid_parity_async(parity: Parity) -> None:
+async def test_valid_parity_async(adapter_pair: tuple[str, str], parity: Parity) -> None:
     """Test that valid parity settings are accepted."""
-    async with async_create_dual_loopback(baudrate=115200, parity=parity) as (
+    async with async_create_dual_loopback(adapter_pair[0], adapter_pair[1], baudrate=115200, parity=parity) as (
         reader,
         writer,
         _,
@@ -308,12 +303,12 @@ async def test_valid_parity_async(parity: Parity) -> None:
         (2, StopBits.TWO),
     ],
 )
-async def test_valid_stopbits_async(
+async def test_valid_stopbits_async(adapter_pair: tuple[str, str], 
     stopbits: StopBits | int | float,
     expected: StopBits,
 ) -> None:
     """Test that valid stopbits settings are accepted."""
-    async with async_create_dual_loopback(baudrate=115200, stopbits=stopbits) as (
+    async with async_create_dual_loopback(adapter_pair[0], adapter_pair[1], baudrate=115200, stopbits=stopbits) as (
         reader,
         writer,
         _,
@@ -324,9 +319,9 @@ async def test_valid_stopbits_async(
 
 
 @pytest.mark.parametrize("byte_size", [5, 6, 7, 8])
-async def test_valid_byte_size_async(byte_size: int) -> None:
+async def test_valid_byte_size_async(adapter_pair: tuple[str, str], byte_size: int) -> None:
     """Test that valid byte sizes are accepted."""
-    async with async_create_dual_loopback(baudrate=115200, byte_size=byte_size) as (
+    async with async_create_dual_loopback(adapter_pair[0], adapter_pair[1], baudrate=115200, byte_size=byte_size) as (
         reader,
         writer,
         _,
@@ -336,9 +331,9 @@ async def test_valid_byte_size_async(byte_size: int) -> None:
 
 
 @pytest.mark.parametrize("xonxoff", [True, False])
-async def test_xonxoff_setting_async(xonxoff: bool) -> None:
+async def test_xonxoff_setting_async(adapter_pair: tuple[str, str], xonxoff: bool) -> None:
     """Test that xonxoff setting is accepted."""
-    async with async_create_dual_loopback(baudrate=115200, xonxoff=xonxoff) as (
+    async with async_create_dual_loopback(adapter_pair[0], adapter_pair[1], baudrate=115200, xonxoff=xonxoff) as (
         reader,
         writer,
         _,
@@ -351,9 +346,9 @@ async def test_xonxoff_setting_async(xonxoff: bool) -> None:
     "rtscts",
     [True, False],
 )
-async def test_rtscts_setting_async(rtscts: bool) -> None:
+async def test_rtscts_setting_async(adapter_pair: tuple[str, str], rtscts: bool) -> None:
     """Test that rtscts setting is accepted."""
-    async with async_create_dual_loopback(baudrate=115200, rtscts=rtscts) as (
+    async with async_create_dual_loopback(adapter_pair[0], adapter_pair[1], baudrate=115200, rtscts=rtscts) as (
         reader,
         writer,
         _,
@@ -362,9 +357,9 @@ async def test_rtscts_setting_async(rtscts: bool) -> None:
         writer.write(b"test")
 
 
-async def test_concurrent_writes_async() -> None:
+async def test_concurrent_writes_async(adapter_pair: tuple[str, str]) -> None:
     """Test concurrent writes from multiple tasks."""
-    async with async_create_dual_loopback(baudrate=115200) as (
+    async with async_create_dual_loopback(adapter_pair[0], adapter_pair[1], baudrate=115200) as (
         reader_left,
         writer_left,
         reader_right,
@@ -390,9 +385,9 @@ async def test_concurrent_writes_async() -> None:
         assert total_data == b"A" * 100 + b"B" * 100 + b"C" * 100
 
 
-async def test_read_with_timeout_async() -> None:
+async def test_read_with_timeout_async(adapter_pair: tuple[str, str]) -> None:
     """Test reading with timeout."""
-    async with async_create_dual_loopback(baudrate=115200) as (
+    async with async_create_dual_loopback(adapter_pair[0], adapter_pair[1], baudrate=115200) as (
         reader_left,
         writer_left,
         reader_right,
@@ -424,7 +419,7 @@ async def test_fast_open_close() -> None:
         def connection_lost(self, exc: Exception | None) -> None:
             connection_lost_event.set()
 
-    async with async_create_reader_writer(DUAL_LOOPBACK_RIGHT, baudrate=300) as (
+    async with async_create_reader_writer(adapter_pair[1], baudrate=300) as (
         reader,
         writer,
     ):
@@ -434,7 +429,7 @@ async def test_fast_open_close() -> None:
         transport, _ = await create_serial_connection(
             asyncio.get_running_loop(),
             FastCloseProtocol,
-            DUAL_LOOPBACK_LEFT,
+            adapter_pair[0],
             baudrate=300,
         )
 
@@ -442,15 +437,15 @@ async def test_fast_open_close() -> None:
         assert await read_task == message
 
 
-async def test_deassert_on_open_async() -> None:
+async def test_deassert_on_open_async(adapter_pair: tuple[str, str]) -> None:
     """Test DTR/CTS deassertion on open."""
-    async with async_create_reader_writer(DUAL_LOOPBACK_LEFT, baudrate=115200) as (
+    async with async_create_reader_writer(adapter_pair[0], baudrate=115200) as (
         reader_left,
         writer_left,
     ):
         # Open and set DTR/CTS
         async with async_create_reader_writer(
-            DUAL_LOOPBACK_RIGHT,
+            adapter_pair[1],
             baudrate=115200,
             rtsdtr_on_open=PinState.HIGH,
             rtsdtr_on_close=PinState.HIGH,
@@ -466,7 +461,7 @@ async def test_deassert_on_open_async() -> None:
 
         # When we deassert on open, it should clear
         async with async_create_reader_writer(
-            DUAL_LOOPBACK_RIGHT,
+            adapter_pair[1],
             baudrate=115200,
             rtsdtr_on_open=PinState.LOW,
             rtsdtr_on_close=PinState.HIGH,
@@ -481,15 +476,15 @@ async def test_deassert_on_open_async() -> None:
         assert (await writer_left.transport.get_modem_pins()).cts is PinState.HIGH
 
 
-async def test_hang_up_on_close_async() -> None:
+async def test_hang_up_on_close_async(adapter_pair: tuple[str, str]) -> None:
     """Test DTR/CTS hang up on close."""
-    async with async_create_reader_writer(DUAL_LOOPBACK_LEFT, baudrate=115200) as (
+    async with async_create_reader_writer(adapter_pair[0], baudrate=115200) as (
         reader_left,
         writer_left,
     ):
         # Open and set DTR/CTS
         async with async_create_reader_writer(
-            DUAL_LOOPBACK_RIGHT,
+            adapter_pair[1],
             baudrate=115200,
             rtsdtr_on_close=PinState.HIGH,
             rtsdtr_on_open=PinState.HIGH,
@@ -505,7 +500,7 @@ async def test_hang_up_on_close_async() -> None:
 
         # Without hang up on close, it still persists
         async with async_create_reader_writer(
-            DUAL_LOOPBACK_RIGHT,
+            adapter_pair[1],
             baudrate=115200,
             rtsdtr_on_close=PinState.HIGH,
             rtsdtr_on_open=PinState.HIGH,
@@ -519,7 +514,7 @@ async def test_hang_up_on_close_async() -> None:
 
         # When we hang up on close, it should clear
         async with async_create_reader_writer(
-            DUAL_LOOPBACK_RIGHT,
+            adapter_pair[1],
             baudrate=115200,
             rtsdtr_on_close=PinState.LOW,
             rtsdtr_on_open=PinState.HIGH,
@@ -541,17 +536,17 @@ async def test_hang_up_on_close_async() -> None:
         (True, PinState.LOW, PinState.LOW),  # Flow control, clear pins
     ],
 )
-async def test_deassert_on_open_with_rtscts_async(
+async def test_deassert_on_open_with_rtscts_async(adapter_pair: tuple[str, str], 
     rtscts: bool, rtsdtr_on_open: PinState, expected_state: PinState
 ) -> None:
     """Test interaction of rtsdtr_on_open with rtscts."""
-    async with async_create_reader_writer(DUAL_LOOPBACK_LEFT, baudrate=115200) as (
+    async with async_create_reader_writer(adapter_pair[0], baudrate=115200) as (
         reader_left,
         writer_left,
     ):
         # Set DTR on right side, verify CTS appears on left
         async with async_create_reader_writer(
-            DUAL_LOOPBACK_RIGHT,
+            adapter_pair[1],
             baudrate=115200,
             rtscts=False,
             rtsdtr_on_open=PinState.HIGH,
@@ -567,7 +562,7 @@ async def test_deassert_on_open_with_rtscts_async(
 
         # Open with test parameters
         async with async_create_reader_writer(
-            DUAL_LOOPBACK_RIGHT,
+            adapter_pair[1],
             baudrate=115200,
             rtscts=rtscts,
             rtsdtr_on_open=rtsdtr_on_open,

--- a/tests/test_loopback_dual_async.py
+++ b/tests/test_loopback_dual_async.py
@@ -459,7 +459,7 @@ async def test_read_with_timeout_async(adapter_pair: tuple[str, str]) -> None:
             await asyncio.wait_for(reader_right.readexactly(1), timeout=0.1)
 
 
-async def test_fast_open_close() -> None:
+async def test_fast_open_close(adapter_pair: tuple[str, str]) -> None:
     """Test quickly opening and closing a port."""
     message = b"Fast write and close test" * 10
     connection_lost_event = asyncio.Event()

--- a/tests/test_loopback_dual_async.py
+++ b/tests/test_loopback_dual_async.py
@@ -6,17 +6,14 @@ import os
 import pytest
 
 from serialx import Parity, PinState, StopBits, create_serial_connection
-from tests.common import (
-    async_create_dual_loopback,
-    async_create_reader_writer,
-)
-
-
+from tests.common import async_create_dual_loopback, async_create_reader_writer
 
 
 async def test_all_bytes_async(adapter_pair: tuple[str, str]) -> None:
     """Test that all bytes 0-255 can be transmitted."""
-    async with async_create_dual_loopback(adapter_pair[0], adapter_pair[1], baudrate=115200) as (
+    async with async_create_dual_loopback(
+        adapter_pair[0], adapter_pair[1], baudrate=115200
+    ) as (
         reader_left,
         writer_left,
         reader_right,
@@ -33,7 +30,9 @@ async def test_all_bytes_async(adapter_pair: tuple[str, str]) -> None:
 
 async def test_segmented_binary_data_async(adapter_pair: tuple[str, str]) -> None:
     """Test binary data sent in segments."""
-    async with async_create_dual_loopback(adapter_pair[0], adapter_pair[1], baudrate=115200) as (
+    async with async_create_dual_loopback(
+        adapter_pair[0], adapter_pair[1], baudrate=115200
+    ) as (
         reader_left,
         writer_left,
         reader_right,
@@ -54,9 +53,13 @@ async def test_segmented_binary_data_async(adapter_pair: tuple[str, str]) -> Non
     "size",
     [1, 16, 64, 256, 512, 1024],
 )
-async def test_binary_payload_sizes_async(adapter_pair: tuple[str, str], size: int) -> None:
+async def test_binary_payload_sizes_async(
+    adapter_pair: tuple[str, str], size: int
+) -> None:
     """Test various binary payload sizes."""
-    async with async_create_dual_loopback(adapter_pair[0], adapter_pair[1], baudrate=115200) as (
+    async with async_create_dual_loopback(
+        adapter_pair[0], adapter_pair[1], baudrate=115200
+    ) as (
         reader_left,
         writer_left,
         reader_right,
@@ -73,7 +76,9 @@ async def test_binary_payload_sizes_async(adapter_pair: tuple[str, str], size: i
 
 async def test_null_bytes_async(adapter_pair: tuple[str, str]) -> None:
     """Test that null bytes (0x00) can be transmitted."""
-    async with async_create_dual_loopback(adapter_pair[0], adapter_pair[1], baudrate=115200) as (
+    async with async_create_dual_loopback(
+        adapter_pair[0], adapter_pair[1], baudrate=115200
+    ) as (
         reader_left,
         writer_left,
         reader_right,
@@ -90,7 +95,9 @@ async def test_null_bytes_async(adapter_pair: tuple[str, str]) -> None:
 
 async def test_overlapping_read_write_async(adapter_pair: tuple[str, str]) -> None:
     """Test that read and write can overlap, data is buffered."""
-    async with async_create_dual_loopback(adapter_pair[0], adapter_pair[1], baudrate=115200) as (
+    async with async_create_dual_loopback(
+        adapter_pair[0], adapter_pair[1], baudrate=115200
+    ) as (
         reader_left,
         writer_left,
         reader_right,
@@ -124,9 +131,13 @@ async def test_overlapping_read_write_async(adapter_pair: tuple[str, str]) -> No
         # (921600, 1024),
     ],
 )
-async def test_random_large_async(adapter_pair: tuple[str, str], baudrate: int, chunk_size: int) -> None:
+async def test_random_large_async(
+    adapter_pair: tuple[str, str], baudrate: int, chunk_size: int
+) -> None:
     """Test random read/write at various speeds."""
-    async with async_create_dual_loopback(adapter_pair[0], adapter_pair[1], baudrate=baudrate) as (
+    async with async_create_dual_loopback(
+        adapter_pair[0], adapter_pair[1], baudrate=baudrate
+    ) as (
         reader_left,
         writer_left,
         reader_right,
@@ -143,9 +154,13 @@ async def test_random_large_async(adapter_pair: tuple[str, str], baudrate: int, 
     "iterations",
     [16, 32, 64],
 )
-async def test_repeated_write_read_cycles_async(adapter_pair: tuple[str, str], iterations: int) -> None:
+async def test_repeated_write_read_cycles_async(
+    adapter_pair: tuple[str, str], iterations: int
+) -> None:
     """Test repeated write/read cycles."""
-    async with async_create_dual_loopback(adapter_pair[0], adapter_pair[1], baudrate=115200) as (
+    async with async_create_dual_loopback(
+        adapter_pair[0], adapter_pair[1], baudrate=115200
+    ) as (
         reader_left,
         writer_left,
         reader_right,
@@ -161,7 +176,9 @@ async def test_repeated_write_read_cycles_async(adapter_pair: tuple[str, str], i
 
 async def test_buffered_writes_then_read_async(adapter_pair: tuple[str, str]) -> None:
     """Test multiple writes followed by a single read."""
-    async with async_create_dual_loopback(adapter_pair[0], adapter_pair[1], baudrate=115200) as (
+    async with async_create_dual_loopback(
+        adapter_pair[0], adapter_pair[1], baudrate=115200
+    ) as (
         reader_left,
         writer_left,
         reader_right,
@@ -187,9 +204,13 @@ async def test_buffered_writes_then_read_async(adapter_pair: tuple[str, str]) ->
     "payload_size",
     [1024, 2048],  # Kernel buffers are typically ~4KB, stay well below that
 )
-async def test_large_payload_async(adapter_pair: tuple[str, str], payload_size: int) -> None:
+async def test_large_payload_async(
+    adapter_pair: tuple[str, str], payload_size: int
+) -> None:
     """Test large payload transmission."""
-    async with async_create_dual_loopback(adapter_pair[0], adapter_pair[1], baudrate=460800) as (
+    async with async_create_dual_loopback(
+        adapter_pair[0], adapter_pair[1], baudrate=460800
+    ) as (
         reader_left,
         writer_left,
         reader_right,
@@ -205,7 +226,9 @@ async def test_large_payload_async(adapter_pair: tuple[str, str], payload_size: 
 
 async def test_rapid_small_writes_async(adapter_pair: tuple[str, str]) -> None:
     """Test rapid succession of small writes."""
-    async with async_create_dual_loopback(adapter_pair[0], adapter_pair[1], baudrate=115200) as (
+    async with async_create_dual_loopback(
+        adapter_pair[0], adapter_pair[1], baudrate=115200
+    ) as (
         reader_left,
         writer_left,
         reader_right,
@@ -234,9 +257,13 @@ async def test_rapid_small_writes_async(adapter_pair: tuple[str, str]) -> None:
         # (921600, 512),  # Hardware can't reliably handle 921600 with dual loopback
     ],
 )
-async def test_sustained_throughput_async(adapter_pair: tuple[str, str], baudrate: int, iterations: int) -> None:
+async def test_sustained_throughput_async(
+    adapter_pair: tuple[str, str], baudrate: int, iterations: int
+) -> None:
     """Test sustained data throughput at various baudrates."""
-    async with async_create_dual_loopback(adapter_pair[0], adapter_pair[1], baudrate=baudrate) as (
+    async with async_create_dual_loopback(
+        adapter_pair[0], adapter_pair[1], baudrate=baudrate
+    ) as (
         reader_left,
         writer_left,
         reader_right,
@@ -263,9 +290,13 @@ async def test_sustained_throughput_async(adapter_pair: tuple[str, str], baudrat
         # 921600,  # Hardware can't reliably handle 921600 with dual loopback
     ],
 )
-async def test_valid_baudrates_async(adapter_pair: tuple[str, str], baudrate: int) -> None:
+async def test_valid_baudrates_async(
+    adapter_pair: tuple[str, str], baudrate: int
+) -> None:
     """Test that valid baudrates are accepted."""
-    async with async_create_dual_loopback(adapter_pair[0], adapter_pair[1], baudrate=baudrate) as (
+    async with async_create_dual_loopback(
+        adapter_pair[0], adapter_pair[1], baudrate=baudrate
+    ) as (
         reader,
         writer,
         _,
@@ -280,9 +311,13 @@ async def test_valid_baudrates_async(adapter_pair: tuple[str, str], baudrate: in
     "parity",
     [Parity.NONE, Parity.ODD, Parity.EVEN, Parity.MARK, Parity.SPACE],
 )
-async def test_valid_parity_async(adapter_pair: tuple[str, str], parity: Parity) -> None:
+async def test_valid_parity_async(
+    adapter_pair: tuple[str, str], parity: Parity
+) -> None:
     """Test that valid parity settings are accepted."""
-    async with async_create_dual_loopback(adapter_pair[0], adapter_pair[1], baudrate=115200, parity=parity) as (
+    async with async_create_dual_loopback(
+        adapter_pair[0], adapter_pair[1], baudrate=115200, parity=parity
+    ) as (
         reader,
         writer,
         _,
@@ -303,12 +338,15 @@ async def test_valid_parity_async(adapter_pair: tuple[str, str], parity: Parity)
         (2, StopBits.TWO),
     ],
 )
-async def test_valid_stopbits_async(adapter_pair: tuple[str, str], 
+async def test_valid_stopbits_async(
+    adapter_pair: tuple[str, str],
     stopbits: StopBits | int | float,
     expected: StopBits,
 ) -> None:
     """Test that valid stopbits settings are accepted."""
-    async with async_create_dual_loopback(adapter_pair[0], adapter_pair[1], baudrate=115200, stopbits=stopbits) as (
+    async with async_create_dual_loopback(
+        adapter_pair[0], adapter_pair[1], baudrate=115200, stopbits=stopbits
+    ) as (
         reader,
         writer,
         _,
@@ -319,9 +357,13 @@ async def test_valid_stopbits_async(adapter_pair: tuple[str, str],
 
 
 @pytest.mark.parametrize("byte_size", [5, 6, 7, 8])
-async def test_valid_byte_size_async(adapter_pair: tuple[str, str], byte_size: int) -> None:
+async def test_valid_byte_size_async(
+    adapter_pair: tuple[str, str], byte_size: int
+) -> None:
     """Test that valid byte sizes are accepted."""
-    async with async_create_dual_loopback(adapter_pair[0], adapter_pair[1], baudrate=115200, byte_size=byte_size) as (
+    async with async_create_dual_loopback(
+        adapter_pair[0], adapter_pair[1], baudrate=115200, byte_size=byte_size
+    ) as (
         reader,
         writer,
         _,
@@ -331,9 +373,13 @@ async def test_valid_byte_size_async(adapter_pair: tuple[str, str], byte_size: i
 
 
 @pytest.mark.parametrize("xonxoff", [True, False])
-async def test_xonxoff_setting_async(adapter_pair: tuple[str, str], xonxoff: bool) -> None:
+async def test_xonxoff_setting_async(
+    adapter_pair: tuple[str, str], xonxoff: bool
+) -> None:
     """Test that xonxoff setting is accepted."""
-    async with async_create_dual_loopback(adapter_pair[0], adapter_pair[1], baudrate=115200, xonxoff=xonxoff) as (
+    async with async_create_dual_loopback(
+        adapter_pair[0], adapter_pair[1], baudrate=115200, xonxoff=xonxoff
+    ) as (
         reader,
         writer,
         _,
@@ -346,9 +392,13 @@ async def test_xonxoff_setting_async(adapter_pair: tuple[str, str], xonxoff: boo
     "rtscts",
     [True, False],
 )
-async def test_rtscts_setting_async(adapter_pair: tuple[str, str], rtscts: bool) -> None:
+async def test_rtscts_setting_async(
+    adapter_pair: tuple[str, str], rtscts: bool
+) -> None:
     """Test that rtscts setting is accepted."""
-    async with async_create_dual_loopback(adapter_pair[0], adapter_pair[1], baudrate=115200, rtscts=rtscts) as (
+    async with async_create_dual_loopback(
+        adapter_pair[0], adapter_pair[1], baudrate=115200, rtscts=rtscts
+    ) as (
         reader,
         writer,
         _,
@@ -359,7 +409,9 @@ async def test_rtscts_setting_async(adapter_pair: tuple[str, str], rtscts: bool)
 
 async def test_concurrent_writes_async(adapter_pair: tuple[str, str]) -> None:
     """Test concurrent writes from multiple tasks."""
-    async with async_create_dual_loopback(adapter_pair[0], adapter_pair[1], baudrate=115200) as (
+    async with async_create_dual_loopback(
+        adapter_pair[0], adapter_pair[1], baudrate=115200
+    ) as (
         reader_left,
         writer_left,
         reader_right,
@@ -387,7 +439,9 @@ async def test_concurrent_writes_async(adapter_pair: tuple[str, str]) -> None:
 
 async def test_read_with_timeout_async(adapter_pair: tuple[str, str]) -> None:
     """Test reading with timeout."""
-    async with async_create_dual_loopback(adapter_pair[0], adapter_pair[1], baudrate=115200) as (
+    async with async_create_dual_loopback(
+        adapter_pair[0], adapter_pair[1], baudrate=115200
+    ) as (
         reader_left,
         writer_left,
         reader_right,
@@ -536,8 +590,11 @@ async def test_hang_up_on_close_async(adapter_pair: tuple[str, str]) -> None:
         (True, PinState.LOW, PinState.LOW),  # Flow control, clear pins
     ],
 )
-async def test_deassert_on_open_with_rtscts_async(adapter_pair: tuple[str, str], 
-    rtscts: bool, rtsdtr_on_open: PinState, expected_state: PinState
+async def test_deassert_on_open_with_rtscts_async(
+    adapter_pair: tuple[str, str],
+    rtscts: bool,
+    rtsdtr_on_open: PinState,
+    expected_state: PinState,
 ) -> None:
     """Test interaction of rtsdtr_on_open with rtscts."""
     async with async_create_reader_writer(adapter_pair[0], baudrate=115200) as (

--- a/tests/test_loopback_dual_sync.py
+++ b/tests/test_loopback_dual_sync.py
@@ -48,6 +48,7 @@ def test_segmented_binary_data_dual(adapter_pair: tuple[str, str]) -> None:
 )
 def test_binary_payload_sizes_dual(adapter_pair: tuple[str, str], size: int) -> None:
     """Test various binary payload sizes."""
+    left_port, right_port = adapter_pair
     with create_dual_loopback(left_port, right_port, baudrate=115200) as (
         serial_left,
         serial_right,
@@ -63,7 +64,6 @@ def test_binary_payload_sizes_dual(adapter_pair: tuple[str, str], size: int) -> 
 
 def test_null_bytes_dual(adapter_pair: tuple[str, str]) -> None:
     """Test that null bytes (0x00) can be transmitted."""
-    left_port, right_port = adapter_pair
     left_port, right_port = adapter_pair
     with create_dual_loopback(left_port, right_port, baudrate=115200) as (
         serial_left,
@@ -117,6 +117,7 @@ def test_random_large_dual(
     adapter_pair: tuple[str, str], baudrate: int, chunk_size: int
 ) -> None:
     """Test loopback adapter random read/write."""
+    left_port, right_port = adapter_pair
     with create_dual_loopback(left_port, right_port, baudrate=baudrate) as (
         serial_left,
         serial_right,
@@ -178,6 +179,7 @@ def test_buffered_writes_then_read_dual(adapter_pair: tuple[str, str]) -> None:
 )
 def test_large_payload_dual(adapter_pair: tuple[str, str], payload_size: int) -> None:
     """Test large payload transmission."""
+    left_port, right_port = adapter_pair
     # Using 115200 instead of 921600 due to hardware limitations
     with create_dual_loopback(left_port, right_port, baudrate=115200) as (
         serial_left,
@@ -193,7 +195,6 @@ def test_large_payload_dual(adapter_pair: tuple[str, str], payload_size: int) ->
 
 def test_rapid_small_writes_dual(adapter_pair: tuple[str, str]) -> None:
     """Test rapid succession of small writes."""
-    left_port, right_port = adapter_pair
     left_port, right_port = adapter_pair
     with create_dual_loopback(left_port, right_port, baudrate=115200) as (
         serial_left,
@@ -226,6 +227,7 @@ def test_sustained_throughput_dual(
     adapter_pair: tuple[str, str], baudrate: int, iterations: int
 ) -> None:
     """Test sustained data throughput at various baudrates."""
+    left_port, right_port = adapter_pair
     with create_dual_loopback(left_port, right_port, baudrate=baudrate) as (
         serial_left,
         serial_right,
@@ -265,6 +267,7 @@ def test_valid_baudrates_dual(adapter_pair: tuple[str, str], baudrate: int) -> N
 )
 def test_valid_parity_dual(adapter_pair: tuple[str, str], parity: Parity) -> None:
     """Test that valid parity settings are accepted."""
+    left_port, right_port = adapter_pair
     with Serial(adapter_pair[0], baudrate=115200, parity=parity) as serial:
         assert serial.parity == parity
         serial.write(b"test")
@@ -296,6 +299,7 @@ def test_valid_stopbits_dual(
 @pytest.mark.parametrize("byte_size", [5, 6, 7, 8])
 def test_valid_byte_size_dual(adapter_pair: tuple[str, str], byte_size: int) -> None:
     """Test that valid byte sizes are accepted."""
+    left_port, right_port = adapter_pair
     with Serial(adapter_pair[0], baudrate=115200, byte_size=byte_size) as serial:
         serial.write(b"test")
 
@@ -314,13 +318,13 @@ def test_xonxoff_setting_dual(adapter_pair: tuple[str, str], xonxoff: bool) -> N
 )
 def test_rtscts_setting_dual(adapter_pair: tuple[str, str], rtscts: bool) -> None:
     """Test that rtscts setting is accepted."""
+    left_port, right_port = adapter_pair
     with Serial(adapter_pair[0], baudrate=115200, rtscts=rtscts) as serial:
         serial.write(b"test")
 
 
 def test_exclusive_dual(adapter_pair: tuple[str, str]) -> None:
     """Test that exclusive setting is respected."""
-    left_port, right_port = adapter_pair
     left_port, right_port = adapter_pair
     with Serial(adapter_pair[0], baudrate=115200, exclusive=True) as serial:
         assert serial.exclusive is True
@@ -452,7 +456,6 @@ def test_fast_open_close(adapter_pair: tuple[str, str]) -> None:
 def test_deprecated_dtr_cts_dual(adapter_pair: tuple[str, str]) -> None:
     """Test DTR and CTS properties (deprecated alias)."""
     left_port, right_port = adapter_pair
-    left_port, right_port = adapter_pair
     with create_dual_loopback(left_port, right_port, baudrate=115200) as (
         serial_left,
         serial_right,
@@ -492,7 +495,8 @@ def test_dtr_cts_dual(adapter_pair: tuple[str, str]) -> None:
 
 def test_deassert_on_open(adapter_pair: tuple[str, str]) -> None:
     """Test DTR/CTS deassertion on open."""
-    with Serial(adapter_pair[0], baudrate=115200) as serial_left:
+    left_port, right_port = adapter_pair
+    with Serial(left_port, baudrate=115200) as serial_left:
         # Open and set DTR/CTS
         with Serial(
             right_port,

--- a/tests/test_loopback_dual_sync.py
+++ b/tests/test_loopback_dual_sync.py
@@ -5,17 +5,13 @@ import os
 import pytest
 
 from serialx import Parity, PinState, Serial, StopBits
-from tests.common import DUAL_LOOPBACK_LEFT, DUAL_LOOPBACK_RIGHT, create_dual_loopback
-
-pytestmark = pytest.mark.skipif(
-    not DUAL_LOOPBACK_LEFT or not DUAL_LOOPBACK_RIGHT,
-    reason="SERIALX_DUAL_LOOPBACK_LEFT and SERIALX_DUAL_LOOPBACK_RIGHT not set",
-)
+from tests.common import create_dual_loopback
 
 
-def test_all_bytes_dual() -> None:
+def test_all_bytes_dual(adapter_pair: tuple[str, str]) -> None:
     """Test that all bytes 0-255 can be transmitted."""
-    with create_dual_loopback(baudrate=115200) as (serial_left, serial_right):
+    left_port, right_port = adapter_pair
+    with create_dual_loopback(left_port, right_port, baudrate=115200) as (serial_left, serial_right):
         # Create a byte array with all possible byte values
         data = bytes(range(256))
 
@@ -25,9 +21,10 @@ def test_all_bytes_dual() -> None:
         assert result == data
 
 
-def test_segmented_binary_data_dual() -> None:
+def test_segmented_binary_data_dual(adapter_pair: tuple[str, str]) -> None:
     """Test binary data sent in segments."""
-    with create_dual_loopback(baudrate=115200) as (serial_left, serial_right):
+    left_port, right_port = adapter_pair
+    with create_dual_loopback(left_port, right_port, baudrate=115200) as (serial_left, serial_right):
         # Send all bytes in smaller segments
         segment_size = 16
         data = bytes(range(256))
@@ -43,9 +40,9 @@ def test_segmented_binary_data_dual() -> None:
     "size",
     [1, 16, 64, 256, 512, 1024],
 )
-def test_binary_payload_sizes_dual(size: int) -> None:
+def test_binary_payload_sizes_dual(adapter_pair: tuple[str, str], size: int) -> None:
     """Test various binary payload sizes."""
-    with create_dual_loopback(baudrate=115200) as (serial_left, serial_right):
+    with create_dual_loopback(left_port, right_port, baudrate=115200) as (serial_left, serial_right):
         # Create binary data with repeating pattern
         data = bytes([i % 256 for i in range(size)])
 
@@ -55,9 +52,11 @@ def test_binary_payload_sizes_dual(size: int) -> None:
         assert result == data
 
 
-def test_null_bytes_dual() -> None:
+def test_null_bytes_dual(adapter_pair: tuple[str, str]) -> None:
     """Test that null bytes (0x00) can be transmitted."""
-    with create_dual_loopback(baudrate=115200) as (serial_left, serial_right):
+    left_port, right_port = adapter_pair
+    left_port, right_port = adapter_pair
+    with create_dual_loopback(left_port, right_port, baudrate=115200) as (serial_left, serial_right):
         # Send a bunch of null bytes
         null_data = b"\x00" * 64
 
@@ -67,9 +66,10 @@ def test_null_bytes_dual() -> None:
         assert result == null_data
 
 
-def test_overlapping_read_write_dual() -> None:
+def test_overlapping_read_write_dual(adapter_pair: tuple[str, str]) -> None:
     """Test that read and write can overlap, data is buffered."""
-    with create_dual_loopback(baudrate=115200) as (serial_left, serial_right):
+    left_port, right_port = adapter_pair
+    with create_dual_loopback(left_port, right_port, baudrate=115200) as (serial_left, serial_right):
         data = bytes(range(256))
         read = b""
 
@@ -98,9 +98,9 @@ def test_overlapping_read_write_dual() -> None:
         # (921600, 1024),
     ],
 )
-def test_random_large_dual(baudrate: int, chunk_size: int) -> None:
+def test_random_large_dual(adapter_pair: tuple[str, str], baudrate: int, chunk_size: int) -> None:
     """Test loopback adapter random read/write."""
-    with create_dual_loopback(baudrate=baudrate) as (serial_left, serial_right):
+    with create_dual_loopback(left_port, right_port, baudrate=baudrate) as (serial_left, serial_right):
         data = os.urandom(chunk_size)
         serial_left.write(data)
 
@@ -112,9 +112,10 @@ def test_random_large_dual(baudrate: int, chunk_size: int) -> None:
     "iterations",
     [16, 32, 64],
 )
-def test_repeated_write_read_cycles_dual(iterations: int) -> None:
+def test_repeated_write_read_cycles_dual(adapter_pair: tuple[str, str], iterations: int) -> None:
     """Test repeated write/read cycles."""
-    with create_dual_loopback(baudrate=115200) as (serial_left, serial_right):
+    left_port, right_port = adapter_pair
+    with create_dual_loopback(left_port, right_port, baudrate=115200) as (serial_left, serial_right):
         data = bytes(range(256))
 
         for _i in range(iterations):
@@ -123,9 +124,10 @@ def test_repeated_write_read_cycles_dual(iterations: int) -> None:
             assert result == data
 
 
-def test_buffered_writes_then_read_dual() -> None:
+def test_buffered_writes_then_read_dual(adapter_pair: tuple[str, str]) -> None:
     """Test multiple writes followed by a single read."""
-    with create_dual_loopback(baudrate=115200) as (serial_left, serial_right):
+    left_port, right_port = adapter_pair
+    with create_dual_loopback(left_port, right_port, baudrate=115200) as (serial_left, serial_right):
         chunk = bytes(range(256))
         iterations = 4
 
@@ -146,10 +148,10 @@ def test_buffered_writes_then_read_dual() -> None:
     "payload_size",
     [1024, 2048],  # Kernel buffers are typically ~4KB, stay well below that
 )
-def test_large_payload_dual(payload_size: int) -> None:
+def test_large_payload_dual(adapter_pair: tuple[str, str], payload_size: int) -> None:
     """Test large payload transmission."""
     # Using 115200 instead of 921600 due to hardware limitations
-    with create_dual_loopback(baudrate=115200) as (serial_left, serial_right):
+    with create_dual_loopback(left_port, right_port, baudrate=115200) as (serial_left, serial_right):
         data = bytes([i % 256 for i in range(payload_size)])
 
         serial_left.write(data)
@@ -158,9 +160,11 @@ def test_large_payload_dual(payload_size: int) -> None:
         assert result == data
 
 
-def test_rapid_small_writes_dual() -> None:
+def test_rapid_small_writes_dual(adapter_pair: tuple[str, str]) -> None:
     """Test rapid succession of small writes."""
-    with create_dual_loopback(baudrate=115200) as (serial_left, serial_right):
+    left_port, right_port = adapter_pair
+    left_port, right_port = adapter_pair
+    with create_dual_loopback(left_port, right_port, baudrate=115200) as (serial_left, serial_right):
         # Send many small writes
         iterations = 256
         received = bytearray()
@@ -184,9 +188,9 @@ def test_rapid_small_writes_dual() -> None:
         # (921600, 512),  # Hardware can't reliably handle 921600 with dual loopback
     ],
 )
-def test_sustained_throughput_dual(baudrate: int, iterations: int) -> None:
+def test_sustained_throughput_dual(adapter_pair: tuple[str, str], baudrate: int, iterations: int) -> None:
     """Test sustained data throughput at various baudrates."""
-    with create_dual_loopback(baudrate=baudrate) as (serial_left, serial_right):
+    with create_dual_loopback(left_port, right_port, baudrate=baudrate) as (serial_left, serial_right):
         chunk = os.urandom(1024)
 
         for _ in range(iterations):
@@ -208,9 +212,10 @@ def test_sustained_throughput_dual(baudrate: int, iterations: int) -> None:
         # 921600,  # Hardware can't reliably handle 921600 with dual loopback
     ],
 )
-def test_valid_baudrates_dual(baudrate: int) -> None:
+def test_valid_baudrates_dual(adapter_pair: tuple[str, str], baudrate: int) -> None:
     """Test that valid baudrates are accepted."""
-    with Serial(DUAL_LOOPBACK_LEFT, baudrate=baudrate) as serial:
+    left_port, right_port = adapter_pair
+    with Serial(adapter_pair[0], baudrate=baudrate) as serial:
         assert serial.baudrate == baudrate
         serial.write(b"test")
 
@@ -219,9 +224,9 @@ def test_valid_baudrates_dual(baudrate: int) -> None:
     "parity",
     [Parity.NONE, Parity.ODD, Parity.EVEN, Parity.MARK, Parity.SPACE],
 )
-def test_valid_parity_dual(parity: Parity) -> None:
+def test_valid_parity_dual(adapter_pair: tuple[str, str], parity: Parity) -> None:
     """Test that valid parity settings are accepted."""
-    with Serial(DUAL_LOOPBACK_LEFT, baudrate=115200, parity=parity) as serial:
+    with Serial(adapter_pair[0], baudrate=115200, parity=parity) as serial:
         assert serial.parity == parity
         serial.write(b"test")
 
@@ -237,27 +242,29 @@ def test_valid_parity_dual(parity: Parity) -> None:
         (2, StopBits.TWO),
     ],
 )
-def test_valid_stopbits_dual(
+def test_valid_stopbits_dual(adapter_pair: tuple[str, str], 
     stopbits: StopBits | int | float,
     expected: StopBits,
 ) -> None:
     """Test that valid stopbits settings are accepted."""
-    with Serial(DUAL_LOOPBACK_LEFT, baudrate=115200, stopbits=stopbits) as serial:
+    left_port, right_port = adapter_pair
+    with Serial(adapter_pair[0], baudrate=115200, stopbits=stopbits) as serial:
         assert serial.stopbits == expected
         serial.write(b"test")
 
 
 @pytest.mark.parametrize("byte_size", [5, 6, 7, 8])
-def test_valid_byte_size_dual(byte_size: int) -> None:
+def test_valid_byte_size_dual(adapter_pair: tuple[str, str], byte_size: int) -> None:
     """Test that valid byte sizes are accepted."""
-    with Serial(DUAL_LOOPBACK_LEFT, baudrate=115200, byte_size=byte_size) as serial:
+    with Serial(adapter_pair[0], baudrate=115200, byte_size=byte_size) as serial:
         serial.write(b"test")
 
 
 @pytest.mark.parametrize("xonxoff", [True, False])
-def test_xonxoff_setting_dual(xonxoff: bool) -> None:
+def test_xonxoff_setting_dual(adapter_pair: tuple[str, str], xonxoff: bool) -> None:
     """Test that xonxoff setting is accepted."""
-    with Serial(DUAL_LOOPBACK_LEFT, baudrate=115200, xonxoff=xonxoff) as serial:
+    left_port, right_port = adapter_pair
+    with Serial(adapter_pair[0], baudrate=115200, xonxoff=xonxoff) as serial:
         serial.write(b"test")
 
 
@@ -265,39 +272,43 @@ def test_xonxoff_setting_dual(xonxoff: bool) -> None:
     "rtscts",
     [True, False],
 )
-def test_rtscts_setting_dual(rtscts: bool) -> None:
+def test_rtscts_setting_dual(adapter_pair: tuple[str, str], rtscts: bool) -> None:
     """Test that rtscts setting is accepted."""
-    with Serial(DUAL_LOOPBACK_LEFT, baudrate=115200, rtscts=rtscts) as serial:
+    with Serial(adapter_pair[0], baudrate=115200, rtscts=rtscts) as serial:
         serial.write(b"test")
 
 
-def test_exclusive_dual() -> None:
+def test_exclusive_dual(adapter_pair: tuple[str, str]) -> None:
     """Test that exclusive setting is respected."""
-    with Serial(DUAL_LOOPBACK_LEFT, baudrate=115200, exclusive=True) as serial:
+    left_port, right_port = adapter_pair
+    left_port, right_port = adapter_pair
+    with Serial(adapter_pair[0], baudrate=115200, exclusive=True) as serial:
         assert serial.exclusive is True
 
         # Opening a second one will fail
         with pytest.raises(OSError):
-            with Serial(DUAL_LOOPBACK_LEFT, baudrate=115200, exclusive=True):
+            with Serial(adapter_pair[0], baudrate=115200, exclusive=True):
                 pass
 
 
-def test_exclusive_disabled_dual() -> None:
+def test_exclusive_disabled_dual(adapter_pair: tuple[str, str]) -> None:
     """Test that exclusive setting is respected."""
-    with Serial(DUAL_LOOPBACK_LEFT, baudrate=115200, exclusive=False) as serial1:
+    left_port, right_port = adapter_pair
+    with Serial(adapter_pair[0], baudrate=115200, exclusive=False) as serial1:
         assert serial1.exclusive is False
 
         # Can open the same port again without exclusive
-        with Serial(DUAL_LOOPBACK_LEFT, baudrate=115200, exclusive=False) as serial2:
+        with Serial(adapter_pair[0], baudrate=115200, exclusive=False) as serial2:
             assert serial2.exclusive is False
             # Both can write without error
             serial2.write(b"test")
 
 
-def test_context_manager_multiple_times_dual() -> None:
+def test_context_manager_multiple_times_dual(adapter_pair: tuple[str, str]) -> None:
     """Test that context manager can be used multiple times."""
-    serial_left = Serial(DUAL_LOOPBACK_LEFT, baudrate=115200)
-    serial_right = Serial(DUAL_LOOPBACK_RIGHT, baudrate=115200)
+    left_port, right_port = adapter_pair
+    serial_left = Serial(adapter_pair[0], baudrate=115200)
+    serial_right = Serial(adapter_pair[1], baudrate=115200)
 
     # First context
     with serial_left, serial_right:
@@ -312,10 +323,11 @@ def test_context_manager_multiple_times_dual() -> None:
         assert result == b"test2"
 
 
-def test_open_close_cycles_dual() -> None:
+def test_open_close_cycles_dual(adapter_pair: tuple[str, str]) -> None:
     """Test multiple open/close cycles."""
-    serial_left = Serial(DUAL_LOOPBACK_LEFT, baudrate=115200)
-    serial_right = Serial(DUAL_LOOPBACK_RIGHT, baudrate=115200)
+    left_port, right_port = adapter_pair
+    serial_left = Serial(adapter_pair[0], baudrate=115200)
+    serial_right = Serial(adapter_pair[1], baudrate=115200)
 
     # Cycle 1
     serial_left.open()
@@ -348,9 +360,10 @@ def test_open_close_cycles_dual() -> None:
     serial_right.close()
 
 
-def test_flush_after_write_dual() -> None:
+def test_flush_after_write_dual(adapter_pair: tuple[str, str]) -> None:
     """Test flushing after write operation."""
-    with create_dual_loopback(baudrate=115200) as (serial_left, serial_right):
+    left_port, right_port = adapter_pair
+    with create_dual_loopback(left_port, right_port, baudrate=115200) as (serial_left, serial_right):
         serial_left.flush()
 
         data = b"Test flush operation"
@@ -361,9 +374,10 @@ def test_flush_after_write_dual() -> None:
         assert result == data
 
 
-def test_multiple_flush_calls_dual() -> None:
+def test_multiple_flush_calls_dual(adapter_pair: tuple[str, str]) -> None:
     """Test multiple consecutive flush calls."""
-    with create_dual_loopback(baudrate=115200) as (serial_left, serial_right):
+    left_port, right_port = adapter_pair
+    with create_dual_loopback(left_port, right_port, baudrate=115200) as (serial_left, serial_right):
         data = b""
 
         for i in range(5):
@@ -377,21 +391,23 @@ def test_multiple_flush_calls_dual() -> None:
         assert result == data
 
 
-def test_fast_open_close() -> None:
+def test_fast_open_close(adapter_pair: tuple[str, str]) -> None:
     """Test quickly opening and closing a port."""
 
     message = b"Fast write and close test"
 
-    with Serial(DUAL_LOOPBACK_LEFT, baudrate=300) as serial_left:
-        with Serial(DUAL_LOOPBACK_RIGHT, baudrate=300) as serial_right:
+    with Serial(adapter_pair[0], baudrate=300) as serial_left:
+        with Serial(adapter_pair[1], baudrate=300) as serial_right:
             serial_right.write(message)
 
         assert serial_left.readexactly(len(message)) == message
 
 
-def test_deprecated_dtr_cts_dual() -> None:
+def test_deprecated_dtr_cts_dual(adapter_pair: tuple[str, str]) -> None:
     """Test DTR and CTS properties (deprecated alias)."""
-    with create_dual_loopback(baudrate=115200) as (serial_left, serial_right):
+    left_port, right_port = adapter_pair
+    left_port, right_port = adapter_pair
+    with create_dual_loopback(left_port, right_port, baudrate=115200) as (serial_left, serial_right):
         serial_left.dtr = True
         assert serial_right.get_modem_pins().cts is PinState.HIGH
 
@@ -405,9 +421,10 @@ def test_deprecated_dtr_cts_dual() -> None:
         assert serial_left.get_modem_pins().cts is PinState.LOW
 
 
-def test_dtr_cts_dual() -> None:
+def test_dtr_cts_dual(adapter_pair: tuple[str, str]) -> None:
     """Test DTR and CTS."""
-    with create_dual_loopback(baudrate=115200) as (serial_left, serial_right):
+    left_port, right_port = adapter_pair
+    with create_dual_loopback(left_port, right_port, baudrate=115200) as (serial_left, serial_right):
         serial_left.set_modem_pins(dtr=True)
         assert serial_right.get_modem_pins().cts is PinState.HIGH
 
@@ -421,12 +438,12 @@ def test_dtr_cts_dual() -> None:
         assert serial_left.get_modem_pins().cts is PinState.LOW
 
 
-def test_deassert_on_open() -> None:
+def test_deassert_on_open(adapter_pair: tuple[str, str]) -> None:
     """Test DTR/CTS deassertion on open."""
-    with Serial(DUAL_LOOPBACK_LEFT, baudrate=115200) as serial_left:
+    with Serial(adapter_pair[0], baudrate=115200) as serial_left:
         # Open and set DTR/CTS
         with Serial(
-            DUAL_LOOPBACK_RIGHT,
+            right_port,
             baudrate=115200,
             rtsdtr_on_open=PinState.HIGH,
             rtsdtr_on_close=PinState.HIGH,
@@ -439,7 +456,7 @@ def test_deassert_on_open() -> None:
 
         # When we deassert on open, it should clear
         with Serial(
-            DUAL_LOOPBACK_RIGHT,
+            right_port,
             baudrate=115200,
             rtsdtr_on_open=PinState.LOW,
             rtsdtr_on_close=PinState.HIGH,
@@ -451,12 +468,13 @@ def test_deassert_on_open() -> None:
         assert serial_left.get_modem_pins().cts is PinState.HIGH
 
 
-def test_hang_up_on_close() -> None:
+def test_hang_up_on_close(adapter_pair: tuple[str, str]) -> None:
     """Test DTR/CTS hang up on close."""
-    with Serial(DUAL_LOOPBACK_LEFT, baudrate=115200) as serial_left:
+    left_port, right_port = adapter_pair
+    with Serial(adapter_pair[0], baudrate=115200) as serial_left:
         # Open and set DTR/CTS
         with Serial(
-            DUAL_LOOPBACK_RIGHT,
+            right_port,
             baudrate=115200,
             rtsdtr_on_close=PinState.HIGH,
             rtsdtr_on_open=PinState.HIGH,
@@ -469,7 +487,7 @@ def test_hang_up_on_close() -> None:
 
         # Without hang up on close, it still persists
         with Serial(
-            DUAL_LOOPBACK_RIGHT,
+            right_port,
             baudrate=115200,
             rtsdtr_on_close=PinState.HIGH,
             rtsdtr_on_open=PinState.HIGH,
@@ -480,7 +498,7 @@ def test_hang_up_on_close() -> None:
 
         # When we hang up on close, it should clear
         with Serial(
-            DUAL_LOOPBACK_RIGHT,
+            right_port,
             baudrate=115200,
             rtsdtr_on_close=PinState.LOW,
             rtsdtr_on_open=PinState.HIGH,
@@ -500,13 +518,15 @@ def test_hang_up_on_close() -> None:
     ],
 )
 def test_deassert_on_open_with_rtscts(
+    adapter_pair: tuple[str, str],
     rtscts: bool, rtsdtr_on_open: PinState, expected_state: PinState
 ) -> None:
     """Test interaction of rtsdtr_on_open with rtscts."""
-    with Serial(DUAL_LOOPBACK_LEFT, baudrate=115200) as serial_left:
+    left_port, right_port = adapter_pair
+    with Serial(left_port, baudrate=115200) as serial_left:
         # Set DTR on right side, verify CTS appears on left
         with Serial(
-            DUAL_LOOPBACK_RIGHT,
+            right_port,
             baudrate=115200,
             rtscts=False,
             rtsdtr_on_open=PinState.HIGH,
@@ -519,7 +539,7 @@ def test_deassert_on_open_with_rtscts(
 
         # Open with test parameters
         with Serial(
-            DUAL_LOOPBACK_RIGHT,
+            right_port,
             baudrate=115200,
             rtscts=rtscts,
             rtsdtr_on_open=rtsdtr_on_open,

--- a/tests/test_loopback_dual_sync.py
+++ b/tests/test_loopback_dual_sync.py
@@ -11,7 +11,10 @@ from tests.common import create_dual_loopback
 def test_all_bytes_dual(adapter_pair: tuple[str, str]) -> None:
     """Test that all bytes 0-255 can be transmitted."""
     left_port, right_port = adapter_pair
-    with create_dual_loopback(left_port, right_port, baudrate=115200) as (serial_left, serial_right):
+    with create_dual_loopback(left_port, right_port, baudrate=115200) as (
+        serial_left,
+        serial_right,
+    ):
         # Create a byte array with all possible byte values
         data = bytes(range(256))
 
@@ -24,7 +27,10 @@ def test_all_bytes_dual(adapter_pair: tuple[str, str]) -> None:
 def test_segmented_binary_data_dual(adapter_pair: tuple[str, str]) -> None:
     """Test binary data sent in segments."""
     left_port, right_port = adapter_pair
-    with create_dual_loopback(left_port, right_port, baudrate=115200) as (serial_left, serial_right):
+    with create_dual_loopback(left_port, right_port, baudrate=115200) as (
+        serial_left,
+        serial_right,
+    ):
         # Send all bytes in smaller segments
         segment_size = 16
         data = bytes(range(256))
@@ -42,7 +48,10 @@ def test_segmented_binary_data_dual(adapter_pair: tuple[str, str]) -> None:
 )
 def test_binary_payload_sizes_dual(adapter_pair: tuple[str, str], size: int) -> None:
     """Test various binary payload sizes."""
-    with create_dual_loopback(left_port, right_port, baudrate=115200) as (serial_left, serial_right):
+    with create_dual_loopback(left_port, right_port, baudrate=115200) as (
+        serial_left,
+        serial_right,
+    ):
         # Create binary data with repeating pattern
         data = bytes([i % 256 for i in range(size)])
 
@@ -56,7 +65,10 @@ def test_null_bytes_dual(adapter_pair: tuple[str, str]) -> None:
     """Test that null bytes (0x00) can be transmitted."""
     left_port, right_port = adapter_pair
     left_port, right_port = adapter_pair
-    with create_dual_loopback(left_port, right_port, baudrate=115200) as (serial_left, serial_right):
+    with create_dual_loopback(left_port, right_port, baudrate=115200) as (
+        serial_left,
+        serial_right,
+    ):
         # Send a bunch of null bytes
         null_data = b"\x00" * 64
 
@@ -69,7 +81,10 @@ def test_null_bytes_dual(adapter_pair: tuple[str, str]) -> None:
 def test_overlapping_read_write_dual(adapter_pair: tuple[str, str]) -> None:
     """Test that read and write can overlap, data is buffered."""
     left_port, right_port = adapter_pair
-    with create_dual_loopback(left_port, right_port, baudrate=115200) as (serial_left, serial_right):
+    with create_dual_loopback(left_port, right_port, baudrate=115200) as (
+        serial_left,
+        serial_right,
+    ):
         data = bytes(range(256))
         read = b""
 
@@ -98,9 +113,14 @@ def test_overlapping_read_write_dual(adapter_pair: tuple[str, str]) -> None:
         # (921600, 1024),
     ],
 )
-def test_random_large_dual(adapter_pair: tuple[str, str], baudrate: int, chunk_size: int) -> None:
+def test_random_large_dual(
+    adapter_pair: tuple[str, str], baudrate: int, chunk_size: int
+) -> None:
     """Test loopback adapter random read/write."""
-    with create_dual_loopback(left_port, right_port, baudrate=baudrate) as (serial_left, serial_right):
+    with create_dual_loopback(left_port, right_port, baudrate=baudrate) as (
+        serial_left,
+        serial_right,
+    ):
         data = os.urandom(chunk_size)
         serial_left.write(data)
 
@@ -112,10 +132,15 @@ def test_random_large_dual(adapter_pair: tuple[str, str], baudrate: int, chunk_s
     "iterations",
     [16, 32, 64],
 )
-def test_repeated_write_read_cycles_dual(adapter_pair: tuple[str, str], iterations: int) -> None:
+def test_repeated_write_read_cycles_dual(
+    adapter_pair: tuple[str, str], iterations: int
+) -> None:
     """Test repeated write/read cycles."""
     left_port, right_port = adapter_pair
-    with create_dual_loopback(left_port, right_port, baudrate=115200) as (serial_left, serial_right):
+    with create_dual_loopback(left_port, right_port, baudrate=115200) as (
+        serial_left,
+        serial_right,
+    ):
         data = bytes(range(256))
 
         for _i in range(iterations):
@@ -127,7 +152,10 @@ def test_repeated_write_read_cycles_dual(adapter_pair: tuple[str, str], iteratio
 def test_buffered_writes_then_read_dual(adapter_pair: tuple[str, str]) -> None:
     """Test multiple writes followed by a single read."""
     left_port, right_port = adapter_pair
-    with create_dual_loopback(left_port, right_port, baudrate=115200) as (serial_left, serial_right):
+    with create_dual_loopback(left_port, right_port, baudrate=115200) as (
+        serial_left,
+        serial_right,
+    ):
         chunk = bytes(range(256))
         iterations = 4
 
@@ -151,7 +179,10 @@ def test_buffered_writes_then_read_dual(adapter_pair: tuple[str, str]) -> None:
 def test_large_payload_dual(adapter_pair: tuple[str, str], payload_size: int) -> None:
     """Test large payload transmission."""
     # Using 115200 instead of 921600 due to hardware limitations
-    with create_dual_loopback(left_port, right_port, baudrate=115200) as (serial_left, serial_right):
+    with create_dual_loopback(left_port, right_port, baudrate=115200) as (
+        serial_left,
+        serial_right,
+    ):
         data = bytes([i % 256 for i in range(payload_size)])
 
         serial_left.write(data)
@@ -164,7 +195,10 @@ def test_rapid_small_writes_dual(adapter_pair: tuple[str, str]) -> None:
     """Test rapid succession of small writes."""
     left_port, right_port = adapter_pair
     left_port, right_port = adapter_pair
-    with create_dual_loopback(left_port, right_port, baudrate=115200) as (serial_left, serial_right):
+    with create_dual_loopback(left_port, right_port, baudrate=115200) as (
+        serial_left,
+        serial_right,
+    ):
         # Send many small writes
         iterations = 256
         received = bytearray()
@@ -188,9 +222,14 @@ def test_rapid_small_writes_dual(adapter_pair: tuple[str, str]) -> None:
         # (921600, 512),  # Hardware can't reliably handle 921600 with dual loopback
     ],
 )
-def test_sustained_throughput_dual(adapter_pair: tuple[str, str], baudrate: int, iterations: int) -> None:
+def test_sustained_throughput_dual(
+    adapter_pair: tuple[str, str], baudrate: int, iterations: int
+) -> None:
     """Test sustained data throughput at various baudrates."""
-    with create_dual_loopback(left_port, right_port, baudrate=baudrate) as (serial_left, serial_right):
+    with create_dual_loopback(left_port, right_port, baudrate=baudrate) as (
+        serial_left,
+        serial_right,
+    ):
         chunk = os.urandom(1024)
 
         for _ in range(iterations):
@@ -242,7 +281,8 @@ def test_valid_parity_dual(adapter_pair: tuple[str, str], parity: Parity) -> Non
         (2, StopBits.TWO),
     ],
 )
-def test_valid_stopbits_dual(adapter_pair: tuple[str, str], 
+def test_valid_stopbits_dual(
+    adapter_pair: tuple[str, str],
     stopbits: StopBits | int | float,
     expected: StopBits,
 ) -> None:
@@ -363,7 +403,10 @@ def test_open_close_cycles_dual(adapter_pair: tuple[str, str]) -> None:
 def test_flush_after_write_dual(adapter_pair: tuple[str, str]) -> None:
     """Test flushing after write operation."""
     left_port, right_port = adapter_pair
-    with create_dual_loopback(left_port, right_port, baudrate=115200) as (serial_left, serial_right):
+    with create_dual_loopback(left_port, right_port, baudrate=115200) as (
+        serial_left,
+        serial_right,
+    ):
         serial_left.flush()
 
         data = b"Test flush operation"
@@ -377,7 +420,10 @@ def test_flush_after_write_dual(adapter_pair: tuple[str, str]) -> None:
 def test_multiple_flush_calls_dual(adapter_pair: tuple[str, str]) -> None:
     """Test multiple consecutive flush calls."""
     left_port, right_port = adapter_pair
-    with create_dual_loopback(left_port, right_port, baudrate=115200) as (serial_left, serial_right):
+    with create_dual_loopback(left_port, right_port, baudrate=115200) as (
+        serial_left,
+        serial_right,
+    ):
         data = b""
 
         for i in range(5):
@@ -407,7 +453,10 @@ def test_deprecated_dtr_cts_dual(adapter_pair: tuple[str, str]) -> None:
     """Test DTR and CTS properties (deprecated alias)."""
     left_port, right_port = adapter_pair
     left_port, right_port = adapter_pair
-    with create_dual_loopback(left_port, right_port, baudrate=115200) as (serial_left, serial_right):
+    with create_dual_loopback(left_port, right_port, baudrate=115200) as (
+        serial_left,
+        serial_right,
+    ):
         serial_left.dtr = True
         assert serial_right.get_modem_pins().cts is PinState.HIGH
 
@@ -424,7 +473,10 @@ def test_deprecated_dtr_cts_dual(adapter_pair: tuple[str, str]) -> None:
 def test_dtr_cts_dual(adapter_pair: tuple[str, str]) -> None:
     """Test DTR and CTS."""
     left_port, right_port = adapter_pair
-    with create_dual_loopback(left_port, right_port, baudrate=115200) as (serial_left, serial_right):
+    with create_dual_loopback(left_port, right_port, baudrate=115200) as (
+        serial_left,
+        serial_right,
+    ):
         serial_left.set_modem_pins(dtr=True)
         assert serial_right.get_modem_pins().cts is PinState.HIGH
 
@@ -519,7 +571,9 @@ def test_hang_up_on_close(adapter_pair: tuple[str, str]) -> None:
 )
 def test_deassert_on_open_with_rtscts(
     adapter_pair: tuple[str, str],
-    rtscts: bool, rtsdtr_on_open: PinState, expected_state: PinState
+    rtscts: bool,
+    rtsdtr_on_open: PinState,
+    expected_state: PinState,
 ) -> None:
     """Test interaction of rtsdtr_on_open with rtscts."""
     left_port, right_port = adapter_pair

--- a/tests/test_loopback_sync.py
+++ b/tests/test_loopback_sync.py
@@ -5,20 +5,13 @@ import os
 import pytest
 
 from serialx import Parity, PinState, Serial, StopBits
-from tests.common import LOOPBACK_ADAPTER
-
-# All tests here use a real adapter, skip if not configured
-pytestmark = pytest.mark.skipif(
-    LOOPBACK_ADAPTER is None,
-    reason="Loopback adapter port not set via SERIALX_LOOPBACK_PORT",
-)
 
 
-def test_all_bytes_loopback() -> None:
+def test_all_bytes_loopback(loopback_adapter: str) -> None:
     """Test that all bytes 0-255 can be transmitted."""
 
     # We intentionally use a non-POSIX baudrate
-    with Serial(LOOPBACK_ADAPTER, baudrate=12345) as serial:
+    with Serial(loopback_adapter, baudrate=12345) as serial:
         # Create a byte array with all possible byte values
         data = bytes(range(256))
 
@@ -28,9 +21,9 @@ def test_all_bytes_loopback() -> None:
         assert result == data
 
 
-def test_segmented_binary_data_loopback() -> None:
+def test_segmented_binary_data_loopback(loopback_adapter: str) -> None:
     """Test binary data sent in segments."""
-    with Serial(LOOPBACK_ADAPTER, baudrate=115200) as serial:
+    with Serial(loopback_adapter, baudrate=115200) as serial:
         # Send all bytes in smaller segments
         segment_size = 16
         data = bytes(range(256))
@@ -46,9 +39,9 @@ def test_segmented_binary_data_loopback() -> None:
     "size",
     [1, 16, 64, 256, 512, 1024],
 )
-def test_binary_payload_sizes_loopback(size: int) -> None:
+def test_binary_payload_sizes_loopback(loopback_adapter: str, size: int) -> None:
     """Test various binary payload sizes."""
-    with Serial(LOOPBACK_ADAPTER, baudrate=115200) as serial:
+    with Serial(loopback_adapter, baudrate=115200) as serial:
         # Create binary data with repeating pattern
         data = bytes([i % 256 for i in range(size)])
 
@@ -58,9 +51,9 @@ def test_binary_payload_sizes_loopback(size: int) -> None:
         assert result == data
 
 
-def test_null_bytes_loopback() -> None:
+def test_null_bytes_loopback(loopback_adapter: str) -> None:
     """Test that null bytes (0x00) can be transmitted."""
-    with Serial(LOOPBACK_ADAPTER, baudrate=115200) as serial:
+    with Serial(loopback_adapter, baudrate=115200) as serial:
         # Send a bunch of null bytes
         null_data = b"\x00" * 64
 
@@ -70,9 +63,9 @@ def test_null_bytes_loopback() -> None:
         assert result == null_data
 
 
-def test_overlapping_read_write_loopback() -> None:
+def test_overlapping_read_write_loopback(loopback_adapter: str) -> None:
     """Test that read and write can overlap, data is buffered."""
-    with Serial(LOOPBACK_ADAPTER, baudrate=115200) as serial:
+    with Serial(loopback_adapter, baudrate=115200) as serial:
         data = bytes(range(256))
         read = b""
 
@@ -101,9 +94,9 @@ def test_overlapping_read_write_loopback() -> None:
         (921600, 1024),
     ],
 )
-def test_random_large_loopback(baudrate: int, chunk_size: int) -> None:
+def test_random_large_loopback(loopback_adapter: str, baudrate: int, chunk_size: int) -> None:
     """Test loopback adapter random read/write."""
-    with Serial(LOOPBACK_ADAPTER, baudrate=baudrate) as serial:
+    with Serial(loopback_adapter, baudrate=baudrate) as serial:
         data = os.urandom(chunk_size)
         serial.write(data)
 
@@ -115,9 +108,9 @@ def test_random_large_loopback(baudrate: int, chunk_size: int) -> None:
     "iterations",
     [16, 32, 64],
 )
-def test_repeated_write_read_cycles_loopback(iterations: int) -> None:
+def test_repeated_write_read_cycles_loopback(loopback_adapter: str, iterations: int) -> None:
     """Test repeated write/read cycles."""
-    with Serial(LOOPBACK_ADAPTER, baudrate=115200) as serial:
+    with Serial(loopback_adapter, baudrate=115200) as serial:
         data = bytes(range(256))
 
         for _i in range(iterations):
@@ -126,9 +119,9 @@ def test_repeated_write_read_cycles_loopback(iterations: int) -> None:
             assert result == data
 
 
-def test_buffered_writes_then_read_loopback() -> None:
+def test_buffered_writes_then_read_loopback(loopback_adapter: str) -> None:
     """Test multiple writes followed by a single read."""
-    with Serial(LOOPBACK_ADAPTER, baudrate=115200) as serial:
+    with Serial(loopback_adapter, baudrate=115200) as serial:
         chunk = bytes(range(256))
         iterations = 4
 
@@ -149,9 +142,9 @@ def test_buffered_writes_then_read_loopback() -> None:
     "payload_size",
     [1024, 2048],  # Kernel buffers are typically ~4KB, stay well below that
 )
-def test_large_payload_loopback(payload_size: int) -> None:
+def test_large_payload_loopback(loopback_adapter: str, payload_size: int) -> None:
     """Test large payload transmission."""
-    with Serial(LOOPBACK_ADAPTER, baudrate=921600) as serial:
+    with Serial(loopback_adapter, baudrate=921600) as serial:
         data = bytes([i % 256 for i in range(payload_size)])
 
         serial.write(data)
@@ -160,9 +153,9 @@ def test_large_payload_loopback(payload_size: int) -> None:
         assert result == data
 
 
-def test_rapid_small_writes_loopback() -> None:
+def test_rapid_small_writes_loopback(loopback_adapter: str) -> None:
     """Test rapid succession of small writes."""
-    with Serial(LOOPBACK_ADAPTER, baudrate=115200) as serial:
+    with Serial(loopback_adapter, baudrate=115200) as serial:
         # Send many small writes
         iterations = 256
         received = bytearray()
@@ -186,9 +179,9 @@ def test_rapid_small_writes_loopback() -> None:
         (921600, 512),
     ],
 )
-def test_sustained_throughput_loopback(baudrate: int, iterations: int) -> None:
+def test_sustained_throughput_loopback(loopback_adapter: str, baudrate: int, iterations: int) -> None:
     """Test sustained data throughput at various baudrates."""
-    with Serial(LOOPBACK_ADAPTER, baudrate=baudrate) as serial:
+    with Serial(loopback_adapter, baudrate=baudrate) as serial:
         chunk = os.urandom(1024)
 
         for _ in range(iterations):
@@ -201,9 +194,9 @@ def test_sustained_throughput_loopback(baudrate: int, iterations: int) -> None:
     "baudrate",
     [9600, 19200, 38400, 57600, 115200, 230400, 460800, 921600],
 )
-def test_valid_baudrates_loopback(baudrate: int) -> None:
+def test_valid_baudrates_loopback(loopback_adapter: str, baudrate: int) -> None:
     """Test that valid baudrates are accepted."""
-    with Serial(LOOPBACK_ADAPTER, baudrate=baudrate) as serial:
+    with Serial(loopback_adapter, baudrate=baudrate) as serial:
         assert serial.baudrate == baudrate
         serial.write(b"test")
 
@@ -212,9 +205,9 @@ def test_valid_baudrates_loopback(baudrate: int) -> None:
     "parity",
     [Parity.NONE, Parity.ODD, Parity.EVEN, Parity.MARK, Parity.SPACE],
 )
-def test_valid_parity_loopback(parity: Parity) -> None:
+def test_valid_parity_loopback(loopback_adapter: str, parity: Parity) -> None:
     """Test that valid parity settings are accepted."""
-    with Serial(LOOPBACK_ADAPTER, baudrate=115200, parity=parity) as serial:
+    with Serial(loopback_adapter, baudrate=115200, parity=parity) as serial:
         assert serial.parity == parity
         serial.write(b"test")
 
@@ -230,26 +223,26 @@ def test_valid_parity_loopback(parity: Parity) -> None:
         (2, StopBits.TWO),
     ],
 )
-def test_valid_stopbits_loopback(
+def test_valid_stopbits_loopback(loopback_adapter: str, 
     stopbits: StopBits | int | float, expected: StopBits
 ) -> None:
     """Test that valid stopbits settings are accepted."""
-    with Serial(LOOPBACK_ADAPTER, baudrate=115200, stopbits=stopbits) as serial:
+    with Serial(loopback_adapter, baudrate=115200, stopbits=stopbits) as serial:
         assert serial.stopbits == expected
         serial.write(b"test")
 
 
 @pytest.mark.parametrize("byte_size", [5, 6, 7, 8])
-def test_valid_byte_size_loopback(byte_size: int) -> None:
+def test_valid_byte_size_loopback(loopback_adapter: str, byte_size: int) -> None:
     """Test that valid byte sizes are accepted."""
-    with Serial(LOOPBACK_ADAPTER, baudrate=115200, byte_size=byte_size) as serial:
+    with Serial(loopback_adapter, baudrate=115200, byte_size=byte_size) as serial:
         serial.write(b"test")
 
 
 @pytest.mark.parametrize("xonxoff", [True, False])
-def test_xonxoff_setting_loopback(xonxoff: bool) -> None:
+def test_xonxoff_setting_loopback(loopback_adapter: str, xonxoff: bool) -> None:
     """Test that xonxoff setting is accepted."""
-    with Serial(LOOPBACK_ADAPTER, baudrate=115200, xonxoff=xonxoff) as serial:
+    with Serial(loopback_adapter, baudrate=115200, xonxoff=xonxoff) as serial:
         serial.write(b"test")
 
 
@@ -257,38 +250,38 @@ def test_xonxoff_setting_loopback(xonxoff: bool) -> None:
     "rtscts",
     [True, False],
 )
-def test_rtscts_setting_loopback(rtscts: bool) -> None:
+def test_rtscts_setting_loopback(loopback_adapter: str, rtscts: bool) -> None:
     """Test that rtscts setting is accepted."""
-    with Serial(LOOPBACK_ADAPTER, baudrate=115200, rtscts=rtscts) as serial:
+    with Serial(loopback_adapter, baudrate=115200, rtscts=rtscts) as serial:
         serial.write(b"test")
 
 
-def test_exclusive_loopback() -> None:
+def test_exclusive_loopback(loopback_adapter: str) -> None:
     """Test that exclusive setting is respected."""
-    with Serial(LOOPBACK_ADAPTER, baudrate=115200, exclusive=True) as serial:
+    with Serial(loopback_adapter, baudrate=115200, exclusive=True) as serial:
         assert serial.exclusive is True
 
         # Opening a second one will fail
         with pytest.raises(OSError):
-            with Serial(LOOPBACK_ADAPTER, baudrate=115200, exclusive=True):
+            with Serial(loopback_adapter, baudrate=115200, exclusive=True):
                 pass
 
 
-def test_exclusive_disabled_loopback() -> None:
+def test_exclusive_disabled_loopback(loopback_adapter: str) -> None:
     """Test that exclusive setting is respected."""
-    with Serial(LOOPBACK_ADAPTER, baudrate=115200, exclusive=False) as serial1:
+    with Serial(loopback_adapter, baudrate=115200, exclusive=False) as serial1:
         assert serial1.exclusive is False
 
-        with Serial(LOOPBACK_ADAPTER, baudrate=115200, exclusive=False) as serial2:
+        with Serial(loopback_adapter, baudrate=115200, exclusive=False) as serial2:
             assert serial2.exclusive is False
             serial2.write(b"test")
 
         assert serial1.readexactly(4) == b"test"
 
 
-def test_context_manager_multiple_times_loopback() -> None:
+def test_context_manager_multiple_times_loopback(loopback_adapter: str) -> None:
     """Test that context manager can be used multiple times."""
-    serial = Serial(LOOPBACK_ADAPTER, baudrate=115200)
+    serial = Serial(loopback_adapter, baudrate=115200)
 
     # First context
     with serial:
@@ -303,9 +296,9 @@ def test_context_manager_multiple_times_loopback() -> None:
         assert result == b"test2"
 
 
-def test_open_close_cycles_loopback() -> None:
+def test_open_close_cycles_loopback(loopback_adapter: str) -> None:
     """Test multiple open/close cycles."""
-    serial = Serial(LOOPBACK_ADAPTER, baudrate=115200)
+    serial = Serial(loopback_adapter, baudrate=115200)
 
     # Cycle 1
     serial.open()
@@ -329,9 +322,9 @@ def test_open_close_cycles_loopback() -> None:
     serial.close()
 
 
-def test_flush_after_write_loopback() -> None:
+def test_flush_after_write_loopback(loopback_adapter: str) -> None:
     """Test flushing after write operation."""
-    with Serial(LOOPBACK_ADAPTER, baudrate=115200) as serial:
+    with Serial(loopback_adapter, baudrate=115200) as serial:
         serial.flush()
 
         data = b"Test flush operation"
@@ -342,9 +335,9 @@ def test_flush_after_write_loopback() -> None:
         assert result == data
 
 
-def test_multiple_flush_calls_loopback() -> None:
+def test_multiple_flush_calls_loopback(loopback_adapter: str) -> None:
     """Test multiple consecutive flush calls."""
-    with Serial(LOOPBACK_ADAPTER, baudrate=115200) as serial:
+    with Serial(loopback_adapter, baudrate=115200) as serial:
         data = b""
 
         for i in range(5):
@@ -358,9 +351,9 @@ def test_multiple_flush_calls_loopback() -> None:
         assert result == data
 
 
-def test_set_modem_pins_loopback() -> None:
+def test_set_modem_pins_loopback(loopback_adapter: str) -> None:
     """Test setting modem control bits with loopback adapter."""
-    with Serial(LOOPBACK_ADAPTER, baudrate=115200) as serial:
+    with Serial(loopback_adapter, baudrate=115200) as serial:
         serial.set_modem_pins(dtr=True, rts=True)
 
         modem_pins = serial.get_modem_pins()
@@ -382,9 +375,9 @@ def test_set_modem_pins_loopback() -> None:
         assert modem_pins.rts is PinState.LOW
 
 
-def test_deprecated_dtr_property_loopback() -> None:
+def test_deprecated_dtr_property_loopback(loopback_adapter: str) -> None:
     """Test DTR property (deprecated alias) with loopback adapter."""
-    with Serial(LOOPBACK_ADAPTER, baudrate=115200) as serial:
+    with Serial(loopback_adapter, baudrate=115200) as serial:
         serial.dtr = True
         assert serial.dtr is True
 
@@ -392,9 +385,9 @@ def test_deprecated_dtr_property_loopback() -> None:
         assert serial.dtr is False
 
 
-def test_deprecated_rts_property_loopback() -> None:
+def test_deprecated_rts_property_loopback(loopback_adapter: str) -> None:
     """Test RTS property (deprecated alias) with loopback adapter."""
-    with Serial(LOOPBACK_ADAPTER, baudrate=115200) as serial:
+    with Serial(loopback_adapter, baudrate=115200) as serial:
         serial.rts = True
         assert serial.rts is True
 

--- a/tests/test_loopback_sync.py
+++ b/tests/test_loopback_sync.py
@@ -94,7 +94,9 @@ def test_overlapping_read_write_loopback(loopback_adapter: str) -> None:
         (921600, 1024),
     ],
 )
-def test_random_large_loopback(loopback_adapter: str, baudrate: int, chunk_size: int) -> None:
+def test_random_large_loopback(
+    loopback_adapter: str, baudrate: int, chunk_size: int
+) -> None:
     """Test loopback adapter random read/write."""
     with Serial(loopback_adapter, baudrate=baudrate) as serial:
         data = os.urandom(chunk_size)
@@ -108,7 +110,9 @@ def test_random_large_loopback(loopback_adapter: str, baudrate: int, chunk_size:
     "iterations",
     [16, 32, 64],
 )
-def test_repeated_write_read_cycles_loopback(loopback_adapter: str, iterations: int) -> None:
+def test_repeated_write_read_cycles_loopback(
+    loopback_adapter: str, iterations: int
+) -> None:
     """Test repeated write/read cycles."""
     with Serial(loopback_adapter, baudrate=115200) as serial:
         data = bytes(range(256))
@@ -179,7 +183,9 @@ def test_rapid_small_writes_loopback(loopback_adapter: str) -> None:
         (921600, 512),
     ],
 )
-def test_sustained_throughput_loopback(loopback_adapter: str, baudrate: int, iterations: int) -> None:
+def test_sustained_throughput_loopback(
+    loopback_adapter: str, baudrate: int, iterations: int
+) -> None:
     """Test sustained data throughput at various baudrates."""
     with Serial(loopback_adapter, baudrate=baudrate) as serial:
         chunk = os.urandom(1024)
@@ -223,8 +229,8 @@ def test_valid_parity_loopback(loopback_adapter: str, parity: Parity) -> None:
         (2, StopBits.TWO),
     ],
 )
-def test_valid_stopbits_loopback(loopback_adapter: str, 
-    stopbits: StopBits | int | float, expected: StopBits
+def test_valid_stopbits_loopback(
+    loopback_adapter: str, stopbits: StopBits | int | float, expected: StopBits
 ) -> None:
     """Test that valid stopbits settings are accepted."""
     with Serial(loopback_adapter, baudrate=115200, stopbits=stopbits) as serial:


### PR DESCRIPTION
See the new development section in the README for more info. This forgoes environment variables in favor of CLI flags for loopback adapters and adapter pairs, allowing combinations to be tested easily.