### PR TITLE
Serial port listing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,9 @@ jobs:
         with:
           path: venv
           key: >-
-            2-${{ runner.os }}-base-venv-${{
+            1-${{ runner.os }}-base-venv-${{
             steps.python.outputs.python-version }}-${{
-            hashFiles('pyproject.toml', 'Cargo.toml', 'src/**') }}
-      - name: Set up Rust
-        if: steps.cache-venv.outputs.cache-hit != 'true'
-        uses: dtolnay/rust-toolchain@stable
+            hashFiles('pyproject.toml') }}
       - name: Create Python virtual environment
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -39,7 +36,7 @@ jobs:
           uv venv venv
           . venv/bin/activate
           uv pip install -U pip setuptools pre-commit setuptools-rust
-          uv pip install -e .[dev]
+          SETUPTOOLS_RUST_SKIP_BUILD=1 uv pip install -e .[dev]
       - name: Cache base Python virtual environment
         if: steps.cache-venv.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
@@ -66,9 +63,9 @@ jobs:
           fail-on-cache-miss: true
           path: venv
           key: >-
-            2-${{ runner.os }}-base-venv-${{
+            1-${{ runner.os }}-base-venv-${{
             steps.python.outputs.python-version }}-${{
-            hashFiles('pyproject.toml', 'Cargo.toml', 'src/**') }}
+            hashFiles('pyproject.toml') }}
       - name: Restore pre-commit environment from cache
         id: cache-precommit
         uses: actions/cache/restore@v4
@@ -116,9 +113,9 @@ jobs:
           fail-on-cache-miss: true
           path: venv
           key: >-
-            2-${{ runner.os }}-base-venv-${{
+            1-${{ runner.os }}-base-venv-${{
             steps.python.outputs.python-version }}-${{
-            hashFiles('pyproject.toml', 'Cargo.toml', 'src/**') }}
+            hashFiles('pyproject.toml') }}
       - name: Install socat
         run: |
           sudo apt-get update
@@ -170,9 +167,9 @@ jobs:
           fail-on-cache-miss: true
           path: venv
           key: >-
-            2-${{ runner.os }}-base-venv-${{
+            1-${{ runner.os }}-base-venv-${{
             steps.python.outputs.python-version }}-${{
-            hashFiles('pyproject.toml', 'Cargo.toml', 'src/**') }}
+            hashFiles('pyproject.toml') }}
       - name: Download all coverage artifacts
         uses: actions/download-artifact@v4
       - name: Combine coverage results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           uv venv venv
           . venv/bin/activate
           uv pip install -U pip setuptools pre-commit setuptools-rust
-          uv pip install -e .[dev]
+          PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 uv pip install -e .[dev]
       - name: Cache base Python virtual environment
         if: steps.cache-venv.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,13 @@ jobs:
           key: >-
             1-${{ runner.os }}-base-venv-${{
             steps.python.outputs.python-version }}-${{
-            hashFiles('pyproject.toml') }}
+            hashFiles('pyproject.toml', 'Cargo.toml', 'src/lib.rs') }}
+      - name: Install system dependencies
+        if: steps.cache-venv.outputs.cache-hit != 'true'
+        run: sudo apt-get update && sudo apt-get install -y libudev-dev
+      - name: Set up Rust
+        if: steps.cache-venv.outputs.cache-hit != 'true'
+        uses: dtolnay/rust-toolchain@stable
       - name: Create Python virtual environment
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -36,7 +42,7 @@ jobs:
           uv venv venv
           . venv/bin/activate
           uv pip install -U pip setuptools pre-commit setuptools-rust
-          SETUPTOOLS_RUST_SKIP_BUILD=1 uv pip install -e .[dev]
+          uv pip install -e .[dev]
       - name: Cache base Python virtual environment
         if: steps.cache-venv.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
@@ -65,7 +71,7 @@ jobs:
           key: >-
             1-${{ runner.os }}-base-venv-${{
             steps.python.outputs.python-version }}-${{
-            hashFiles('pyproject.toml') }}
+            hashFiles('pyproject.toml', 'Cargo.toml', 'src/lib.rs') }}
       - name: Restore pre-commit environment from cache
         id: cache-precommit
         uses: actions/cache/restore@v4
@@ -115,7 +121,7 @@ jobs:
           key: >-
             1-${{ runner.os }}-base-venv-${{
             steps.python.outputs.python-version }}-${{
-            hashFiles('pyproject.toml') }}
+            hashFiles('pyproject.toml', 'Cargo.toml', 'src/lib.rs') }}
       - name: Install socat
         run: |
           sudo apt-get update
@@ -169,7 +175,7 @@ jobs:
           key: >-
             1-${{ runner.os }}-base-venv-${{
             steps.python.outputs.python-version }}-${{
-            hashFiles('pyproject.toml') }}
+            hashFiles('pyproject.toml', 'Cargo.toml', 'src/lib.rs') }}
       - name: Download all coverage artifacts
         uses: actions/download-artifact@v4
       - name: Combine coverage results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,8 @@ jobs:
             1-${{ runner.os }}-base-venv-${{
             steps.python.outputs.python-version }}-${{
             hashFiles('pyproject.toml', 'Cargo.toml', 'src/lib.rs') }}
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libudev-dev
       - name: Restore pre-commit environment from cache
         id: cache-precommit
         uses: actions/cache/restore@v4
@@ -122,10 +124,10 @@ jobs:
             1-${{ runner.os }}-base-venv-${{
             steps.python.outputs.python-version }}-${{
             hashFiles('pyproject.toml', 'Cargo.toml', 'src/lib.rs') }}
-      - name: Install socat
+      - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y socat
+          sudo apt-get install -y socat libudev-dev
       - name: Register Python problem matcher
         run: |
           echo "::add-matcher::.github/workflows/matchers/python.json"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,16 +26,19 @@ jobs:
         with:
           path: venv
           key: >-
-            1-${{ runner.os }}-base-venv-${{
+            2-${{ runner.os }}-base-venv-${{
             steps.python.outputs.python-version }}-${{
-            hashFiles('pyproject.toml') }}
+            hashFiles('pyproject.toml', 'Cargo.toml', 'src/**') }}
+      - name: Set up Rust
+        if: steps.cache-venv.outputs.cache-hit != 'true'
+        uses: dtolnay/rust-action@stable
       - name: Create Python virtual environment
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
           uv venv venv
           . venv/bin/activate
-          uv pip install -U pip setuptools pre-commit
+          uv pip install -U pip setuptools pre-commit setuptools-rust
           uv pip install -e .[dev]
       - name: Cache base Python virtual environment
         if: steps.cache-venv.outputs.cache-hit != 'true'
@@ -63,9 +66,9 @@ jobs:
           fail-on-cache-miss: true
           path: venv
           key: >-
-            1-${{ runner.os }}-base-venv-${{
+            2-${{ runner.os }}-base-venv-${{
             steps.python.outputs.python-version }}-${{
-            hashFiles('pyproject.toml') }}
+            hashFiles('pyproject.toml', 'Cargo.toml', 'src/**') }}
       - name: Restore pre-commit environment from cache
         id: cache-precommit
         uses: actions/cache/restore@v4
@@ -113,9 +116,9 @@ jobs:
           fail-on-cache-miss: true
           path: venv
           key: >-
-            1-${{ runner.os }}-base-venv-${{
+            2-${{ runner.os }}-base-venv-${{
             steps.python.outputs.python-version }}-${{
-            hashFiles('pyproject.toml') }}
+            hashFiles('pyproject.toml', 'Cargo.toml', 'src/**') }}
       - name: Install socat
         run: |
           sudo apt-get update
@@ -167,9 +170,9 @@ jobs:
           fail-on-cache-miss: true
           path: venv
           key: >-
-            1-${{ runner.os }}-base-venv-${{
+            2-${{ runner.os }}-base-venv-${{
             steps.python.outputs.python-version }}-${{
-            hashFiles('pyproject.toml') }}
+            hashFiles('pyproject.toml', 'Cargo.toml', 'src/**') }}
       - name: Download all coverage artifacts
         uses: actions/download-artifact@v4
       - name: Combine coverage results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
             hashFiles('pyproject.toml', 'Cargo.toml', 'src/**') }}
       - name: Set up Rust
         if: steps.cache-venv.outputs.cache-hit != 'true'
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
       - name: Create Python virtual environment
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Rust
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.22

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,4 +1,4 @@
-name: Publish distributions to PyPI
+name: Build and Publish to PyPI
 
 permissions:
   id-token: write
@@ -7,24 +7,84 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
 
 jobs:
-  build-and-publish:
-    name: Build and publish distributions to PyPI
+  build-wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Rust
+        uses: dtolnay/rust-action@stable
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.22
+        env:
+          # Build for Python 3.10+
+          CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-*"
+          # Skip 32-bit builds
+          CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_i686"
+          # Build for x86_64 and arm64 on macOS
+          CIBW_ARCHS_MACOS: "x86_64 arm64"
+          # Build for x86_64 on Linux (add aarch64 if needed)
+          CIBW_ARCHS_LINUX: "x86_64 aarch64"
+          # Build for x86_64 on Windows
+          CIBW_ARCHS_WINDOWS: "AMD64"
+          # Install Rust in the build environment
+          CIBW_BEFORE_ALL_LINUX: "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"
+          CIBW_ENVIRONMENT_LINUX: 'PATH="$HOME/.cargo/bin:$PATH"'
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}
+          path: ./wheelhouse/*.whl
+
+  build-sdist:
+    name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.10"
-    - name: Install build tools
-      run: >-
-        pip install wheel build
-    - name: Build wheel
-      run: >-
-        python3 -m build
-    - name: Publish distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install build tools
+        run: pip install build
+
+      - name: Build sdist
+        run: python -m build --sdist
+
+      - name: Upload sdist
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+
+  publish:
+    name: Publish to PyPI
+    needs: [build-wheels, build-sdist]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 
 # C extensions
 *.so
+*.pyd
 
 # Distribution / packaging
 .Python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,3 +22,23 @@ repos:
       - id: ruff-check
         args: [--fix]
       - id: ruff-format
+
+  - repo: local
+    hooks:
+      - id: cargo-fmt
+        name: Cargo fmt
+        entry: cargo fmt --all
+        language: system
+        pass_filenames: false
+
+      - id: cargo-check
+        name: Cargo check
+        entry: cargo check --workspace
+        language: system
+        pass_filenames: false
+
+      - id: rust-clippy
+        name: Cargo clippy
+        entry: cargo clippy --all-targets --all-features -- -Dclippy::all -Dclippy::nursery
+        language: system
+        pass_filenames: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "serialx"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "_serialx_rust"
+crate-type = ["cdylib"]
+
+[dependencies]
+pyo3 = { version = "0.23", features = ["extension-module"] }
+serialport = "4"

--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ All development dependencies are listed in `pyproject.toml`. To install them, us
 uv pip install '.[dev]'
 ```
 
+On macOS and Windows, a Rust toolchain is required to build the native serial port
+enumeration extension. Install Rust via [rustup](https://rustup.rs/).
+
 Set up pre-commit hooks with `pre-commit install`. Your code will then be type checked
 and auto-formatted when you run `git commit`. You can do this on-demand with
 `pre-commit run`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0.0", "wheel", "setuptools-git-versioning<2", "setuptools-rust"]
+requires = ["setuptools>=80", "setuptools-scm[simple]>=8", "setuptools-rust"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -35,9 +35,6 @@ exclude = ["tests", "tests.*"]
 target = "serialx._serialx_rust"
 path = "Cargo.toml"
 binding = "PyO3"
-
-[tool.setuptools-git-versioning]
-enabled = true
 
 [tool.pytest.ini_options]
 addopts = "--showlocals --verbose -n auto --dist loadgroup"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0.0", "wheel", "setuptools-git-versioning<2"]
+requires = ["setuptools>=61.0.0", "wheel", "setuptools-git-versioning<2", "setuptools-rust"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -30,6 +30,11 @@ dev = [
 
 [tool.setuptools.packages.find]
 exclude = ["tests", "tests.*"]
+
+[[tool.setuptools-rust.ext-modules]]
+target = "serialx._serialx_rust"
+path = "Cargo.toml"
+binding = "PyO3"
 
 [tool.setuptools-git-versioning]
 enabled = true

--- a/serialx/__init__.py
+++ b/serialx/__init__.py
@@ -8,8 +8,7 @@ from .async_serial import (
     open_serial_connection,
 )
 from .common import ModemPins, Parity, PinState, SerialPortInfo, StopBits
-from .platforms import Serial, SerialTransport
-from .port_listing import list_serial_ports
+from .platforms import Serial, SerialTransport, list_serial_ports
 
 __all__ = [
     "create_serial_connection",

--- a/serialx/__init__.py
+++ b/serialx/__init__.py
@@ -7,16 +7,19 @@ from .async_serial import (
     create_serial_connection,
     open_serial_connection,
 )
-from .common import ModemPins, Parity, PinState, StopBits
+from .common import ModemPins, Parity, PinState, SerialPortInfo, StopBits
 from .platforms import Serial, SerialTransport
+from .port_listing import list_serial_ports
 
 __all__ = [
     "create_serial_connection",
+    "list_serial_ports",
     "open_serial_connection",
     "ModemPins",
     "Parity",
     "PinState",
     "Serial",
+    "SerialPortInfo",
     "SerialStreamWriter",
     "SerialTransport",
     "StopBits",

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -7,8 +7,10 @@ import asyncio
 import dataclasses
 from enum import Enum
 import io
+import os
 from pathlib import Path
 from typing import Any
+import warnings
 
 from typing_extensions import Self
 
@@ -430,3 +432,27 @@ class BaseSerialTransport(asyncio.Transport):
     async def flush(self) -> None:
         """Flush write buffers, waiting until all data is written."""
         raise NotImplementedError
+
+
+@dataclasses.dataclass
+class SerialPortInfo:
+    """A serial port."""
+
+    device: os.PathLike
+    resolved_device: os.PathLike
+
+    vid: str | None
+    pid: str | None
+    serial_number: str | None
+    manufacturer: str | None
+    product: str | None
+
+    @property
+    def description(self) -> str | None:
+        """Deprecated alias for `product`."""
+        warnings.warn(
+            "`description` is deprecated, use `product` instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.product

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -441,8 +441,8 @@ class SerialPortInfo:
     device: os.PathLike
     resolved_device: os.PathLike
 
-    vid: str | None
-    pid: str | None
+    vid: int | None
+    pid: int | None
     serial_number: str | None
     manufacturer: str | None
     product: str | None

--- a/serialx/platforms/__init__.py
+++ b/serialx/platforms/__init__.py
@@ -2,25 +2,69 @@
 
 import sys
 
+from serialx.common import SerialPortInfo
+
+try:
+    from serialx._serialx_rust import list_serial_ports_impl
+except ImportError:
+    list_serial_ports_impl = None
+
+
+def list_serial_ports_native() -> list[SerialPortInfo]:
+    """List available serial ports via the Rust `serial` package."""
+
+    if list_serial_ports_impl is None:
+        raise RuntimeError(
+            "This platform does not support listing serial ports via the native Rust"
+            " implementation."
+        )
+
+    return [
+        SerialPortInfo(
+            device=port_name,
+            resolved_device=port_name,
+            vid=vid,
+            pid=pid,
+            serial_number=serial_number,
+            manufacturer=manufacturer,
+            product=product,
+        )
+        for (
+            port_name,
+            vid,
+            pid,
+            serial_number,
+            manufacturer,
+            product,
+        ) in list_serial_ports_impl()
+    ]
+
+
 if sys.platform == "win32":
     from .serial_win32 import (
         Win32Serial as Serial,
         Win32SerialTransport as SerialTransport,
     )
+
+    list_serial_ports = list_serial_ports_native
 elif sys.platform == "linux":
     from .serial_posix import (
         PosixSerial as Serial,
         PosixSerialTransport as SerialTransport,
+        posix_list_serial_ports as list_serial_ports,
     )
 elif sys.platform == "darwin":
     from .serial_darwin import (
         DarwinSerial as Serial,
         DarwinSerialTransport as SerialTransport,
     )
+
+    list_serial_ports = list_serial_ports_native
 else:
     raise RuntimeError(f"Unsupported platform: {sys.platform}")
 
 __all__ = [
     "Serial",
     "SerialTransport",
+    "list_serial_ports",
 ]

--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -34,6 +34,9 @@ from ..descriptor_transport import DescriptorTransport
 
 LOGGER = logging.getLogger(__name__)
 
+SYS_ROOT = Path("/sys")
+DEV_ROOT = Path("/dev")
+
 FLUSH_TIMEOUT = 10.0
 
 # Reportedly, some drivers benefit from delaying between the `open` syscall and using
@@ -535,13 +538,15 @@ class PosixSerialTransport(DescriptorTransport, BaseSerialTransport):
 def posix_list_serial_ports() -> list[SerialPortInfo]:
     """List serial ports on Linux."""
     by_id_symlinks = {}
+    by_id_path = DEV_ROOT / "serial/by-id"
 
-    for symlink in Path("/dev/serial/by-id").iterdir():
-        by_id_symlinks[symlink.resolve()] = symlink
+    if by_id_path.exists():
+        for symlink in by_id_path.iterdir():
+            by_id_symlinks[symlink.resolve()] = symlink
 
     results = []
 
-    for path in Path("/sys/class/tty").iterdir():
+    for path in (SYS_ROOT / "class/tty").iterdir():
         if not path.name.startswith("tty"):
             continue
 
@@ -549,7 +554,7 @@ def posix_list_serial_ports() -> list[SerialPortInfo]:
         if not (tty_device / "driver").exists():
             continue
 
-        device = Path("/dev") / path.name
+        device = DEV_ROOT / path.name
         resolved = tty_device.resolve()
         subsystem = (resolved / "subsystem").resolve().name
         unique_device = by_id_symlinks.get(device, device)

--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -532,7 +532,7 @@ class PosixSerialTransport(DescriptorTransport, BaseSerialTransport):
             self._reset_empty_waiter()
 
 
-def list_serial_ports() -> list[SerialPortInfo]:
+def posix_list_serial_ports() -> list[SerialPortInfo]:
     """List serial ports on Linux."""
     by_id_symlinks = {}
 

--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -9,6 +9,7 @@ import errno
 import fcntl
 import logging
 import os
+from pathlib import Path
 import sys
 import termios
 import time
@@ -26,6 +27,7 @@ from ..common import (
     ModemPins,
     Parity,
     PinState,
+    SerialPortInfo,
     StopBits,
 )
 from ..descriptor_transport import DescriptorTransport
@@ -528,3 +530,72 @@ class PosixSerialTransport(DescriptorTransport, BaseSerialTransport):
                 await self._loop.run_in_executor(None, self._serial.flush)
         finally:
             self._reset_empty_waiter()
+
+
+def list_serial_ports() -> list[SerialPortInfo]:
+    """List serial ports on Linux."""
+    by_id_symlinks = {}
+
+    for symlink in Path("/dev/serial/by-id").iterdir():
+        by_id_symlinks[symlink.resolve()] = symlink
+
+    results = []
+
+    for path in Path("/sys/class/tty").iterdir():
+        if not path.name.startswith("tty"):
+            continue
+
+        tty_device = path / "device"
+        if not (tty_device / "driver").exists():
+            continue
+
+        device = Path("/dev") / path.name
+        resolved = tty_device.resolve()
+        subsystem = (resolved / "subsystem").resolve().name
+        unique_device = by_id_symlinks.get(device, device)
+
+        if subsystem == "usb-serial":
+            # USB-serial chips
+            usb_device = resolved.parent.parent
+            info = SerialPortInfo(
+                device=unique_device,
+                resolved_device=device,
+                vid=(usb_device / "idVendor").read_text()[:-1],
+                pid=(usb_device / "idProduct").read_text()[:-1],
+                serial_number=(usb_device / "serial").read_text()[:-1],
+                manufacturer=(usb_device / "manufacturer").read_text()[:-1],
+                product=(usb_device / "product").read_text()[:-1],
+            )
+        elif subsystem == "usb":
+            # CDC ACM devices
+            usb_device = resolved.parent
+            info = SerialPortInfo(
+                device=unique_device,
+                resolved_device=device,
+                vid=(usb_device / "idVendor").read_text()[:-1],
+                pid=(usb_device / "idProduct").read_text()[:-1],
+                serial_number=(usb_device / "serial").read_text()[:-1],
+                manufacturer=(usb_device / "manufacturer").read_text()[:-1],
+                product=(usb_device / "product").read_text()[:-1],
+            )
+        elif subsystem == "serial-base":
+            # Native serial ports
+            info = SerialPortInfo(
+                device=unique_device,
+                resolved_device=device,
+                vid=None,
+                pid=None,
+                serial_number=None,
+                manufacturer=None,
+                product=None,
+            )
+        else:
+            LOGGER.warning(
+                "Unknown serial device subsystem %r for device %r",
+                subsystem,
+                device,
+            )
+
+        results.append(info)
+
+    return results

--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -560,8 +560,8 @@ def posix_list_serial_ports() -> list[SerialPortInfo]:
             info = SerialPortInfo(
                 device=unique_device,
                 resolved_device=device,
-                vid=(usb_device / "idVendor").read_text()[:-1],
-                pid=(usb_device / "idProduct").read_text()[:-1],
+                vid=int((usb_device / "idVendor").read_text(), 16),
+                pid=int((usb_device / "idProduct").read_text(), 16),
                 serial_number=(usb_device / "serial").read_text()[:-1],
                 manufacturer=(usb_device / "manufacturer").read_text()[:-1],
                 product=(usb_device / "product").read_text()[:-1],
@@ -572,8 +572,8 @@ def posix_list_serial_ports() -> list[SerialPortInfo]:
             info = SerialPortInfo(
                 device=unique_device,
                 resolved_device=device,
-                vid=(usb_device / "idVendor").read_text()[:-1],
-                pid=(usb_device / "idProduct").read_text()[:-1],
+                vid=int((usb_device / "idVendor").read_text(), 16),
+                pid=int((usb_device / "idProduct").read_text(), 16),
                 serial_number=(usb_device / "serial").read_text()[:-1],
                 manufacturer=(usb_device / "manufacturer").read_text()[:-1],
                 product=(usb_device / "product").read_text()[:-1],

--- a/serialx/tools/__init__.py
+++ b/serialx/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Pyserial compatibility module."""

--- a/serialx/tools/list_ports.py
+++ b/serialx/tools/list_ports.py
@@ -1,0 +1,5 @@
+"""Pyserial compatibility module."""
+
+from serialx import list_serial_ports as comports
+
+__all__ = ["comports"]

--- a/serialx/tools/list_ports_common.py
+++ b/serialx/tools/list_ports_common.py
@@ -1,0 +1,5 @@
+"""Pyserial compatibility module."""
+
+from serialx import SerialPortInfo as ListPortInfo
+
+__all__ = ["ListPortInfo"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,8 @@ use serialport::{available_ports, SerialPortType};
 /// (port_name, vid, pid, serial_number, manufacturer, product)
 type PortInfo = (
     String,
-    Option<String>,
-    Option<String>,
+    Option<u16>,
+    Option<u16>,
     Option<String>,
     Option<String>,
     Option<String>,
@@ -21,8 +21,8 @@ fn list_serial_ports_impl() -> PyResult<Vec<PortInfo>> {
         .map(|p| {
             let (vid, pid, sn, mfr, prod) = match p.port_type {
                 SerialPortType::UsbPort(u) => (
-                    Some(format!("{:04x}", u.vid)),
-                    Some(format!("{:04x}", u.pid)),
+                    Some(u.vid),
+                    Some(u.pid),
                     u.serial_number,
                     u.manufacturer,
                     u.product,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,19 +1,20 @@
 use pyo3::prelude::*;
 use serialport::{available_ports, SerialPortType};
 
+/// (port_name, vid, pid, serial_number, manufacturer, product)
+type PortInfo = (
+    String,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+);
+
 #[pyfunction]
-fn list_serial_ports_impl() -> PyResult<
-    Vec<(
-        String,
-        Option<String>,
-        Option<String>,
-        Option<String>,
-        Option<String>,
-        Option<String>,
-    )>,
-> {
+fn list_serial_ports_impl() -> PyResult<Vec<PortInfo>> {
     let ports = available_ports()
-        .map_err(|e| PyErr::new::<pyo3::exceptions::PyOSError, _>(format!("{}", e)))?;
+        .map_err(|e| PyErr::new::<pyo3::exceptions::PyOSError, _>(format!("{e}")))?;
 
     Ok(ports
         .into_iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,43 @@
+use pyo3::prelude::*;
+use serialport::{available_ports, SerialPortType};
+
+#[pyfunction]
+fn list_serial_ports_impl() -> PyResult<
+    Vec<(
+        String,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+    )>,
+> {
+    let ports = available_ports()
+        .map_err(|e| PyErr::new::<pyo3::exceptions::PyOSError, _>(format!("{}", e)))?;
+
+    Ok(ports
+        .into_iter()
+        .map(|p| {
+            let (vid, pid, sn, mfr, prod) = match p.port_type {
+                SerialPortType::UsbPort(u) => (
+                    Some(format!("{:04x}", u.vid)),
+                    Some(format!("{:04x}", u.pid)),
+                    u.serial_number,
+                    u.manufacturer,
+                    u.product,
+                ),
+                SerialPortType::PciPort => (None, None, None, None, None),
+                SerialPortType::BluetoothPort => (None, None, None, None, None),
+                SerialPortType::Unknown => (None, None, None, None, None),
+            };
+
+            (p.port_name, vid, pid, sn, mfr, prod)
+        })
+        .collect())
+}
+
+#[pymodule]
+fn _serialx_rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(list_serial_ports_impl, m)?)?;
+    Ok(())
+}

--- a/tests/test_list_serial_ports.py
+++ b/tests/test_list_serial_ports.py
@@ -1,0 +1,375 @@
+"""Tests for Linux serial port listing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from serialx.common import SerialPortInfo
+from serialx.platforms import serial_posix
+from serialx.platforms.serial_posix import posix_list_serial_ports
+
+
+def create_usb_serial_device(
+    sys_root: Path,
+    dev_root: Path,
+    *,
+    tty_name: str,
+    device_path: str,
+    vid: str,
+    pid: str,
+    serial: str,
+    manufacturer: str,
+    product: str,
+    by_id_name: str | None = None,
+) -> None:
+    """Create a fake usb-serial device (ttyUSB*) in the fake sysfs."""
+    full_device_path = sys_root / device_path.lstrip("/")
+    ttyusb_dir = full_device_path.parent.parent  # .../ttyUSB0
+    interface_path = ttyusb_dir.parent  # .../1-1.1.1.1:1.0
+    usb_device_path = interface_path.parent  # .../1-1.1.1.1
+
+    tty_class = sys_root / "class/tty" / tty_name
+    tty_class.parent.mkdir(parents=True, exist_ok=True)
+    tty_class.symlink_to(Path("../..") / device_path.lstrip("/"))
+
+    full_device_path.mkdir(parents=True, exist_ok=True)
+    (full_device_path / "device").symlink_to(ttyusb_dir)
+
+    ttyusb_dir.mkdir(parents=True, exist_ok=True)
+
+    # Create driver and subsystem directories, then symlink to them
+    driver_dir = sys_root / "bus/usb-serial/drivers/cp210x"
+    driver_dir.mkdir(parents=True, exist_ok=True)
+    (ttyusb_dir / "driver").symlink_to(driver_dir)
+
+    subsystem_dir = sys_root / "bus/usb-serial"
+    subsystem_dir.mkdir(parents=True, exist_ok=True)
+    (ttyusb_dir / "subsystem").symlink_to(subsystem_dir)
+
+    usb_device_path.mkdir(parents=True, exist_ok=True)
+    (usb_device_path / "idVendor").write_text(vid + "\n")
+    (usb_device_path / "idProduct").write_text(pid + "\n")
+    (usb_device_path / "serial").write_text(serial + "\n")
+    (usb_device_path / "manufacturer").write_text(manufacturer + "\n")
+    (usb_device_path / "product").write_text(product + "\n")
+
+    if by_id_name:
+        by_id_dir = dev_root / "serial/by-id"
+        by_id_dir.mkdir(parents=True, exist_ok=True)
+        (by_id_dir / by_id_name).symlink_to(dev_root / tty_name)
+
+
+def create_cdc_acm_device(
+    sys_root: Path,
+    dev_root: Path,
+    *,
+    tty_name: str,
+    device_path: str,
+    vid: str,
+    pid: str,
+    serial: str,
+    manufacturer: str,
+    product: str,
+    by_id_name: str | None = None,
+) -> None:
+    """Create a fake CDC ACM device (ttyACM*) in the fake sysfs."""
+    full_device_path = sys_root / device_path.lstrip("/")
+    interface_path = full_device_path.parent.parent  # .../1-1.2:1.0
+    usb_device_path = interface_path.parent  # .../1-1.2
+
+    tty_class = sys_root / "class/tty" / tty_name
+    tty_class.parent.mkdir(parents=True, exist_ok=True)
+    tty_class.symlink_to(Path("../..") / device_path.lstrip("/"))
+
+    full_device_path.mkdir(parents=True, exist_ok=True)
+    (full_device_path / "device").symlink_to(interface_path)
+
+    interface_path.mkdir(parents=True, exist_ok=True)
+
+    # Create driver and subsystem directories, then symlink to them
+    driver_dir = sys_root / "bus/usb/drivers/cdc_acm"
+    driver_dir.mkdir(parents=True, exist_ok=True)
+    (interface_path / "driver").symlink_to(driver_dir)
+
+    subsystem_dir = sys_root / "bus/usb"
+    subsystem_dir.mkdir(parents=True, exist_ok=True)
+    (interface_path / "subsystem").symlink_to(subsystem_dir)
+
+    usb_device_path.mkdir(parents=True, exist_ok=True)
+    (usb_device_path / "idVendor").write_text(vid + "\n")
+    (usb_device_path / "idProduct").write_text(pid + "\n")
+    (usb_device_path / "serial").write_text(serial + "\n")
+    (usb_device_path / "manufacturer").write_text(manufacturer + "\n")
+    (usb_device_path / "product").write_text(product + "\n")
+
+    if by_id_name:
+        by_id_dir = dev_root / "serial/by-id"
+        by_id_dir.mkdir(parents=True, exist_ok=True)
+        (by_id_dir / by_id_name).symlink_to(dev_root / tty_name)
+
+
+def create_native_serial_device(
+    sys_root: Path,
+    dev_root: Path,
+    *,
+    tty_name: str,
+    device_path: str,
+) -> None:
+    """Create a fake native serial device (ttyAMA*) in the fake sysfs."""
+    full_device_path = sys_root / device_path.lstrip("/")
+    serial_base_path = full_device_path.parent.parent
+
+    tty_class = sys_root / "class/tty" / tty_name
+    tty_class.parent.mkdir(parents=True, exist_ok=True)
+    tty_class.symlink_to(Path("../..") / device_path.lstrip("/"))
+
+    full_device_path.mkdir(parents=True, exist_ok=True)
+    (full_device_path / "device").symlink_to(serial_base_path)
+
+    serial_base_path.mkdir(parents=True, exist_ok=True)
+
+    # Create driver and subsystem directories, then symlink to them
+    driver_dir = sys_root / "bus/serial-base/drivers/port"
+    driver_dir.mkdir(parents=True, exist_ok=True)
+    (serial_base_path / "driver").symlink_to(driver_dir)
+
+    subsystem_dir = sys_root / "bus/serial-base"
+    (serial_base_path / "subsystem").symlink_to(subsystem_dir)
+
+
+@pytest.fixture
+def fake_sysfs(tmp_path):
+    """Create a fake sysfs structure mimicking Home Assistant OS with a few devices."""
+    sys_root = tmp_path / "sys"
+    dev_root = tmp_path / "dev"
+    sys_root.mkdir()
+    dev_root.mkdir()
+
+    # /dev/ttyUSB0: CP2102 through hub
+    create_usb_serial_device(
+        sys_root,
+        dev_root,
+        tty_name="ttyUSB0",
+        device_path="devices/platform/soc/fe980000.usb/usb1/1-1/1-1.1/1-1.1.1/1-1.1.1.1/1-1.1.1.1:1.0/ttyUSB0/tty/ttyUSB0",
+        vid="10c4",
+        pid="ea60",
+        serial="ec4903cb",
+        manufacturer="Silicon Labs",
+        product="CP2102 USB to UART Bridge Controller",
+        by_id_name="usb-Silicon_Labs_CP2102_USB_to_UART_Bridge_Controller_ec4903cb-if00-port0",
+    )
+
+    # /dev/ttyUSB1: Another CP2102 through hub
+    create_usb_serial_device(
+        sys_root,
+        dev_root,
+        tty_name="ttyUSB1",
+        device_path="devices/platform/soc/fe980000.usb/usb1/1-1/1-1.1/1-1.1.1/1-1.1.1.4/1-1.1.1.4:1.0/ttyUSB1/tty/ttyUSB1",
+        vid="10c4",
+        pid="ea60",
+        serial="41b06ea8",
+        manufacturer="Silicon Labs",
+        product="CP2102 USB to UART Bridge Controller",
+        by_id_name="usb-Silicon_Labs_CP2102_USB_to_UART_Bridge_Controller_41b06ea8-if00-port0",
+    )
+
+    # /dev/ttyUSB2: FTDI through hub
+    create_usb_serial_device(
+        sys_root,
+        dev_root,
+        tty_name="ttyUSB2",
+        device_path="devices/platform/soc/fe980000.usb/usb1/1-1/1-1.1/1-1.1.2/1-1.1.2:1.0/ttyUSB2/tty/ttyUSB2",
+        vid="0403",
+        pid="6001",
+        serial="A5069RR4",
+        manufacturer="FTDI",
+        product="FT232R USB UART",
+        by_id_name="usb-FTDI_FT232R_USB_UART_A5069RR4-if00-port0",
+    )
+
+    # /dev/ttyUSB3: Prolific through hub
+    create_usb_serial_device(
+        sys_root,
+        dev_root,
+        tty_name="ttyUSB3",
+        device_path="devices/platform/soc/fe980000.usb/usb1/1-1/1-1.1/1-1.1.4/1-1.1.4:1.0/ttyUSB3/tty/ttyUSB3",
+        vid="067b",
+        pid="23a3",
+        serial="DSDCb147613",
+        manufacturer="Prolific Technology Inc.",
+        product="USB-Serial Controller",
+        by_id_name="usb-Prolific_Technology_Inc._USB-Serial_Controller_DSDCb147613-if00-port0",
+    )
+
+    # /dev/ttyUSB4: Another FTDI with custom serial
+    create_usb_serial_device(
+        sys_root,
+        dev_root,
+        tty_name="ttyUSB4",
+        device_path="devices/platform/soc/fe980000.usb/usb1/1-1/1-1.1/1-1.1.3/1-1.1.3:1.0/ttyUSB4/tty/ttyUSB4",
+        vid="0403",
+        pid="6001",
+        serial="rutabaga",
+        manufacturer="FTDI",
+        product="FT232R USB UART",
+        by_id_name="usb-FTDI_FT232R_USB_UART_rutabaga-if00-port0",
+    )
+
+    # /dev/ttyACM0: ZBT-2 CDC ACM device connected directly
+    create_cdc_acm_device(
+        sys_root,
+        dev_root,
+        tty_name="ttyACM0",
+        device_path="devices/platform/soc/fe980000.usb/usb1/1-1/1-1.2/1-1.2:1.0/tty/ttyACM0",
+        vid="303a",
+        pid="4005",
+        serial="80B54EEFAE18",
+        manufacturer="Nabu Casa",
+        product="ZBT-2",
+        by_id_name="usb-Nabu_Casa_ZBT-2_80B54EEFAE18-if00",
+    )
+
+    # /dev/ttyAMA0: Raspberry Pi native UART
+    create_native_serial_device(
+        sys_root,
+        dev_root,
+        tty_name="ttyAMA0",
+        device_path="devices/platform/soc/fe201000.serial/fe201000.serial:0/fe201000.serial:0.0/tty/ttyAMA0",
+    )
+
+    # /dev/ttyAMA1: Another Raspberry Pi native UART
+    create_native_serial_device(
+        sys_root,
+        dev_root,
+        tty_name="ttyAMA1",
+        device_path="devices/platform/soc/fe201800.serial/fe201800.serial:0/fe201800.serial:0.0/tty/ttyAMA1",
+    )
+
+    # /dev/ttyAMA2: Third Raspberry Pi native UART
+    create_native_serial_device(
+        sys_root,
+        dev_root,
+        tty_name="ttyAMA2",
+        device_path="devices/platform/soc/fe201a00.serial/fe201a00.serial:0/fe201a00.serial:0.0/tty/ttyAMA2",
+    )
+
+    with (
+        patch.object(serial_posix, "SYS_ROOT", sys_root),
+        patch.object(serial_posix, "DEV_ROOT", dev_root),
+    ):
+        yield sys_root, dev_root
+
+
+def test_list_serial_ports(fake_sysfs) -> None:
+    """Test listing all serial ports on a system mimicking test-yellow-core."""
+    sys_root, dev_root = fake_sysfs
+
+    ports = posix_list_serial_ports()
+    assert len(ports) == 9
+
+    ports_by_name = {Path(p.resolved_device).name: p for p in ports}
+
+    # /dev/ttyUSB0: CP2102
+    assert ports_by_name["ttyUSB0"] == SerialPortInfo(
+        device=dev_root
+        / "serial/by-id/usb-Silicon_Labs_CP2102_USB_to_UART_Bridge_Controller_ec4903cb-if00-port0",
+        resolved_device=dev_root / "ttyUSB0",
+        vid=0x10C4,
+        pid=0xEA60,
+        serial_number="ec4903cb",
+        manufacturer="Silicon Labs",
+        product="CP2102 USB to UART Bridge Controller",
+    )
+
+    # /dev/ttyUSB1: Another CP2102
+    assert ports_by_name["ttyUSB1"] == SerialPortInfo(
+        device=dev_root
+        / "serial/by-id/usb-Silicon_Labs_CP2102_USB_to_UART_Bridge_Controller_41b06ea8-if00-port0",
+        resolved_device=dev_root / "ttyUSB1",
+        vid=0x10C4,
+        pid=0xEA60,
+        serial_number="41b06ea8",
+        manufacturer="Silicon Labs",
+        product="CP2102 USB to UART Bridge Controller",
+    )
+
+    # /dev/ttyUSB2: FTDI
+    assert ports_by_name["ttyUSB2"] == SerialPortInfo(
+        device=dev_root / "serial/by-id/usb-FTDI_FT232R_USB_UART_A5069RR4-if00-port0",
+        resolved_device=dev_root / "ttyUSB2",
+        vid=0x0403,
+        pid=0x6001,
+        serial_number="A5069RR4",
+        manufacturer="FTDI",
+        product="FT232R USB UART",
+    )
+
+    # /dev/ttyUSB3: Prolific
+    assert ports_by_name["ttyUSB3"] == SerialPortInfo(
+        device=dev_root
+        / "serial/by-id/usb-Prolific_Technology_Inc._USB-Serial_Controller_DSDCb147613-if00-port0",
+        resolved_device=dev_root / "ttyUSB3",
+        vid=0x067B,
+        pid=0x23A3,
+        serial_number="DSDCb147613",
+        manufacturer="Prolific Technology Inc.",
+        product="USB-Serial Controller",
+    )
+
+    # /dev/ttyUSB4: FTDI with custom serial
+    assert ports_by_name["ttyUSB4"] == SerialPortInfo(
+        device=dev_root / "serial/by-id/usb-FTDI_FT232R_USB_UART_rutabaga-if00-port0",
+        resolved_device=dev_root / "ttyUSB4",
+        vid=0x0403,
+        pid=0x6001,
+        serial_number="rutabaga",
+        manufacturer="FTDI",
+        product="FT232R USB UART",
+    )
+
+    # /dev/ttyACM0: ZBT-2 CDC ACM
+    assert ports_by_name["ttyACM0"] == SerialPortInfo(
+        device=dev_root / "serial/by-id/usb-Nabu_Casa_ZBT-2_80B54EEFAE18-if00",
+        resolved_device=dev_root / "ttyACM0",
+        vid=0x303A,
+        pid=0x4005,
+        serial_number="80B54EEFAE18",
+        manufacturer="Nabu Casa",
+        product="ZBT-2",
+    )
+
+    # /dev/ttyAMA0: Native UART
+    assert ports_by_name["ttyAMA0"] == SerialPortInfo(
+        device=dev_root / "ttyAMA0",
+        resolved_device=dev_root / "ttyAMA0",
+        vid=None,
+        pid=None,
+        serial_number=None,
+        manufacturer=None,
+        product=None,
+    )
+
+    # /dev/ttyAMA1: Native UART
+    assert ports_by_name["ttyAMA1"] == SerialPortInfo(
+        device=dev_root / "ttyAMA1",
+        resolved_device=dev_root / "ttyAMA1",
+        vid=None,
+        pid=None,
+        serial_number=None,
+        manufacturer=None,
+        product=None,
+    )
+
+    # /dev/ttyAMA2: Native UART
+    assert ports_by_name["ttyAMA2"] == SerialPortInfo(
+        device=dev_root / "ttyAMA2",
+        resolved_device=dev_root / "ttyAMA2",
+        vid=None,
+        pid=None,
+        serial_number=None,
+        manufacturer=None,
+        product=None,
+    )


### PR DESCRIPTION
To support listing serial ports, we introduce a tiny Rust shim module to let us utilize the `serial` crate.

Listing serial ports on Linux is a little tricky but straightforward. macOS and Windows require _unreasonable_ complexity to implement, unfortunately. We fall back to a native Rust module in this case.