### PR TITLE
Fix wheel building for macOS and Linux

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -29,15 +29,10 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.22
         env:
-          # Build for Python 3.10+
-          CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-*"
-          # Skip 32-bit builds
-          CIBW_SKIP: "*-win32"
-          # Build for x86_64 and arm64 on macOS
+          CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-* cp314-*"
           CIBW_ARCHS_MACOS: "x86_64 arm64"
-          # Build for x86_64 on Windows
-          CIBW_ARCHS_WINDOWS: "AMD64"
-          # Add cross-compilation targets for macOS (runners are arm64)
+          CIBW_ARCHS_WINDOWS: "AMD64 x86 ARM64"
+          CIBW_BEFORE_ALL_WINDOWS: "rustup target add aarch64-pc-windows-msvc i686-pc-windows-msvc"
           CIBW_BEFORE_ALL_MACOS: "rustup target add x86_64-apple-darwin aarch64-apple-darwin"
 
       - name: Upload wheels

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -15,7 +15,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        # Only build Rust extension wheels for Windows/macOS
+        os: [windows-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -31,16 +32,13 @@ jobs:
           # Build for Python 3.10+
           CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-*"
           # Skip 32-bit builds
-          CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_i686"
+          CIBW_SKIP: "*-win32"
           # Build for x86_64 and arm64 on macOS
           CIBW_ARCHS_MACOS: "x86_64 arm64"
-          # Build for x86_64 on Linux (add aarch64 if needed)
-          CIBW_ARCHS_LINUX: "x86_64 aarch64"
           # Build for x86_64 on Windows
           CIBW_ARCHS_WINDOWS: "AMD64"
-          # Install Rust in the build environment
-          CIBW_BEFORE_ALL_LINUX: "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"
-          CIBW_ENVIRONMENT_LINUX: 'PATH="$HOME/.cargo/bin:$PATH"'
+          # Add cross-compilation targets for macOS (runners are arm64)
+          CIBW_BEFORE_ALL_MACOS: "rustup target add x86_64-apple-darwin aarch64-apple-darwin"
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4
@@ -49,7 +47,7 @@ jobs:
           path: ./wheelhouse/*.whl
 
   build-sdist:
-    name: Build source distribution
+    name: Build sdist and pure Python wheel
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -64,14 +62,20 @@ jobs:
       - name: Install build tools
         run: pip install build
 
-      - name: Build sdist
-        run: python -m build --sdist
+      - name: Build sdist and wheel
+        run: python -m build
 
       - name: Upload sdist
         uses: actions/upload-artifact@v4
         with:
           name: sdist
           path: dist/*.tar.gz
+
+      - name: Upload wheel
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-ubuntu
+          path: dist/*.whl
 
   publish:
     name: Publish to PyPI

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -59,7 +59,16 @@ jobs:
         run: pip install build
 
       - name: Build sdist and wheel
-        run: python -m build
+        env:
+          # Point to non-existent cargo so setuptools-rust skips the optional extension
+          CARGO: /bin/false
+        run: |
+          python -m build
+          pip install wheel
+
+          # setuptools-rust marks it platform-specific even when skipped, retag it
+          wheel tags --python-tag=py3 --abi-tag=none --platform-tag=any dist/*.whl
+          rm dist/*-cp*-*.whl
 
       - name: Upload sdist
         uses: actions/upload-artifact@v4

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -34,6 +34,7 @@ jobs:
           CIBW_ARCHS_WINDOWS: "AMD64 x86 ARM64"
           CIBW_BEFORE_ALL_WINDOWS: "rustup target add aarch64-pc-windows-msvc i686-pc-windows-msvc"
           CIBW_BEFORE_ALL_MACOS: "rustup target add x86_64-apple-darwin aarch64-apple-darwin"
+          CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=10.12"
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ exclude = ["tests", "tests.*"]
 target = "serialx._serialx_rust"
 path = "Cargo.toml"
 binding = "PyO3"
+optional = true
 
 [tool.pytest.ini_options]
 addopts = "--showlocals --verbose -n auto --dist loadgroup"


### PR DESCRIPTION
Fixes CI publishing for macOS and Linux. Windows surprisingly is the only platform that worked.

- For Linux, we build without Rust retag the wheel to make it non-platform-specific.
- For Windows, we now support 3.14 and all architectures.
