### PR TITLE
Extend `SerialPortInfo` with `bcd_device`, `interface_description`, and `interface_num`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,8 +103,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-    name: >-
-      Run tests Python ${{ matrix.python-version }}
+    name: Run tests Python ${{ matrix.python-version }} (Linux)
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v4
@@ -155,6 +154,26 @@ jobs:
           name: coverage-${{ matrix.python-version }}
           include-hidden-files: true
           path: .coverage
+
+  pytest-other:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest]
+    name: Run tests Python 3.13 (${{ matrix.os }})
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install dependencies and run tests
+        run: |
+          pip install -e .[dev]
+          pytest --timeout=20 tests
 
   coverage:
     name: Process test coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,13 +172,19 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: Install dependencies and run tests
         run: |
-          pip install -e .[dev]
-          pytest --timeout=20 tests
+          pip install -e .[dev] pytest-cov
+          pytest --timeout=20 --cov serialx --cov-config pyproject.toml tests
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.os }}
+          include-hidden-files: true
+          path: .coverage
 
   coverage:
     name: Process test coverage
     runs-on: ubuntu-latest
-    needs: pytest
+    needs: [pytest, pytest-other]
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
             -qq \
             --timeout=20 \
             --durations=10 \
-            --cov \
+            --cov=serialx \
             -o console_output_style=count \
             -p no:sugar \
             tests
@@ -172,7 +172,7 @@ jobs:
       - name: Install dependencies and run tests
         run: |
           pip install -e .[dev] pytest-cov
-          pytest --timeout=20 --cov tests
+          pytest --timeout=20 --cov=serialx tests
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,8 +143,7 @@ jobs:
             -qq \
             --timeout=20 \
             --durations=10 \
-            --cov serialx \
-            --cov-config pyproject.toml \
+            --cov \
             -o console_output_style=count \
             -p no:sugar \
             tests
@@ -173,7 +172,7 @@ jobs:
       - name: Install dependencies and run tests
         run: |
           pip install -e .[dev] pytest-cov
-          pytest --timeout=20 --cov serialx --cov-config pyproject.toml tests
+          pytest --timeout=20 --cov tests
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,4 @@ core-foundation-sys = "0.8"
 io-kit-sys = "0.4"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.58", features = [
-    "Win32_Devices_DeviceAndDriverInstallation",
-    "Win32_Devices_Properties",
-    "Win32_Foundation",
-    "Win32_System_Registry",
-] }
+serialport = "4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,16 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.23", features = ["extension-module"] }
-serialport = "4"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+core-foundation = "0.10"
+core-foundation-sys = "0.8"
+io-kit-sys = "0.4"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { version = "0.58", features = [
+    "Win32_Devices_DeviceAndDriverInstallation",
+    "Win32_Devices_Properties",
+    "Win32_Foundation",
+    "Win32_System_Registry",
+] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ core-foundation-sys = "0.8"
 io-kit-sys = "0.4"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-serialport = "4"
+serialport = { version = "4", features = ["usbportinfo-interface"] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ show_error_context = true
 
 [tool.coverage.run]
 source = ["serialx"]
+relative_files = true
 
 [tool.ruff]
 target-version = "py310"

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -448,6 +448,7 @@ class SerialPortInfo:
     product: str | None
     bcd_device: int | None
     interface: str | None
+    interface_num: int | None
 
     @property
     def description(self) -> str | None:

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -447,7 +447,7 @@ class SerialPortInfo:
     manufacturer: str | None
     product: str | None
     bcd_device: int | None
-    interface: str | None
+    interface_description: str | None
     interface_num: int | None
 
     @property

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -446,6 +446,8 @@ class SerialPortInfo:
     serial_number: str | None
     manufacturer: str | None
     product: str | None
+    bcd_device: int | None
+    interface: str | None
 
     @property
     def description(self) -> str | None:

--- a/serialx/platforms/__init__.py
+++ b/serialx/platforms/__init__.py
@@ -2,51 +2,12 @@
 
 import sys
 
-from serialx.common import SerialPortInfo
-
-try:
-    from serialx._serialx_rust import list_serial_ports_impl
-except ImportError:
-    list_serial_ports_impl = None
-
-
-def list_serial_ports_native() -> list[SerialPortInfo]:
-    """List available serial ports via the Rust `serial` package."""
-
-    if list_serial_ports_impl is None:
-        raise RuntimeError(
-            "This platform does not support listing serial ports via the native Rust"
-            " implementation."
-        )
-
-    return [
-        SerialPortInfo(
-            device=port_name,
-            resolved_device=port_name,
-            vid=vid,
-            pid=pid,
-            serial_number=serial_number,
-            manufacturer=manufacturer,
-            product=product,
-        )
-        for (
-            port_name,
-            vid,
-            pid,
-            serial_number,
-            manufacturer,
-            product,
-        ) in list_serial_ports_impl()
-    ]
-
-
 if sys.platform == "win32":
     from .serial_win32 import (
         Win32Serial as Serial,
         Win32SerialTransport as SerialTransport,
+        win32_list_serial_ports as list_serial_ports,
     )
-
-    list_serial_ports = list_serial_ports_native
 elif sys.platform == "linux":
     from .serial_posix import (
         PosixSerial as Serial,
@@ -57,9 +18,8 @@ elif sys.platform == "darwin":
     from .serial_darwin import (
         DarwinSerial as Serial,
         DarwinSerialTransport as SerialTransport,
+        darwin_list_serial_ports as list_serial_ports,
     )
-
-    list_serial_ports = list_serial_ports_native
 else:
     raise RuntimeError(f"Unsupported platform: {sys.platform}")
 

--- a/serialx/platforms/serial_darwin.py
+++ b/serialx/platforms/serial_darwin.py
@@ -52,6 +52,7 @@ def darwin_list_serial_ports() -> list[SerialPortInfo]:
             product=port.product,
             bcd_device=port.bcd_device,
             interface=port.interface,
+            interface_num=port.interface_num,
         )
         for port in list_serial_ports_darwin_impl()
     ]

--- a/serialx/platforms/serial_darwin.py
+++ b/serialx/platforms/serial_darwin.py
@@ -51,7 +51,7 @@ def darwin_list_serial_ports() -> list[SerialPortInfo]:
             manufacturer=port.manufacturer,
             product=port.product,
             bcd_device=port.bcd_device,
-            interface=port.interface,
+            interface_description=port.interface_description,
             interface_num=port.interface_num,
         )
         for port in list_serial_ports_darwin_impl()

--- a/serialx/platforms/serial_darwin.py
+++ b/serialx/platforms/serial_darwin.py
@@ -1,9 +1,14 @@
 """Darwin serial port implementation."""
 
+from __future__ import annotations
+
 import array
 import errno
 import fcntl
 import logging
+
+from serialx._serialx_rust import list_serial_ports_darwin_impl
+from serialx.common import SerialPortInfo
 
 from .serial_posix import PosixSerial, PosixSerialTransport
 
@@ -32,3 +37,21 @@ class DarwinSerialTransport(PosixSerialTransport):
     """Darwin asyncio serial port transport."""
 
     _serial_cls = DarwinSerial
+
+
+def darwin_list_serial_ports() -> list[SerialPortInfo]:
+    """List available serial ports on macOS using native IOKit via Rust."""
+    return [
+        SerialPortInfo(
+            device=port.device,
+            resolved_device=port.device,
+            vid=port.vid,
+            pid=port.pid,
+            serial_number=port.serial_number,
+            manufacturer=port.manufacturer,
+            product=port.product,
+            bcd_device=port.bcd_device,
+            interface=port.interface,
+        )
+        for port in list_serial_ports_darwin_impl()
+    ]

--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -561,7 +561,9 @@ def posix_list_serial_ports() -> list[SerialPortInfo]:
 
         if subsystem == "usb-serial":
             # USB-serial chips
-            usb_device = resolved.parent.parent
+            usb_interface = resolved.parent
+            usb_device = usb_interface.parent
+            interface_file = usb_interface / "interface"
             info = SerialPortInfo(
                 device=unique_device,
                 resolved_device=device,
@@ -570,10 +572,16 @@ def posix_list_serial_ports() -> list[SerialPortInfo]:
                 serial_number=(usb_device / "serial").read_text()[:-1],
                 manufacturer=(usb_device / "manufacturer").read_text()[:-1],
                 product=(usb_device / "product").read_text()[:-1],
+                bcd_device=int((usb_device / "bcdDevice").read_text(), 16),
+                interface=(
+                    interface_file.read_text()[:-1] if interface_file.exists() else None
+                ),
             )
         elif subsystem == "usb":
             # CDC ACM devices
-            usb_device = resolved.parent
+            usb_interface = resolved
+            usb_device = usb_interface.parent
+            interface_file = usb_interface / "interface"
             info = SerialPortInfo(
                 device=unique_device,
                 resolved_device=device,
@@ -582,6 +590,10 @@ def posix_list_serial_ports() -> list[SerialPortInfo]:
                 serial_number=(usb_device / "serial").read_text()[:-1],
                 manufacturer=(usb_device / "manufacturer").read_text()[:-1],
                 product=(usb_device / "product").read_text()[:-1],
+                bcd_device=int((usb_device / "bcdDevice").read_text(), 16),
+                interface=(
+                    interface_file.read_text()[:-1] if interface_file.exists() else None
+                ),
             )
         elif subsystem == "serial-base":
             # Native serial ports
@@ -593,6 +605,8 @@ def posix_list_serial_ports() -> list[SerialPortInfo]:
                 serial_number=None,
                 manufacturer=None,
                 product=None,
+                bcd_device=None,
+                interface=None,
             )
         else:
             LOGGER.warning(

--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -576,6 +576,7 @@ def posix_list_serial_ports() -> list[SerialPortInfo]:
                 interface=(
                     interface_file.read_text()[:-1] if interface_file.exists() else None
                 ),
+                interface_num=int((usb_interface / "bInterfaceNumber").read_text(), 16),
             )
         elif subsystem == "usb":
             # CDC ACM devices
@@ -594,6 +595,7 @@ def posix_list_serial_ports() -> list[SerialPortInfo]:
                 interface=(
                     interface_file.read_text()[:-1] if interface_file.exists() else None
                 ),
+                interface_num=int((usb_interface / "bInterfaceNumber").read_text(), 16),
             )
         elif subsystem == "serial-base":
             # Native serial ports
@@ -607,6 +609,7 @@ def posix_list_serial_ports() -> list[SerialPortInfo]:
                 product=None,
                 bcd_device=None,
                 interface=None,
+                interface_num=None,
             )
         else:
             LOGGER.warning(

--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -573,7 +573,7 @@ def posix_list_serial_ports() -> list[SerialPortInfo]:
                 manufacturer=(usb_device / "manufacturer").read_text()[:-1],
                 product=(usb_device / "product").read_text()[:-1],
                 bcd_device=int((usb_device / "bcdDevice").read_text(), 16),
-                interface=(
+                interface_description=(
                     interface_file.read_text()[:-1] if interface_file.exists() else None
                 ),
                 interface_num=int((usb_interface / "bInterfaceNumber").read_text(), 16),
@@ -592,7 +592,7 @@ def posix_list_serial_ports() -> list[SerialPortInfo]:
                 manufacturer=(usb_device / "manufacturer").read_text()[:-1],
                 product=(usb_device / "product").read_text()[:-1],
                 bcd_device=int((usb_device / "bcdDevice").read_text(), 16),
-                interface=(
+                interface_description=(
                     interface_file.read_text()[:-1] if interface_file.exists() else None
                 ),
                 interface_num=int((usb_interface / "bInterfaceNumber").read_text(), 16),
@@ -608,7 +608,7 @@ def posix_list_serial_ports() -> list[SerialPortInfo]:
                 manufacturer=None,
                 product=None,
                 bcd_device=None,
-                interface=None,
+                interface_description=None,
                 interface_num=None,
             )
         else:

--- a/serialx/platforms/serial_win32.py
+++ b/serialx/platforms/serial_win32.py
@@ -480,6 +480,7 @@ def win32_list_serial_ports() -> list[SerialPortInfo]:
             product=port.product,
             bcd_device=port.bcd_device,
             interface=port.interface,
+            interface_num=port.interface_num,
         )
         for port in list_serial_ports_windows_impl()
     ]

--- a/serialx/platforms/serial_win32.py
+++ b/serialx/platforms/serial_win32.py
@@ -479,7 +479,7 @@ def win32_list_serial_ports() -> list[SerialPortInfo]:
             manufacturer=port.manufacturer,
             product=port.product,
             bcd_device=port.bcd_device,
-            interface=port.interface,
+            interface_description=port.interface_description,
             interface_num=port.interface_num,
         )
         for port in list_serial_ports_windows_impl()

--- a/serialx/platforms/serial_win32.py
+++ b/serialx/platforms/serial_win32.py
@@ -1,5 +1,7 @@
 """Windows serial port implementation using Win32 API."""
 
+from __future__ import annotations
+
 import asyncio
 import logging
 import os
@@ -48,6 +50,9 @@ from win32file import (
     WriteFile,
 )
 from winerror import ERROR_IO_PENDING
+
+from serialx._serialx_rust import list_serial_ports_windows_impl
+from serialx.common import SerialPortInfo
 
 from ..common import (
     BaseSerial,
@@ -460,3 +465,21 @@ class Win32SerialTransport(BaseSerialTransport):
             await self._loop.run_in_executor(None, self._serial.flush)
         finally:
             self._internal_transport._reset_empty_waiter()
+
+
+def win32_list_serial_ports() -> list[SerialPortInfo]:
+    """List available serial ports on Windows."""
+    return [
+        SerialPortInfo(
+            device=port.device,
+            resolved_device=port.device,
+            vid=port.vid,
+            pid=port.pid,
+            serial_number=port.serial_number,
+            manufacturer=port.manufacturer,
+            product=port.product,
+            bcd_device=port.bcd_device,
+            interface=port.interface,
+        )
+        for port in list_serial_ports_windows_impl()
+    ]

--- a/src/darwin.rs
+++ b/src/darwin.rs
@@ -1,0 +1,202 @@
+//! macOS IOKit-based serial port enumeration.
+//! Note: io-kit-sys bindings incorrectly use `*mut c_char` where `*const c_char` should be used.
+//! The IOKit functions don't actually mutate these strings, so the casts are safe.
+#![allow(clippy::as_ptr_cast_mut)]
+
+use std::ffi::CStr;
+
+use core_foundation::base::{kCFAllocatorDefault, CFType, TCFType};
+use core_foundation::number::CFNumber;
+use core_foundation::string::CFString;
+use io_kit_sys::ret::kIOReturnSuccess;
+use io_kit_sys::types::{io_iterator_t, io_object_t};
+use io_kit_sys::{
+    kIOMasterPortDefault, kIORegistryIterateParents, kIORegistryIterateRecursively, IOIteratorNext,
+    IOObjectRelease, IOObjectRetain, IORegistryEntryCreateCFProperty,
+    IORegistryEntrySearchCFProperty, IOServiceGetMatchingServices, IOServiceMatching,
+};
+
+use crate::RustSerialPortInfo;
+
+const KIO_SERVICE_PLANE: &CStr = c"IOService";
+
+/// RAII wrapper for IOKit objects.
+struct IoObject(io_object_t);
+
+impl IoObject {
+    /// Create a new scoped object from a raw pointer.
+    const unsafe fn from_raw(obj: io_object_t) -> Self {
+        Self(obj)
+    }
+
+    /// Get the underlying raw object.
+    const fn raw(&self) -> io_object_t {
+        self.0
+    }
+
+    /// Get a string property from the registry entry.
+    fn string_property(&self, key: &str) -> Option<String> {
+        unsafe {
+            let cf_key = CFString::new(key);
+            let value = IORegistryEntryCreateCFProperty(
+                self.0,
+                cf_key.as_concrete_TypeRef() as _,
+                kCFAllocatorDefault,
+                0,
+            );
+
+            if value.is_null() {
+                return None;
+            }
+
+            let cf_type: CFType = TCFType::wrap_under_create_rule(value);
+            cf_type.downcast::<CFString>().map(|s| s.to_string())
+        }
+    }
+
+    /// Search for a string property in the registry (recursively up parents).
+    fn search_parent_string_property(&self, key: &str) -> Option<String> {
+        unsafe {
+            let cf_key = CFString::new(key);
+            let value = IORegistryEntrySearchCFProperty(
+                self.0,
+                KIO_SERVICE_PLANE.as_ptr() as *mut _,
+                cf_key.as_concrete_TypeRef() as _,
+                kCFAllocatorDefault,
+                kIORegistryIterateRecursively | kIORegistryIterateParents,
+            );
+
+            if value.is_null() {
+                return None;
+            }
+
+            let cf_type: CFType = TCFType::wrap_under_create_rule(value);
+            cf_type.downcast::<CFString>().map(|s| s.to_string())
+        }
+    }
+
+    /// Search for a u16 property in the registry (recursively up parents).
+    fn search_parent_u16_property(&self, key: &str) -> Option<u16> {
+        unsafe {
+            let cf_key = CFString::new(key);
+            let value = IORegistryEntrySearchCFProperty(
+                self.0,
+                KIO_SERVICE_PLANE.as_ptr() as *mut _,
+                cf_key.as_concrete_TypeRef() as _,
+                kCFAllocatorDefault,
+                kIORegistryIterateRecursively | kIORegistryIterateParents,
+            );
+
+            if value.is_null() {
+                return None;
+            }
+
+            let cf_type: CFType = TCFType::wrap_under_create_rule(value);
+            cf_type
+                .downcast::<CFNumber>()
+                .and_then(|n| n.to_i64().map(|i| i as u16))
+        }
+    }
+}
+
+impl Clone for IoObject {
+    fn clone(&self) -> Self {
+        unsafe {
+            if self.0 != 0 {
+                IOObjectRetain(self.0);
+            }
+            Self(self.0)
+        }
+    }
+}
+
+impl Drop for IoObject {
+    fn drop(&mut self) {
+        if self.0 != 0 {
+            unsafe { IOObjectRelease(self.0) };
+        }
+    }
+}
+
+/// Iterator wrapper for IOKit iterators.
+struct IoIterator(IoObject);
+
+impl Iterator for IoIterator {
+    type Item = IoObject;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        unsafe {
+            let obj = IOIteratorNext(self.0.raw());
+            if obj == 0 {
+                None
+            } else {
+                Some(IoObject::from_raw(obj))
+            }
+        }
+    }
+}
+
+/// List all serial ports using IOKit.
+pub fn list_serial_ports() -> Result<Vec<RustSerialPortInfo>, String> {
+    let mut results = Vec::new();
+
+    unsafe {
+        // Create matching dictionary for IOSerialBSDClient
+        let matching = IOServiceMatching(c"IOSerialBSDClient".as_ptr());
+        if matching.is_null() {
+            return Err("IOServiceMatching returned null".into());
+        }
+
+        // Get iterator for matching services
+        let mut iterator_raw: io_iterator_t = 0;
+        let kr = IOServiceGetMatchingServices(kIOMasterPortDefault, matching, &mut iterator_raw);
+        if kr != kIOReturnSuccess {
+            return Err(format!("IOServiceGetMatchingServices failed: {}", kr));
+        }
+
+        let iterator = IoIterator(IoObject::from_raw(iterator_raw));
+
+        for service in iterator {
+            if let Some(port_info) = get_serial_port_info(&service) {
+                results.push(port_info);
+            }
+        }
+    }
+
+    Ok(results)
+}
+
+/// Get info for a single serial port service.
+fn get_serial_port_info(service: &IoObject) -> Option<RustSerialPortInfo> {
+    // Get the device path (IOCalloutDevice property)
+    let device = service.string_property("IOCalloutDevice")?;
+
+    // Check if it's a USB device by searching for idVendor up the tree.
+    // IORegistryEntrySearchCFProperty will search parents recursively.
+    if let Some(vid) = service.search_parent_u16_property("idVendor") {
+        Some(RustSerialPortInfo {
+            device,
+            vid: Some(vid),
+            pid: service.search_parent_u16_property("idProduct"),
+            serial_number: service.search_parent_string_property("kUSBSerialNumberString"),
+            // Manufacturers are sometimes in kUSBVendorString
+            manufacturer: service.search_parent_string_property("kUSBVendorString"),
+            product: service.search_parent_string_property("kUSBProductString"),
+            bcd_device: service.search_parent_u16_property("bcdDevice"),
+            // Interface name is usually kUSBString on the IOUSBHostInterface parent
+            interface: service.search_parent_string_property("kUSBString"),
+        })
+    } else {
+        // Non-USB serial port (Bluetooth, native, etc.)
+        Some(RustSerialPortInfo {
+            device,
+            vid: None,
+            pid: None,
+            serial_number: None,
+            manufacturer: None,
+            product: None,
+            bcd_device: None,
+            interface: None,
+        })
+    }
+}

--- a/src/darwin.rs
+++ b/src/darwin.rs
@@ -24,7 +24,7 @@ const KIO_SERVICE_PLANE: &CStr = c"IOService";
 struct IoObject(io_object_t);
 
 impl IoObject {
-    const unsafe fn from_raw(obj: io_object_t) -> Self {
+    const fn from_raw(obj: io_object_t) -> Self {
         Self(obj)
     }
 
@@ -33,22 +33,22 @@ impl IoObject {
     }
 
     fn string_property(&self, key: &str) -> Option<String> {
-        unsafe {
-            let cf_key = CFString::new(key);
-            let value = IORegistryEntryCreateCFProperty(
+        let cf_key = CFString::new(key);
+        let value = unsafe {
+            IORegistryEntryCreateCFProperty(
                 self.0,
                 cf_key.as_concrete_TypeRef() as _,
                 kCFAllocatorDefault,
                 0,
-            );
+            )
+        };
 
-            if value.is_null() {
-                return None;
-            }
-
-            let cf_type: CFType = TCFType::wrap_under_create_rule(value);
-            cf_type.downcast::<CFString>().map(|s| s.to_string())
+        if value.is_null() {
+            return None;
         }
+
+        let cf_type: CFType = unsafe { TCFType::wrap_under_create_rule(value) };
+        cf_type.downcast::<CFString>().map(|s| s.to_string())
     }
 
     fn search_parent_property(&self, key: &str) -> Option<CFType> {
@@ -104,7 +104,7 @@ impl Drop for IoObject {
 struct IoIterator(IoObject);
 
 impl IoIterator {
-    const unsafe fn from_raw(iter: io_iterator_t) -> Self {
+    const fn from_raw(iter: io_iterator_t) -> Self {
         Self(IoObject::from_raw(iter))
     }
 }
@@ -113,14 +113,8 @@ impl Iterator for IoIterator {
     type Item = IoObject;
 
     fn next(&mut self) -> Option<Self::Item> {
-        unsafe {
-            let obj = IOIteratorNext(self.0.raw());
-            if obj == 0 {
-                None
-            } else {
-                Some(IoObject::from_raw(obj))
-            }
-        }
+        let obj = unsafe { IOIteratorNext(self.0.raw()) };
+        (obj != 0).then(|| IoObject::from_raw(obj))
     }
 }
 
@@ -138,7 +132,7 @@ pub fn list_serial_ports() -> Result<Vec<RustSerialPortInfo>, String> {
         return Err(format!("IOServiceGetMatchingServices failed: {}", kr));
     }
 
-    let iterator = unsafe { IoIterator::from_raw(iterator_raw) };
+    let iterator = IoIterator::from_raw(iterator_raw);
 
     Ok(iterator
         .filter_map(|service| get_serial_port_info(&service))

--- a/src/darwin.rs
+++ b/src/darwin.rs
@@ -147,7 +147,6 @@ pub fn list_serial_ports() -> Result<Vec<RustSerialPortInfo>, String> {
             return Err("IOServiceMatching returned null".into());
         }
 
-        // Get iterator for matching services
         let mut iterator_raw: io_iterator_t = 0;
         let kr = IOServiceGetMatchingServices(kIOMasterPortDefault, matching, &mut iterator_raw);
         if kr != kIOReturnSuccess {
@@ -168,22 +167,18 @@ pub fn list_serial_ports() -> Result<Vec<RustSerialPortInfo>, String> {
 
 /// Get info for a single serial port service.
 fn get_serial_port_info(service: &IoObject) -> Option<RustSerialPortInfo> {
-    // Get the device path (IOCalloutDevice property)
     let device = service.string_property("IOCalloutDevice")?;
 
     // Check if it's a USB device by searching for idVendor up the tree.
-    // IORegistryEntrySearchCFProperty will search parents recursively.
     if let Some(vid) = service.search_parent_u16_property("idVendor") {
         Some(RustSerialPortInfo {
             device,
             vid: Some(vid),
             pid: service.search_parent_u16_property("idProduct"),
             serial_number: service.search_parent_string_property("kUSBSerialNumberString"),
-            // Manufacturers are sometimes in kUSBVendorString
             manufacturer: service.search_parent_string_property("kUSBVendorString"),
             product: service.search_parent_string_property("kUSBProductString"),
             bcd_device: service.search_parent_u16_property("bcdDevice"),
-            // Interface description is usually kUSBString on the IOUSBHostInterface parent
             interface_description: service.search_parent_string_property("kUSBString"),
             interface_num: service
                 .search_parent_u16_property("bInterfaceNumber")

--- a/src/darwin.rs
+++ b/src/darwin.rs
@@ -183,8 +183,8 @@ fn get_serial_port_info(service: &IoObject) -> Option<RustSerialPortInfo> {
             manufacturer: service.search_parent_string_property("kUSBVendorString"),
             product: service.search_parent_string_property("kUSBProductString"),
             bcd_device: service.search_parent_u16_property("bcdDevice"),
-            // Interface name is usually kUSBString on the IOUSBHostInterface parent
-            interface: service.search_parent_string_property("kUSBString"),
+            // Interface description is usually kUSBString on the IOUSBHostInterface parent
+            interface_description: service.search_parent_string_property("kUSBString"),
             interface_num: service
                 .search_parent_u16_property("bInterfaceNumber")
                 .map(|n| n as u8),
@@ -199,7 +199,7 @@ fn get_serial_port_info(service: &IoObject) -> Option<RustSerialPortInfo> {
             manufacturer: None,
             product: None,
             bcd_device: None,
-            interface: None,
+            interface_description: None,
             interface_num: None,
         })
     }

--- a/src/darwin.rs
+++ b/src/darwin.rs
@@ -24,17 +24,14 @@ const KIO_SERVICE_PLANE: &CStr = c"IOService";
 struct IoObject(io_object_t);
 
 impl IoObject {
-    /// Create a new scoped object from a raw pointer.
     const unsafe fn from_raw(obj: io_object_t) -> Self {
         Self(obj)
     }
 
-    /// Get the underlying raw object.
     const fn raw(&self) -> io_object_t {
         self.0
     }
 
-    /// Get a string property from the registry entry.
     fn string_property(&self, key: &str) -> Option<String> {
         unsafe {
             let cf_key = CFString::new(key);
@@ -54,59 +51,44 @@ impl IoObject {
         }
     }
 
-    /// Search for a string property in the registry (recursively up parents).
-    fn search_parent_string_property(&self, key: &str) -> Option<String> {
-        unsafe {
-            let cf_key = CFString::new(key);
-            let value = IORegistryEntrySearchCFProperty(
+    fn search_parent_property(&self, key: &str) -> Option<CFType> {
+        let cf_key = CFString::new(key);
+        let value = unsafe {
+            IORegistryEntrySearchCFProperty(
                 self.0,
                 KIO_SERVICE_PLANE.as_ptr() as *mut _,
                 cf_key.as_concrete_TypeRef() as _,
                 kCFAllocatorDefault,
                 kIORegistryIterateRecursively | kIORegistryIterateParents,
-            );
+            )
+        };
 
-            if value.is_null() {
-                return None;
-            }
-
-            let cf_type: CFType = TCFType::wrap_under_create_rule(value);
-            cf_type.downcast::<CFString>().map(|s| s.to_string())
+        if value.is_null() {
+            return None;
         }
+
+        Some(unsafe { TCFType::wrap_under_create_rule(value) })
     }
 
-    /// Search for a u16 property in the registry (recursively up parents).
+    fn search_parent_string_property(&self, key: &str) -> Option<String> {
+        self.search_parent_property(key)?
+            .downcast::<CFString>()
+            .map(|s| s.to_string())
+    }
+
     fn search_parent_u16_property(&self, key: &str) -> Option<u16> {
-        unsafe {
-            let cf_key = CFString::new(key);
-            let value = IORegistryEntrySearchCFProperty(
-                self.0,
-                KIO_SERVICE_PLANE.as_ptr() as *mut _,
-                cf_key.as_concrete_TypeRef() as _,
-                kCFAllocatorDefault,
-                kIORegistryIterateRecursively | kIORegistryIterateParents,
-            );
-
-            if value.is_null() {
-                return None;
-            }
-
-            let cf_type: CFType = TCFType::wrap_under_create_rule(value);
-            cf_type
-                .downcast::<CFNumber>()
-                .and_then(|n| n.to_i64().map(|i| i as u16))
-        }
+        self.search_parent_property(key)?
+            .downcast::<CFNumber>()
+            .and_then(|n| n.to_i64().map(|i| i as u16))
     }
 }
 
 impl Clone for IoObject {
     fn clone(&self) -> Self {
-        unsafe {
-            if self.0 != 0 {
-                IOObjectRetain(self.0);
-            }
-            Self(self.0)
+        if self.0 != 0 {
+            unsafe { IOObjectRetain(self.0) };
         }
+        Self(self.0)
     }
 }
 
@@ -120,6 +102,12 @@ impl Drop for IoObject {
 
 /// Iterator wrapper for IOKit iterators.
 struct IoIterator(IoObject);
+
+impl IoIterator {
+    const unsafe fn from_raw(iter: io_iterator_t) -> Self {
+        Self(IoObject::from_raw(iter))
+    }
+}
 
 impl Iterator for IoIterator {
     type Item = IoObject;
@@ -138,31 +126,23 @@ impl Iterator for IoIterator {
 
 /// List all serial ports using IOKit.
 pub fn list_serial_ports() -> Result<Vec<RustSerialPortInfo>, String> {
-    let mut results = Vec::new();
-
-    unsafe {
-        // Create matching dictionary for IOSerialBSDClient
-        let matching = IOServiceMatching(c"IOSerialBSDClient".as_ptr());
-        if matching.is_null() {
-            return Err("IOServiceMatching returned null".into());
-        }
-
-        let mut iterator_raw: io_iterator_t = 0;
-        let kr = IOServiceGetMatchingServices(kIOMasterPortDefault, matching, &mut iterator_raw);
-        if kr != kIOReturnSuccess {
-            return Err(format!("IOServiceGetMatchingServices failed: {}", kr));
-        }
-
-        let iterator = IoIterator(IoObject::from_raw(iterator_raw));
-
-        for service in iterator {
-            if let Some(port_info) = get_serial_port_info(&service) {
-                results.push(port_info);
-            }
-        }
+    let matching = unsafe { IOServiceMatching(c"IOSerialBSDClient".as_ptr()) };
+    if matching.is_null() {
+        return Err("IOServiceMatching returned null".into());
     }
 
-    Ok(results)
+    let mut iterator_raw: io_iterator_t = 0;
+    let kr =
+        unsafe { IOServiceGetMatchingServices(kIOMasterPortDefault, matching, &mut iterator_raw) };
+    if kr != kIOReturnSuccess {
+        return Err(format!("IOServiceGetMatchingServices failed: {}", kr));
+    }
+
+    let iterator = unsafe { IoIterator::from_raw(iterator_raw) };
+
+    Ok(iterator
+        .filter_map(|service| get_serial_port_info(&service))
+        .collect())
 }
 
 /// Get info for a single serial port service.

--- a/src/darwin.rs
+++ b/src/darwin.rs
@@ -185,6 +185,9 @@ fn get_serial_port_info(service: &IoObject) -> Option<RustSerialPortInfo> {
             bcd_device: service.search_parent_u16_property("bcdDevice"),
             // Interface name is usually kUSBString on the IOUSBHostInterface parent
             interface: service.search_parent_string_property("kUSBString"),
+            interface_num: service
+                .search_parent_u16_property("bInterfaceNumber")
+                .map(|n| n as u8),
         })
     } else {
         // Non-USB serial port (Bluetooth, native, etc.)
@@ -197,6 +200,7 @@ fn get_serial_port_info(service: &IoObject) -> Option<RustSerialPortInfo> {
             product: None,
             bcd_device: None,
             interface: None,
+            interface_num: None,
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,44 +1,48 @@
 use pyo3::prelude::*;
-use serialport::{available_ports, SerialPortType};
 
-/// (port_name, vid, pid, serial_number, manufacturer, product)
-type PortInfo = (
-    String,
-    Option<u16>,
-    Option<u16>,
-    Option<String>,
-    Option<String>,
-    Option<String>,
-);
+#[cfg(target_os = "macos")]
+mod darwin;
 
+#[cfg(target_os = "windows")]
+mod windows;
+
+#[pyclass(get_all)]
+#[derive(Clone)]
+pub struct RustSerialPortInfo {
+    pub device: String,
+    pub vid: Option<u16>,
+    pub pid: Option<u16>,
+    pub serial_number: Option<String>,
+    pub manufacturer: Option<String>,
+    pub product: Option<String>,
+    pub bcd_device: Option<u16>,
+    pub interface: Option<String>,
+}
+
+#[cfg(target_os = "macos")]
 #[pyfunction]
-fn list_serial_ports_impl() -> PyResult<Vec<PortInfo>> {
-    let ports = available_ports()
-        .map_err(|e| PyErr::new::<pyo3::exceptions::PyOSError, _>(format!("{e}")))?;
+fn list_serial_ports_darwin_impl() -> PyResult<Vec<RustSerialPortInfo>> {
+    darwin::list_serial_ports().map_err(PyErr::new::<pyo3::exceptions::PyOSError, _>)
+}
 
-    Ok(ports
-        .into_iter()
-        .map(|p| {
-            let (vid, pid, sn, mfr, prod) = match p.port_type {
-                SerialPortType::UsbPort(u) => (
-                    Some(u.vid),
-                    Some(u.pid),
-                    u.serial_number,
-                    u.manufacturer,
-                    u.product,
-                ),
-                SerialPortType::PciPort => (None, None, None, None, None),
-                SerialPortType::BluetoothPort => (None, None, None, None, None),
-                SerialPortType::Unknown => (None, None, None, None, None),
-            };
-
-            (p.port_name, vid, pid, sn, mfr, prod)
-        })
-        .collect())
+#[cfg(target_os = "windows")]
+#[pyfunction]
+fn list_serial_ports_windows_impl() -> PyResult<Vec<RustSerialPortInfo>> {
+    windows::list_serial_ports().map_err(PyErr::new::<pyo3::exceptions::PyOSError, _>)
 }
 
 #[pymodule]
+#[allow(unused_variables, clippy::missing_const_for_fn)]
 fn _serialx_rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add_function(wrap_pyfunction!(list_serial_ports_impl, m)?)?;
+    #[cfg(target_os = "macos")]
+    {
+        m.add_class::<RustSerialPortInfo>()?;
+        m.add_function(wrap_pyfunction!(list_serial_ports_darwin_impl, m)?)?;
+    }
+    #[cfg(target_os = "windows")]
+    {
+        m.add_class::<RustSerialPortInfo>()?;
+        m.add_function(wrap_pyfunction!(list_serial_ports_windows_impl, m)?)?;
+    }
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub struct RustSerialPortInfo {
     pub product: Option<String>,
     pub bcd_device: Option<u16>,
     pub interface: Option<String>,
+    pub interface_num: Option<u8>,
 }
 
 #[cfg(target_os = "macos")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub struct RustSerialPortInfo {
     pub manufacturer: Option<String>,
     pub product: Option<String>,
     pub bcd_device: Option<u16>,
-    pub interface: Option<String>,
+    pub interface_description: Option<String>,
     pub interface_num: Option<u8>,
 }
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,0 +1,191 @@
+//! Windows SetupAPI-based serial port enumeration.
+
+use crate::RustSerialPortInfo;
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::os::windows::prelude::OsStringExt;
+use windows::core::w;
+use windows::core::GUID;
+use windows::Win32::Devices::DeviceAndDriverInstallation::{
+    SetupDiDestroyDeviceInfoList, SetupDiEnumDeviceInfo, SetupDiGetClassDevsW,
+    SetupDiGetDeviceRegistryPropertyW, SetupDiOpenDevRegKey, DICS_FLAG_GLOBAL,
+    DIGCF_DEVICEINTERFACE, DIGCF_PRESENT, DIREG_DEV, HDEVINFO, SETUP_DI_REGISTRY_PROPERTY,
+    SPDRP_HARDWAREID, SP_DEVINFO_DATA,
+};
+use windows::Win32::System::Registry::{RegCloseKey, RegQueryValueExW, KEY_READ, REG_VALUE_TYPE};
+
+// GUID_DEVINTERFACE_COMPORT: {86E0D1E0-8089-11D0-9CE4-08003E301F73}
+const GUID_DEVINTERFACE_COMPORT: GUID = GUID::from_u128(0x86E0D1E0_8089_11D0_9CE4_08003E301F73);
+
+struct ScopedHDevInfo(HDEVINFO);
+
+impl Drop for ScopedHDevInfo {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = SetupDiDestroyDeviceInfoList(self.0);
+        }
+    }
+}
+
+pub fn list_serial_ports() -> Result<Vec<RustSerialPortInfo>, String> {
+    let mut results = Vec::new();
+
+    unsafe {
+        let hdevinfo = SetupDiGetClassDevsW(
+            Some(&GUID_DEVINTERFACE_COMPORT),
+            None,
+            None,
+            DIGCF_PRESENT | DIGCF_DEVICEINTERFACE,
+        )
+        .map_err(|e| format!("SetupDiGetClassDevsW failed: {}\n", e))?;
+
+        let _scope = ScopedHDevInfo(hdevinfo);
+
+        let mut index = 0;
+        let mut devinfo_data = SP_DEVINFO_DATA {
+            cbSize: std::mem::size_of::<SP_DEVINFO_DATA>() as u32,
+            ..Default::default()
+        };
+
+        while SetupDiEnumDeviceInfo(hdevinfo, index, &mut devinfo_data).is_ok() {
+            index += 1;
+
+            if let Some(device) = get_port_name(hdevinfo, &devinfo_data) {
+                let hardware_ids =
+                    get_property_multi_string(hdevinfo, &devinfo_data, SPDRP_HARDWAREID);
+
+                let (vid, pid) = parse_hardware_id(&hardware_ids);
+
+                results.push(RustSerialPortInfo {
+                    device,
+                    vid,
+                    pid,
+                    serial_number: None,
+                    manufacturer: None,
+                    product: None,
+                    bcd_device: None,
+                    interface: None,
+                });
+            }
+        }
+    }
+
+    Ok(results)
+}
+
+unsafe fn get_property_multi_string(
+    hdevinfo: HDEVINFO,
+    devinfo_data: &SP_DEVINFO_DATA,
+    property: SETUP_DI_REGISTRY_PROPERTY,
+) -> Vec<String> {
+    let mut required_size = 0;
+    let _ = SetupDiGetDeviceRegistryPropertyW(
+        hdevinfo,
+        devinfo_data,
+        property,
+        None,
+        None,
+        Some(&mut required_size),
+    );
+
+    if required_size == 0 {
+        return Vec::new();
+    }
+
+    let mut buffer = vec![0u8; required_size as usize];
+    if SetupDiGetDeviceRegistryPropertyW(
+        hdevinfo,
+        devinfo_data,
+        property,
+        None,
+        Some(&mut buffer),
+        None,
+    )
+    .is_err()
+    {
+        return Vec::new();
+    }
+
+    let u16_vec: Vec<u16> = buffer
+        .chunks_exact(2)
+        .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+        .collect();
+
+    u16_vec
+        .split(|&c| c == 0)
+        .filter(|chunk| !chunk.is_empty())
+        .filter_map(|chunk| OsString::from_wide(chunk).into_string().ok())
+        .collect()
+}
+
+unsafe fn get_port_name(hdevinfo: HDEVINFO, devinfo_data: &SP_DEVINFO_DATA) -> Option<String> {
+    let hkey = SetupDiOpenDevRegKey(
+        hdevinfo,
+        devinfo_data,
+        DICS_FLAG_GLOBAL.0,
+        0,
+        DIREG_DEV,
+        KEY_READ.0,
+    )
+    .ok()?;
+
+    let value_name = w!("PortName");
+    let mut data_type = REG_VALUE_TYPE::default();
+    let mut size = 0u32;
+
+    // First call to get size
+    let _ = RegQueryValueExW(
+        hkey,
+        value_name,
+        None,
+        Some(&mut data_type),
+        None,
+        Some(&mut size),
+    );
+
+    if size == 0 {
+        let _ = RegCloseKey(hkey);
+        return None;
+    }
+
+    let mut buffer = vec![0u16; (size as usize) / 2];
+    let result = RegQueryValueExW(
+        hkey,
+        value_name,
+        None,
+        Some(&mut data_type),
+        Some(buffer.as_mut_ptr() as *mut u8),
+        Some(&mut size),
+    );
+
+    let _ = RegCloseKey(hkey);
+
+    if result.is_err() {
+        return None;
+    }
+
+    // Trim null terminator
+    let len = buffer.iter().position(|&c| c == 0).unwrap_or(buffer.len());
+    OsString::from_wide(&buffer[..len]).into_string().ok()
+}
+
+fn parse_hardware_id(hardware_ids: &[String]) -> (Option<u16>, Option<u16>) {
+    for hwid in hardware_ids {
+        let props: HashMap<&str, &str> = hwid
+            .split(|c: char| c == '\\' || c == '&')
+            .filter_map(|part| part.split_once('_'))
+            .collect();
+
+        let vid = props
+            .get("VID")
+            .and_then(|v| u16::from_str_radix(v, 16).ok());
+        let pid = props
+            .get("PID")
+            .and_then(|v| u16::from_str_radix(v, 16).ok());
+
+        if vid.is_some() || pid.is_some() {
+            return (vid, pid);
+        }
+    }
+    (None, None)
+}

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -7,18 +7,20 @@ pub fn list_serial_ports() -> Result<Vec<RustSerialPortInfo>, String> {
     Ok(ports
         .into_iter()
         .map(|port| {
-            let (vid, pid, serial_number, manufacturer, product) = match port.port_type {
-                SerialPortType::UsbPort(info) => (
-                    Some(info.vid),
-                    Some(info.pid),
-                    info.serial_number,
-                    info.manufacturer,
-                    info.product,
-                ),
-                SerialPortType::PciPort
-                | SerialPortType::BluetoothPort
-                | SerialPortType::Unknown => (None, None, None, None, None),
-            };
+            let (vid, pid, serial_number, manufacturer, product, interface_num) =
+                match port.port_type {
+                    SerialPortType::UsbPort(info) => (
+                        Some(info.vid),
+                        Some(info.pid),
+                        info.serial_number,
+                        info.manufacturer,
+                        info.product,
+                        info.interface,
+                    ),
+                    SerialPortType::PciPort
+                    | SerialPortType::BluetoothPort
+                    | SerialPortType::Unknown => (None, None, None, None, None, None),
+                };
 
             RustSerialPortInfo {
                 device: port.port_name,
@@ -29,6 +31,7 @@ pub fn list_serial_ports() -> Result<Vec<RustSerialPortInfo>, String> {
                 product,
                 bcd_device: None,
                 interface: None,
+                interface_num,
             }
         })
         .collect())

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -30,7 +30,7 @@ pub fn list_serial_ports() -> Result<Vec<RustSerialPortInfo>, String> {
                 manufacturer,
                 product,
                 bcd_device: None,
-                interface: None,
+                interface_description: None,
                 interface_num,
             }
         })

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,191 +1,35 @@
-//! Windows SetupAPI-based serial port enumeration.
-
 use crate::RustSerialPortInfo;
-use std::collections::HashMap;
-use std::ffi::OsString;
-use std::os::windows::prelude::OsStringExt;
-use windows::core::w;
-use windows::core::GUID;
-use windows::Win32::Devices::DeviceAndDriverInstallation::{
-    SetupDiDestroyDeviceInfoList, SetupDiEnumDeviceInfo, SetupDiGetClassDevsW,
-    SetupDiGetDeviceRegistryPropertyW, SetupDiOpenDevRegKey, DICS_FLAG_GLOBAL,
-    DIGCF_DEVICEINTERFACE, DIGCF_PRESENT, DIREG_DEV, HDEVINFO, SETUP_DI_REGISTRY_PROPERTY,
-    SPDRP_HARDWAREID, SP_DEVINFO_DATA,
-};
-use windows::Win32::System::Registry::{RegCloseKey, RegQueryValueExW, KEY_READ, REG_VALUE_TYPE};
-
-// GUID_DEVINTERFACE_COMPORT: {86E0D1E0-8089-11D0-9CE4-08003E301F73}
-const GUID_DEVINTERFACE_COMPORT: GUID = GUID::from_u128(0x86E0D1E0_8089_11D0_9CE4_08003E301F73);
-
-struct ScopedHDevInfo(HDEVINFO);
-
-impl Drop for ScopedHDevInfo {
-    fn drop(&mut self) {
-        unsafe {
-            let _ = SetupDiDestroyDeviceInfoList(self.0);
-        }
-    }
-}
+use serialport::{available_ports, SerialPortType};
 
 pub fn list_serial_ports() -> Result<Vec<RustSerialPortInfo>, String> {
-    let mut results = Vec::new();
+    let ports = available_ports().map_err(|e| e.to_string())?;
 
-    unsafe {
-        let hdevinfo = SetupDiGetClassDevsW(
-            Some(&GUID_DEVINTERFACE_COMPORT),
-            None,
-            None,
-            DIGCF_PRESENT | DIGCF_DEVICEINTERFACE,
-        )
-        .map_err(|e| format!("SetupDiGetClassDevsW failed: {}\n", e))?;
+    Ok(ports
+        .into_iter()
+        .map(|port| {
+            let (vid, pid, serial_number, manufacturer, product) = match port.port_type {
+                SerialPortType::UsbPort(info) => (
+                    Some(info.vid),
+                    Some(info.pid),
+                    info.serial_number,
+                    info.manufacturer,
+                    info.product,
+                ),
+                SerialPortType::PciPort
+                | SerialPortType::BluetoothPort
+                | SerialPortType::Unknown => (None, None, None, None, None),
+            };
 
-        let _scope = ScopedHDevInfo(hdevinfo);
-
-        let mut index = 0;
-        let mut devinfo_data = SP_DEVINFO_DATA {
-            cbSize: std::mem::size_of::<SP_DEVINFO_DATA>() as u32,
-            ..Default::default()
-        };
-
-        while SetupDiEnumDeviceInfo(hdevinfo, index, &mut devinfo_data).is_ok() {
-            index += 1;
-
-            if let Some(device) = get_port_name(hdevinfo, &devinfo_data) {
-                let hardware_ids =
-                    get_property_multi_string(hdevinfo, &devinfo_data, SPDRP_HARDWAREID);
-
-                let (vid, pid) = parse_hardware_id(&hardware_ids);
-
-                results.push(RustSerialPortInfo {
-                    device,
-                    vid,
-                    pid,
-                    serial_number: None,
-                    manufacturer: None,
-                    product: None,
-                    bcd_device: None,
-                    interface: None,
-                });
+            RustSerialPortInfo {
+                device: port.port_name,
+                vid,
+                pid,
+                serial_number,
+                manufacturer,
+                product,
+                bcd_device: None,
+                interface: None,
             }
-        }
-    }
-
-    Ok(results)
-}
-
-unsafe fn get_property_multi_string(
-    hdevinfo: HDEVINFO,
-    devinfo_data: &SP_DEVINFO_DATA,
-    property: SETUP_DI_REGISTRY_PROPERTY,
-) -> Vec<String> {
-    let mut required_size = 0;
-    let _ = SetupDiGetDeviceRegistryPropertyW(
-        hdevinfo,
-        devinfo_data,
-        property,
-        None,
-        None,
-        Some(&mut required_size),
-    );
-
-    if required_size == 0 {
-        return Vec::new();
-    }
-
-    let mut buffer = vec![0u8; required_size as usize];
-    if SetupDiGetDeviceRegistryPropertyW(
-        hdevinfo,
-        devinfo_data,
-        property,
-        None,
-        Some(&mut buffer),
-        None,
-    )
-    .is_err()
-    {
-        return Vec::new();
-    }
-
-    let u16_vec: Vec<u16> = buffer
-        .chunks_exact(2)
-        .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
-        .collect();
-
-    u16_vec
-        .split(|&c| c == 0)
-        .filter(|chunk| !chunk.is_empty())
-        .filter_map(|chunk| OsString::from_wide(chunk).into_string().ok())
-        .collect()
-}
-
-unsafe fn get_port_name(hdevinfo: HDEVINFO, devinfo_data: &SP_DEVINFO_DATA) -> Option<String> {
-    let hkey = SetupDiOpenDevRegKey(
-        hdevinfo,
-        devinfo_data,
-        DICS_FLAG_GLOBAL.0,
-        0,
-        DIREG_DEV,
-        KEY_READ.0,
-    )
-    .ok()?;
-
-    let value_name = w!("PortName");
-    let mut data_type = REG_VALUE_TYPE::default();
-    let mut size = 0u32;
-
-    // First call to get size
-    let _ = RegQueryValueExW(
-        hkey,
-        value_name,
-        None,
-        Some(&mut data_type),
-        None,
-        Some(&mut size),
-    );
-
-    if size == 0 {
-        let _ = RegCloseKey(hkey);
-        return None;
-    }
-
-    let mut buffer = vec![0u16; (size as usize) / 2];
-    let result = RegQueryValueExW(
-        hkey,
-        value_name,
-        None,
-        Some(&mut data_type),
-        Some(buffer.as_mut_ptr() as *mut u8),
-        Some(&mut size),
-    );
-
-    let _ = RegCloseKey(hkey);
-
-    if result.is_err() {
-        return None;
-    }
-
-    // Trim null terminator
-    let len = buffer.iter().position(|&c| c == 0).unwrap_or(buffer.len());
-    OsString::from_wide(&buffer[..len]).into_string().ok()
-}
-
-fn parse_hardware_id(hardware_ids: &[String]) -> (Option<u16>, Option<u16>) {
-    for hwid in hardware_ids {
-        let props: HashMap<&str, &str> = hwid
-            .split(|c: char| c == '\\' || c == '&')
-            .filter_map(|part| part.split_once('_'))
-            .collect();
-
-        let vid = props
-            .get("VID")
-            .and_then(|v| u16::from_str_radix(v, 16).ok());
-        let pid = props
-            .get("PID")
-            .and_then(|v| u16::from_str_radix(v, 16).ok());
-
-        if vid.is_some() || pid.is_some() {
-            return (vid, pid);
-        }
-    }
-    (None, None)
+        })
+        .collect())
 }

--- a/tests/test_list_serial_ports.py
+++ b/tests/test_list_serial_ports.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 from pathlib import Path
+import sys
 from unittest.mock import patch
 
 import pytest
+
+if sys.platform != "linux":
+    pytest.skip("POSIX-only tests", allow_module_level=True)
 
 from serialx.common import SerialPortInfo
 from serialx.platforms import serial_posix
@@ -23,6 +27,8 @@ def create_usb_serial_device(
     serial: str,
     manufacturer: str,
     product: str,
+    bcd_device: str,
+    interface: str | None = None,
     by_id_name: str | None = None,
 ) -> None:
     """Create a fake usb-serial device (ttyUSB*) in the fake sysfs."""
@@ -55,6 +61,12 @@ def create_usb_serial_device(
     (usb_device_path / "serial").write_text(serial + "\n")
     (usb_device_path / "manufacturer").write_text(manufacturer + "\n")
     (usb_device_path / "product").write_text(product + "\n")
+    (usb_device_path / "bcdDevice").write_text(bcd_device + "\n")
+
+    # Interface string is at the USB interface level
+    interface_path.mkdir(parents=True, exist_ok=True)
+    if interface is not None:
+        (interface_path / "interface").write_text(interface + "\n")
 
     if by_id_name:
         by_id_dir = dev_root / "serial/by-id"
@@ -73,6 +85,8 @@ def create_cdc_acm_device(
     serial: str,
     manufacturer: str,
     product: str,
+    bcd_device: str,
+    interface: str | None = None,
     by_id_name: str | None = None,
 ) -> None:
     """Create a fake CDC ACM device (ttyACM*) in the fake sysfs."""
@@ -104,6 +118,11 @@ def create_cdc_acm_device(
     (usb_device_path / "serial").write_text(serial + "\n")
     (usb_device_path / "manufacturer").write_text(manufacturer + "\n")
     (usb_device_path / "product").write_text(product + "\n")
+    (usb_device_path / "bcdDevice").write_text(bcd_device + "\n")
+
+    # Interface string is at the USB interface level
+    if interface is not None:
+        (interface_path / "interface").write_text(interface + "\n")
 
     if by_id_name:
         by_id_dir = dev_root / "serial/by-id"
@@ -159,6 +178,8 @@ def fake_sysfs(tmp_path):
         serial="ec4903cb",
         manufacturer="Silicon Labs",
         product="CP2102 USB to UART Bridge Controller",
+        bcd_device="0100",
+        interface="CP2102 USB to UART Bridge Controller",
         by_id_name="usb-Silicon_Labs_CP2102_USB_to_UART_Bridge_Controller_ec4903cb-if00-port0",
     )
 
@@ -173,6 +194,8 @@ def fake_sysfs(tmp_path):
         serial="41b06ea8",
         manufacturer="Silicon Labs",
         product="CP2102 USB to UART Bridge Controller",
+        bcd_device="0100",
+        interface="CP2102 USB to UART Bridge Controller",
         by_id_name="usb-Silicon_Labs_CP2102_USB_to_UART_Bridge_Controller_41b06ea8-if00-port0",
     )
 
@@ -187,10 +210,12 @@ def fake_sysfs(tmp_path):
         serial="A5069RR4",
         manufacturer="FTDI",
         product="FT232R USB UART",
+        bcd_device="0600",
+        interface="FT232R USB UART",
         by_id_name="usb-FTDI_FT232R_USB_UART_A5069RR4-if00-port0",
     )
 
-    # /dev/ttyUSB3: Prolific through hub
+    # /dev/ttyUSB3: Prolific through hub (no interface string)
     create_usb_serial_device(
         sys_root,
         dev_root,
@@ -201,6 +226,8 @@ def fake_sysfs(tmp_path):
         serial="DSDCb147613",
         manufacturer="Prolific Technology Inc.",
         product="USB-Serial Controller",
+        bcd_device="0605",
+        interface=None,
         by_id_name="usb-Prolific_Technology_Inc._USB-Serial_Controller_DSDCb147613-if00-port0",
     )
 
@@ -215,6 +242,8 @@ def fake_sysfs(tmp_path):
         serial="rutabaga",
         manufacturer="FTDI",
         product="FT232R USB UART",
+        bcd_device="0600",
+        interface="FT232R USB UART",
         by_id_name="usb-FTDI_FT232R_USB_UART_rutabaga-if00-port0",
     )
 
@@ -229,6 +258,8 @@ def fake_sysfs(tmp_path):
         serial="80B54EEFAE18",
         manufacturer="Nabu Casa",
         product="ZBT-2",
+        bcd_device="0100",
+        interface="Nabu Casa ZBT-2",
         by_id_name="usb-Nabu_Casa_ZBT-2_80B54EEFAE18-if00",
     )
 
@@ -282,6 +313,8 @@ def test_list_serial_ports(fake_sysfs) -> None:
         serial_number="ec4903cb",
         manufacturer="Silicon Labs",
         product="CP2102 USB to UART Bridge Controller",
+        bcd_device=0x0100,
+        interface="CP2102 USB to UART Bridge Controller",
     )
 
     # /dev/ttyUSB1: Another CP2102
@@ -294,6 +327,8 @@ def test_list_serial_ports(fake_sysfs) -> None:
         serial_number="41b06ea8",
         manufacturer="Silicon Labs",
         product="CP2102 USB to UART Bridge Controller",
+        bcd_device=0x0100,
+        interface="CP2102 USB to UART Bridge Controller",
     )
 
     # /dev/ttyUSB2: FTDI
@@ -305,6 +340,8 @@ def test_list_serial_ports(fake_sysfs) -> None:
         serial_number="A5069RR4",
         manufacturer="FTDI",
         product="FT232R USB UART",
+        bcd_device=0x0600,
+        interface="FT232R USB UART",
     )
 
     # /dev/ttyUSB3: Prolific
@@ -317,6 +354,8 @@ def test_list_serial_ports(fake_sysfs) -> None:
         serial_number="DSDCb147613",
         manufacturer="Prolific Technology Inc.",
         product="USB-Serial Controller",
+        bcd_device=0x0605,
+        interface=None,
     )
 
     # /dev/ttyUSB4: FTDI with custom serial
@@ -328,6 +367,8 @@ def test_list_serial_ports(fake_sysfs) -> None:
         serial_number="rutabaga",
         manufacturer="FTDI",
         product="FT232R USB UART",
+        bcd_device=0x0600,
+        interface="FT232R USB UART",
     )
 
     # /dev/ttyACM0: ZBT-2 CDC ACM
@@ -339,6 +380,8 @@ def test_list_serial_ports(fake_sysfs) -> None:
         serial_number="80B54EEFAE18",
         manufacturer="Nabu Casa",
         product="ZBT-2",
+        bcd_device=0x0100,
+        interface="Nabu Casa ZBT-2",
     )
 
     # /dev/ttyAMA0: Native UART
@@ -350,6 +393,8 @@ def test_list_serial_ports(fake_sysfs) -> None:
         serial_number=None,
         manufacturer=None,
         product=None,
+        bcd_device=None,
+        interface=None,
     )
 
     # /dev/ttyAMA1: Native UART
@@ -361,6 +406,8 @@ def test_list_serial_ports(fake_sysfs) -> None:
         serial_number=None,
         manufacturer=None,
         product=None,
+        bcd_device=None,
+        interface=None,
     )
 
     # /dev/ttyAMA2: Native UART
@@ -372,4 +419,6 @@ def test_list_serial_ports(fake_sysfs) -> None:
         serial_number=None,
         manufacturer=None,
         product=None,
+        bcd_device=None,
+        interface=None,
     )

--- a/tests/test_list_serial_ports_linux.py
+++ b/tests/test_list_serial_ports_linux.py
@@ -2,14 +2,15 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import sys
-from unittest.mock import patch
 
 import pytest
 
 if sys.platform != "linux":
-    pytest.skip("POSIX-only tests", allow_module_level=True)
+    pytest.skip("Linux-only tests", allow_module_level=True)
+
+from pathlib import Path
+from unittest.mock import patch
 
 from serialx.common import SerialPortInfo
 from serialx.platforms import serial_posix
@@ -294,7 +295,7 @@ def fake_sysfs(tmp_path):
         yield sys_root, dev_root
 
 
-def test_list_serial_ports(fake_sysfs) -> None:
+def test_list_serial_ports_linux(fake_sysfs) -> None:
     """Test listing all serial ports on a system mimicking test-yellow-core."""
     sys_root, dev_root = fake_sysfs
 

--- a/tests/test_list_serial_ports_linux.py
+++ b/tests/test_list_serial_ports_linux.py
@@ -30,6 +30,7 @@ def create_usb_serial_device(
     product: str,
     bcd_device: str,
     interface: str | None = None,
+    interface_num: str = "00",
     by_id_name: str | None = None,
 ) -> None:
     """Create a fake usb-serial device (ttyUSB*) in the fake sysfs."""
@@ -64,8 +65,9 @@ def create_usb_serial_device(
     (usb_device_path / "product").write_text(product + "\n")
     (usb_device_path / "bcdDevice").write_text(bcd_device + "\n")
 
-    # Interface string is at the USB interface level
+    # Interface string and number are at the USB interface level
     interface_path.mkdir(parents=True, exist_ok=True)
+    (interface_path / "bInterfaceNumber").write_text(interface_num + "\n")
     if interface is not None:
         (interface_path / "interface").write_text(interface + "\n")
 
@@ -88,6 +90,7 @@ def create_cdc_acm_device(
     product: str,
     bcd_device: str,
     interface: str | None = None,
+    interface_num: str = "00",
     by_id_name: str | None = None,
 ) -> None:
     """Create a fake CDC ACM device (ttyACM*) in the fake sysfs."""
@@ -121,7 +124,8 @@ def create_cdc_acm_device(
     (usb_device_path / "product").write_text(product + "\n")
     (usb_device_path / "bcdDevice").write_text(bcd_device + "\n")
 
-    # Interface string is at the USB interface level
+    # Interface string and number are at the USB interface level
+    (interface_path / "bInterfaceNumber").write_text(interface_num + "\n")
     if interface is not None:
         (interface_path / "interface").write_text(interface + "\n")
 
@@ -315,7 +319,8 @@ def test_list_serial_ports_linux(fake_sysfs) -> None:
         manufacturer="Silicon Labs",
         product="CP2102 USB to UART Bridge Controller",
         bcd_device=0x0100,
-        interface="CP2102 USB to UART Bridge Controller",
+        interface_description="CP2102 USB to UART Bridge Controller",
+        interface_num=0,
     )
 
     # /dev/ttyUSB1: Another CP2102
@@ -329,7 +334,8 @@ def test_list_serial_ports_linux(fake_sysfs) -> None:
         manufacturer="Silicon Labs",
         product="CP2102 USB to UART Bridge Controller",
         bcd_device=0x0100,
-        interface="CP2102 USB to UART Bridge Controller",
+        interface_description="CP2102 USB to UART Bridge Controller",
+        interface_num=0,
     )
 
     # /dev/ttyUSB2: FTDI
@@ -342,7 +348,8 @@ def test_list_serial_ports_linux(fake_sysfs) -> None:
         manufacturer="FTDI",
         product="FT232R USB UART",
         bcd_device=0x0600,
-        interface="FT232R USB UART",
+        interface_description="FT232R USB UART",
+        interface_num=0,
     )
 
     # /dev/ttyUSB3: Prolific
@@ -356,7 +363,8 @@ def test_list_serial_ports_linux(fake_sysfs) -> None:
         manufacturer="Prolific Technology Inc.",
         product="USB-Serial Controller",
         bcd_device=0x0605,
-        interface=None,
+        interface_description=None,
+        interface_num=0,
     )
 
     # /dev/ttyUSB4: FTDI with custom serial
@@ -369,7 +377,8 @@ def test_list_serial_ports_linux(fake_sysfs) -> None:
         manufacturer="FTDI",
         product="FT232R USB UART",
         bcd_device=0x0600,
-        interface="FT232R USB UART",
+        interface_description="FT232R USB UART",
+        interface_num=0,
     )
 
     # /dev/ttyACM0: ZBT-2 CDC ACM
@@ -382,7 +391,8 @@ def test_list_serial_ports_linux(fake_sysfs) -> None:
         manufacturer="Nabu Casa",
         product="ZBT-2",
         bcd_device=0x0100,
-        interface="Nabu Casa ZBT-2",
+        interface_description="Nabu Casa ZBT-2",
+        interface_num=0,
     )
 
     # /dev/ttyAMA0: Native UART
@@ -395,7 +405,8 @@ def test_list_serial_ports_linux(fake_sysfs) -> None:
         manufacturer=None,
         product=None,
         bcd_device=None,
-        interface=None,
+        interface_description=None,
+        interface_num=None,
     )
 
     # /dev/ttyAMA1: Native UART
@@ -408,7 +419,8 @@ def test_list_serial_ports_linux(fake_sysfs) -> None:
         manufacturer=None,
         product=None,
         bcd_device=None,
-        interface=None,
+        interface_description=None,
+        interface_num=None,
     )
 
     # /dev/ttyAMA2: Native UART
@@ -421,5 +433,6 @@ def test_list_serial_ports_linux(fake_sysfs) -> None:
         manufacturer=None,
         product=None,
         bcd_device=None,
-        interface=None,
+        interface_description=None,
+        interface_num=None,
     )

--- a/tests/test_list_serial_ports_macos.py
+++ b/tests/test_list_serial_ports_macos.py
@@ -1,0 +1,24 @@
+"""Tests for macOS serial port listing."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+if sys.platform != "darwin":
+    pytest.skip("macOS-only tests", allow_module_level=True)
+
+from serialx.common import SerialPortInfo
+from serialx.platforms.serial_darwin import darwin_list_serial_ports
+
+
+def test_list_serial_ports_macos() -> None:
+    """Test listing serial ports on macOS."""
+    ports = darwin_list_serial_ports()
+
+    for port in ports:
+        assert isinstance(port, SerialPortInfo)
+        assert isinstance(port.device, str)
+        assert port.vid is None or isinstance(port.vid, int)
+        assert port.pid is None or isinstance(port.pid, int)

--- a/tests/test_list_serial_ports_windows.py
+++ b/tests/test_list_serial_ports_windows.py
@@ -1,0 +1,24 @@
+"""Tests for Windows serial port listing."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+if sys.platform != "win32":
+    pytest.skip("Windows-only tests", allow_module_level=True)
+
+from serialx.common import SerialPortInfo
+from serialx.platforms.serial_win32 import win32_list_serial_ports
+
+
+def test_list_serial_ports_windows() -> None:
+    """Test listing serial ports on Windows."""
+    ports = win32_list_serial_ports()
+
+    for port in ports:
+        assert isinstance(port, SerialPortInfo)
+        assert isinstance(port.device, str)
+        assert port.vid is None or isinstance(port.vid, int)
+        assert port.pid is None or isinstance(port.pid, int)


### PR DESCRIPTION
We've now outgrown the `serialport` crate and are back to native code for macOS 😄.

`bcd_device`, `interface_num`, and `interface_description` allow downstream applications to filter serial ports with more granularity, since this information is available.