### PR TITLE
Handle `errno.EOPNOTSUPP` error on Docker

### DIFF
--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -353,8 +353,8 @@ class PosixSerial(BaseSerial):
             try:
                 self._set_low_latency(self._low_latency)
             except OSError as exc:
-                if exc.errno == errno.ENOTTY:
-                    LOGGER.debug("Device is not a serial port, cannot set low latency")
+                if exc.errno in (errno.ENOTTY, errno.EOPNOTSUPP):
+                    LOGGER.debug("Device does not support setting low latency")
                 else:
                     raise
 

--- a/tests/test_serial_linux.py
+++ b/tests/test_serial_linux.py
@@ -1,5 +1,12 @@
 """Linux serial port tests."""
 
+import sys
+
+import pytest
+
+if sys.platform not in ("linux", "darwin"):
+    pytest.skip("Linux-only tests", allow_module_level=True)
+
 import errno
 import fcntl
 from typing import Any

--- a/tests/test_serial_linux.py
+++ b/tests/test_serial_linux.py
@@ -1,0 +1,35 @@
+"""Linux serial port tests."""
+
+import errno
+import fcntl
+from typing import Any
+from unittest.mock import ANY, call, patch
+
+from serialx.platforms.serial_posix import PosixSerial
+from tests.common import create_socat_pair
+
+TIOCSSERIAL = 0x0000541F
+TIOCGSERIAL = 0x0000541E
+
+
+@patch("serialx.platforms.serial_posix.TIOCGSERIAL", TIOCGSERIAL)
+@patch("serialx.platforms.serial_posix.TIOCSSERIAL", TIOCSSERIAL)
+def test_tiocgserial_ioctl_not_supported() -> None:
+    """Test that TIOCGSERIAL ioctl not supported is handled gracefully."""
+    ioctl_orig = fcntl.ioctl
+
+    def ioctl(fd: int, request: int, arg: Any = 0, mutate_flag: bool = True) -> None:
+        if request in (TIOCGSERIAL, TIOCSSERIAL):
+            raise OSError(errno.EOPNOTSUPP, "Not supported")
+
+        return ioctl_orig(fd, request, arg, mutate_flag)
+
+    with patch(
+        "serialx.platforms.serial_posix.fcntl.ioctl", side_effect=ioctl
+    ) as mock_ioctl:
+        with create_socat_pair() as (left, _right):
+            with PosixSerial(left, baudrate=115200):
+                # The serial port still opens
+                pass
+
+    assert call(ANY, TIOCGSERIAL, ANY) in mock_ioctl.mock_calls

--- a/tests/test_serial_linux.py
+++ b/tests/test_serial_linux.py
@@ -40,3 +40,27 @@ def test_tiocgserial_ioctl_not_supported() -> None:
                 pass
 
     assert call(ANY, TIOCGSERIAL, ANY) in mock_ioctl.mock_calls
+
+
+@patch("serialx.platforms.serial_posix.TIOCGSERIAL", TIOCGSERIAL)
+@patch("serialx.platforms.serial_posix.TIOCSSERIAL", TIOCSSERIAL)
+def test_tiocgserial_ioctl_unexpected() -> None:
+    """Test that TIOCGSERIAL ioctl not supported is handled gracefully."""
+    ioctl_orig = fcntl.ioctl
+
+    def ioctl(fd: int, request: int, arg: Any = 0, mutate_flag: bool = True) -> None:
+        if request in (TIOCGSERIAL, TIOCSSERIAL):
+            raise OSError(errno.EINVAL, "Invalid argument")
+
+        return ioctl_orig(fd, request, arg, mutate_flag)
+
+    with patch(
+        "serialx.platforms.serial_posix.fcntl.ioctl", side_effect=ioctl
+    ) as mock_ioctl:
+        with create_socat_pair() as (left, _right):
+            with pytest.raises(OSError, match="Invalid argument"):
+                with PosixSerial(left, baudrate=115200):
+                    # The serial port will fail to open
+                    pass
+
+    assert call(ANY, TIOCGSERIAL, ANY) in mock_ioctl.mock_calls

--- a/tests/test_serial_linux.py
+++ b/tests/test_serial_linux.py
@@ -4,7 +4,7 @@ import sys
 
 import pytest
 
-if sys.platform not in ("linux", "darwin"):
+if sys.platform != "linux":
     pytest.skip("Linux-only tests", allow_module_level=True)
 
 import errno


### PR DESCRIPTION
Reported here: https://github.com/home-assistant/core/issues/160495#issuecomment-3724726719