### PR TITLE
Use `abi3audit` and drop version-specific builds for Python 3.10-3.14

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -29,12 +29,16 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.22
         env:
-          CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-* cp314-*"
+          CIBW_BUILD: "cp310-*"
           CIBW_ARCHS_MACOS: "x86_64 arm64"
           CIBW_ARCHS_WINDOWS: "AMD64 x86 ARM64"
           CIBW_BEFORE_ALL_WINDOWS: "rustup target add aarch64-pc-windows-msvc i686-pc-windows-msvc"
           CIBW_BEFORE_ALL_MACOS: "rustup target add x86_64-apple-darwin aarch64-apple-darwin"
           CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=10.12"
+          # Validate abi3 compliance and repair wheels
+          CIBW_BEFORE_BUILD: "pip install abi3audit"
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: "abi3audit {wheel} && delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "abi3audit {wheel} && cp {wheel} {dest_dir}"
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -8,6 +8,12 @@ on:
     types:
       - published
   workflow_dispatch:
+  push:
+    paths:
+      - ".github/workflows/publish-to-pypi.yml"
+  pull_request:
+    paths:
+      - ".github/workflows/publish-to-pypi.yml"
 
 jobs:
   build-wheels:
@@ -41,6 +47,7 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "abi3audit {wheel} && cp {wheel} {dest_dir}"
 
       - name: Upload wheels
+        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
           name: wheels-${{ matrix.os }}
@@ -75,12 +82,14 @@ jobs:
           rm dist/*-cp*-*.whl
 
       - name: Upload sdist
+        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
           name: sdist
           path: dist/*.tar.gz
 
       - name: Upload wheel
+        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
           name: wheels-ubuntu

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name = "_serialx_rust"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.23", features = ["extension-module"] }
+pyo3 = { version = "0.23", features = ["extension-module", "abi3-py310"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,8 @@ target = "serialx._serialx_rust"
 path = "Cargo.toml"
 binding = "PyO3"
 optional = true
+
+[tool.distutils.bdist_wheel]
 py_limited_api = "cp310"
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ target = "serialx._serialx_rust"
 path = "Cargo.toml"
 binding = "PyO3"
 optional = true
+py_limited_api = "cp310"
 
 [tool.pytest.ini_options]
 addopts = "--showlocals --verbose -n auto --dist loadgroup"


### PR DESCRIPTION
This reduces CI time and the number of CI runners required to build wheels by making wheels forward-compatible for 3.10+.