### PR TITLE
Split `socket://` handling into a dedicated platform

### DIFF
--- a/serialx/__init__.py
+++ b/serialx/__init__.py
@@ -7,11 +7,19 @@ from .async_serial import (
     create_serial_connection,
     open_serial_connection,
 )
-from .common import ModemPins, Parity, PinState, SerialPortInfo, StopBits
+from .common import (
+    ModemPins,
+    Parity,
+    PinState,
+    SerialPortInfo,
+    StopBits,
+    get_serial_classes,
+)
 from .platforms import Serial, SerialTransport, list_serial_ports
 
 __all__ = [
     "create_serial_connection",
+    "get_serial_classes",
     "list_serial_ports",
     "open_serial_connection",
     "ModemPins",

--- a/serialx/async_serial.py
+++ b/serialx/async_serial.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 import logging
 from typing import Generic, TypeVar
-import urllib.parse
 
-from .common import Parity, StopBits
-from .platforms import SerialTransport
+from .common import BaseSerialTransport, Parity, StopBits, get_serial_classes
 
 LOGGER = logging.getLogger(__name__)
 
@@ -26,7 +25,7 @@ class SerialStreamWriter(asyncio.StreamWriter, Generic[_T]):
 
 async def create_serial_connection(
     loop,
-    protocol_factory,
+    protocol_factory: Callable[[], asyncio.Protocol],
     url,
     baudrate,
     parity=Parity.NONE,
@@ -34,41 +33,35 @@ async def create_serial_connection(
     xonxoff=False,
     rtscts=False,
     exclusive=True,
-    *,
-    transport_factory=SerialTransport,
     **kwargs,
-) -> tuple[SerialTransport, asyncio.Protocol]:
+) -> tuple[BaseSerialTransport, asyncio.Protocol]:
     """Create a serial port connection with asyncio."""
     if not exclusive:
         raise ValueError("Only exclusive=True is supported")
 
-    parsed_path = urllib.parse.urlparse(url)
+    _, transport_cls = await asyncio.get_running_loop().run_in_executor(
+        None, get_serial_classes, url
+    )
 
-    protocol: asyncio.Protocol
-    if parsed_path.scheme in ("socket", "tcp"):
-        transport, protocol = await loop.create_connection(
-            protocol_factory, parsed_path.hostname, parsed_path.port
-        )
-    else:
-        protocol = protocol_factory()
-        transport = transport_factory(loop=loop, protocol=protocol)
+    protocol = protocol_factory()
+    transport = transport_cls(loop=loop, protocol=protocol)
 
-        await transport.connect(
-            path=url,
-            baudrate=baudrate,
-            parity=parity,
-            stopbits=stopbits,
-            xonxoff=xonxoff,
-            rtscts=rtscts,
-            **kwargs,
-        )
+    await transport.connect(
+        path=url,
+        baudrate=baudrate,
+        parity=parity,
+        stopbits=stopbits,
+        xonxoff=xonxoff,
+        rtscts=rtscts,
+        **kwargs,
+    )
 
     return transport, protocol
 
 
 async def open_serial_connection(
     *args, **kwargs
-) -> tuple[asyncio.StreamReader, SerialStreamWriter[SerialTransport]]:
+) -> tuple[asyncio.StreamReader, SerialStreamWriter[BaseSerialTransport]]:
     """Open a serial port connection using StreamReader and StreamWriter."""
     loop = asyncio.get_running_loop()
 
@@ -77,7 +70,7 @@ async def open_serial_connection(
     transport, _ = await create_serial_connection(
         loop, lambda: protocol, *args, **kwargs
     )
-    writer: SerialStreamWriter[SerialTransport] = SerialStreamWriter(
+    writer: SerialStreamWriter[BaseSerialTransport] = SerialStreamWriter(
         transport, protocol, reader, loop
     )
 

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -10,6 +10,7 @@ import io
 import os
 from pathlib import Path
 from typing import Any
+import urllib.parse
 import warnings
 
 from typing_extensions import Self
@@ -432,6 +433,25 @@ class BaseSerialTransport(asyncio.Transport):
     async def flush(self) -> None:
         """Flush write buffers, waiting until all data is written."""
         raise NotImplementedError
+
+
+def get_serial_classes(
+    url: str,
+) -> tuple[type[BaseSerial], type[BaseSerialTransport]]:
+    """Get the appropriate serial and transport classes based on the URL scheme."""
+    parsed_path = urllib.parse.urlparse(url)
+
+    if parsed_path.scheme in ("socket", "tcp"):
+        from .platforms.serial_socket import (  # noqa: PLC0415
+            SocketSerial,
+            SocketSerialTransport,
+        )
+
+        return SocketSerial, SocketSerialTransport
+    else:
+        from .platforms import Serial, SerialTransport  # noqa: PLC0415
+
+        return Serial, SerialTransport
 
 
 @dataclasses.dataclass

--- a/serialx/platforms/serial_socket.py
+++ b/serialx/platforms/serial_socket.py
@@ -1,0 +1,186 @@
+"""Socket serial transport."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Buffer
+import logging
+from pathlib import Path
+import socket
+import urllib.parse
+
+from serialx.common import BaseSerial, BaseSerialTransport, ModemPins, Parity, StopBits
+
+LOGGER = logging.getLogger(__name__)
+
+
+class SocketSerial(BaseSerial):
+    """Synchronous serial interface over a TCP socket."""
+
+    def __init__(
+        self,
+        path: str | Path,
+        baudrate: int,
+        parity: Parity = Parity.NONE,
+        stopbits: StopBits = StopBits.ONE,
+        xonxoff: bool = False,
+        rtscts: bool = False,
+        byte_size: int = 8,
+        **kwargs,
+    ) -> None:
+        """Initialize socket serial port."""
+        super().__init__(
+            path=path,
+            baudrate=baudrate,
+            parity=parity,
+            stopbits=stopbits,
+            xonxoff=xonxoff,
+            rtscts=rtscts,
+            byte_size=byte_size,
+            **kwargs,
+        )
+
+        parsed = urllib.parse.urlparse(str(path))
+        if parsed.hostname is None or parsed.port is None:
+            raise ValueError(f"Invalid socket URI, expected both host and port: {path}")
+
+        self._host = parsed.hostname
+        self._port = parsed.port
+
+        self._socket: socket.socket | None = None
+
+    def open(self) -> None:
+        """Open the socket connection."""
+        assert self._host is not None
+        assert self._port is not None
+        self._socket = socket.create_connection((self._host, self._port))
+
+    def configure_port(self) -> None:
+        """Configure the serial port settings (no-op for sockets)."""
+
+    def _set_modem_pins(self, modem_pins: ModemPins) -> None:
+        pass
+
+    def _get_modem_pins(self) -> ModemPins:
+        return ModemPins()
+
+    def flush(self) -> None:
+        """Flush write buffers (no-op for sockets)."""
+
+    def write(self, b: Buffer) -> int:
+        """Write bytes to socket."""
+        assert self._socket is not None
+
+        data = bytes(b)
+        self._socket.sendall(data)
+        return len(data)
+
+    def readinto(self, b: Buffer) -> int:
+        """Read bytes from socket into buffer."""
+        assert self._socket is not None
+
+        m = memoryview(b).cast("B")
+        return self._socket.recv_into(m)
+
+    def close(self) -> None:
+        """Close the socket."""
+        if self._socket is not None:
+            self._socket.close()
+            self._socket = None
+
+
+class _SocketProxyProtocol(asyncio.Protocol):
+    """Bridge protocol between asyncio TCP transport and SocketSerialTransport."""
+
+    def __init__(self, serial_transport: SocketSerialTransport) -> None:
+        self._serial_transport = serial_transport
+
+    def data_received(self, data: bytes) -> None:
+        self._serial_transport._data_received(data)
+
+    def connection_lost(self, exc: Exception | None) -> None:
+        self._serial_transport._connection_lost(exc)
+
+
+class SocketSerialTransport(BaseSerialTransport):
+    """Serial transport over a TCP socket."""
+
+    transport_name = "socket"
+    _serial: SocketSerial
+
+    def __init__(
+        self, loop: asyncio.AbstractEventLoop, protocol: asyncio.Protocol
+    ) -> None:
+        """Initialize the socket serial transport."""
+        super().__init__(loop, protocol)
+        self._tcp_transport: asyncio.Transport | None = None
+
+    async def _connect(  # type: ignore[override]
+        self,
+        *,
+        url: str,
+        baudrate: int,
+        parity: Parity = Parity.NONE,
+        stopbits: StopBits = StopBits.ONE,
+        xonxoff: bool = False,
+        rtscts: bool = False,
+        byte_size: int = 8,
+        **kwargs,
+    ) -> None:
+        self._serial = SocketSerial(
+            path=url,
+            baudrate=baudrate,
+            parity=parity,
+            stopbits=stopbits,
+            xonxoff=xonxoff,
+            rtscts=rtscts,
+            byte_size=byte_size,
+        )
+
+        tcp_transport, _ = await self._loop.create_connection(
+            lambda: _SocketProxyProtocol(self),
+            host=self._serial._host,
+            port=self._serial._port,
+        )
+        self._tcp_transport = tcp_transport
+
+        self._protocol.connection_made(self)
+
+    def _data_received(self, data: bytes) -> None:
+        """Handle data received from the TCP transport."""
+        self._protocol.data_received(data)
+
+    def _connection_lost(self, exc: Exception | None) -> None:
+        """Handle connection lost from the TCP transport."""
+        if self._closing:
+            return
+        self._closing = True
+        self._tcp_transport = None
+        self._protocol.connection_lost(exc)
+
+    def write(self, data: bytes | bytearray | memoryview) -> None:
+        """Write data to the socket."""
+        assert self._tcp_transport is not None
+        self._tcp_transport.write(data)
+
+    def is_closing(self) -> bool:
+        """Return whether the transport is closing."""
+        return self._closing
+
+    def close(self) -> None:
+        """Close the transport."""
+        if self._closing:
+            return
+        self._closing = True
+
+        if self._tcp_transport is not None:
+            self._tcp_transport.close()
+
+    async def flush(self) -> None:
+        """Flush write buffers (no-op, TCP transport handles buffering)."""
+
+    def get_write_buffer_size(self) -> int:
+        """Get the number of bytes currently in the write buffer."""
+        if self._tcp_transport is not None:
+            return self._tcp_transport.get_write_buffer_size()
+        return 0

--- a/serialx/platforms/serial_socket.py
+++ b/serialx/platforms/serial_socket.py
@@ -106,6 +106,7 @@ class _SocketProxyProtocol(asyncio.Protocol):
         self._serial_transport._resume_writing()
 
     def connection_lost(self, exc: Exception | None) -> None:
+        self._serial_transport._tcp_connection_lost()
         self._serial_transport._connection_lost(exc)
 
 
@@ -121,6 +122,7 @@ class SocketSerialTransport(BaseSerialTransport):
         """Initialize the socket serial transport."""
         super().__init__(loop, protocol)
         self._tcp_transport: asyncio.Transport | None = None
+        self._tcp_connection_lost_waiter: asyncio.Future[None] | None = None
         self._connection_lost_called = False
 
     async def _connect(  # type: ignore[override]
@@ -144,6 +146,7 @@ class SocketSerialTransport(BaseSerialTransport):
             rtscts=rtscts,
             byte_size=byte_size,
         )
+        self._tcp_connection_lost_waiter = self._loop.create_future()
 
         tcp_transport, _ = await self._loop.create_connection(
             lambda: _SocketProxyProtocol(self),
@@ -154,6 +157,9 @@ class SocketSerialTransport(BaseSerialTransport):
 
         if self._connection_lost_called:
             tcp_transport.close()
+            if self._tcp_connection_lost_waiter is not None:
+                await self._tcp_connection_lost_waiter
+
             self._tcp_transport = None
             return
 
@@ -179,6 +185,14 @@ class SocketSerialTransport(BaseSerialTransport):
         self._closing = True
         self._tcp_transport = None
         self._protocol.connection_lost(exc)
+
+    def _tcp_connection_lost(self) -> None:
+        """Track the underlying TCP transport's connection_lost callback."""
+        if (
+            self._tcp_connection_lost_waiter is not None
+            and not self._tcp_connection_lost_waiter.done()
+        ):
+            self._tcp_connection_lost_waiter.set_result(None)
 
     def write(self, data: bytes | bytearray | memoryview) -> None:
         """Write data to the socket."""

--- a/serialx/platforms/serial_socket.py
+++ b/serialx/platforms/serial_socket.py
@@ -23,7 +23,7 @@ class SocketSerial(BaseSerial):
         path: str | Path,
         baudrate: int,
         parity: Parity = Parity.NONE,
-        stopbits: StopBits = StopBits.ONE,
+        stopbits: StopBits | int | float = StopBits.ONE,
         xonxoff: bool = False,
         rtscts: bool = False,
         byte_size: int = 8,

--- a/serialx/platforms/serial_socket.py
+++ b/serialx/platforms/serial_socket.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Buffer
 import logging
 from pathlib import Path
 import socket
 import urllib.parse
+
+from typing_extensions import Buffer
 
 from serialx.common import BaseSerial, BaseSerialTransport, ModemPins, Parity, StopBits
 
@@ -105,7 +106,6 @@ class _SocketProxyProtocol(asyncio.Protocol):
         self._serial_transport._resume_writing()
 
     def connection_lost(self, exc: Exception | None) -> None:
-        LOGGER.debug("Socket proxy connection lost exc=%r", exc)
         self._serial_transport._connection_lost(exc)
 
 

--- a/serialx/platforms/serial_socket.py
+++ b/serialx/platforms/serial_socket.py
@@ -129,7 +129,7 @@ class SocketSerialTransport(BaseSerialTransport):
         path: str,
         baudrate: int,
         parity: Parity = Parity.NONE,
-        stopbits: StopBits = StopBits.ONE,
+        stopbits: StopBits | int | float = StopBits.ONE,
         xonxoff: bool = False,
         rtscts: bool = False,
         byte_size: int = 8,
@@ -153,6 +153,7 @@ class SocketSerialTransport(BaseSerialTransport):
         self._tcp_transport = tcp_transport
 
         if self._connection_lost_called:
+            tcp_transport.close()
             self._tcp_transport = None
             return
 

--- a/serialx/platforms/serial_socket.py
+++ b/serialx/platforms/serial_socket.py
@@ -98,7 +98,14 @@ class _SocketProxyProtocol(asyncio.Protocol):
     def data_received(self, data: bytes) -> None:
         self._serial_transport._data_received(data)
 
+    def pause_writing(self) -> None:
+        self._serial_transport._pause_writing()
+
+    def resume_writing(self) -> None:
+        self._serial_transport._resume_writing()
+
     def connection_lost(self, exc: Exception | None) -> None:
+        LOGGER.debug("Socket proxy connection lost exc=%r", exc)
         self._serial_transport._connection_lost(exc)
 
 
@@ -114,11 +121,12 @@ class SocketSerialTransport(BaseSerialTransport):
         """Initialize the socket serial transport."""
         super().__init__(loop, protocol)
         self._tcp_transport: asyncio.Transport | None = None
+        self._connection_lost_called = False
 
     async def _connect(  # type: ignore[override]
         self,
         *,
-        url: str,
+        path: str,
         baudrate: int,
         parity: Parity = Parity.NONE,
         stopbits: StopBits = StopBits.ONE,
@@ -128,7 +136,7 @@ class SocketSerialTransport(BaseSerialTransport):
         **kwargs,
     ) -> None:
         self._serial = SocketSerial(
-            path=url,
+            path=path,
             baudrate=baudrate,
             parity=parity,
             stopbits=stopbits,
@@ -144,16 +152,29 @@ class SocketSerialTransport(BaseSerialTransport):
         )
         self._tcp_transport = tcp_transport
 
+        if self._connection_lost_called:
+            self._tcp_transport = None
+            return
+
         self._protocol.connection_made(self)
 
     def _data_received(self, data: bytes) -> None:
         """Handle data received from the TCP transport."""
         self._protocol.data_received(data)
 
+    def _pause_writing(self) -> None:
+        """Propagate backpressure from TCP transport to serial protocol."""
+        self._protocol.pause_writing()
+
+    def _resume_writing(self) -> None:
+        """Propagate resume signal from TCP transport to serial protocol."""
+        self._protocol.resume_writing()
+
     def _connection_lost(self, exc: Exception | None) -> None:
         """Handle connection lost from the TCP transport."""
-        if self._closing:
+        if self._connection_lost_called:
             return
+        self._connection_lost_called = True
         self._closing = True
         self._tcp_transport = None
         self._protocol.connection_lost(exc)
@@ -163,18 +184,30 @@ class SocketSerialTransport(BaseSerialTransport):
         assert self._tcp_transport is not None
         self._tcp_transport.write(data)
 
+    def pause_reading(self) -> None:
+        """Pause reading from the socket transport."""
+        assert self._tcp_transport is not None
+        self._tcp_transport.pause_reading()
+
+    def resume_reading(self) -> None:
+        """Resume reading from the socket transport."""
+        assert self._tcp_transport is not None
+        self._tcp_transport.resume_reading()
+
     def is_closing(self) -> bool:
         """Return whether the transport is closing."""
         return self._closing
 
     def close(self) -> None:
         """Close the transport."""
-        if self._closing:
+        if self._connection_lost_called:
             return
         self._closing = True
 
         if self._tcp_transport is not None:
             self._tcp_transport.close()
+        else:
+            self._connection_lost(None)
 
     async def flush(self) -> None:
         """Flush write buffers (no-op, TCP transport handles buffering)."""

--- a/tests/common.py
+++ b/tests/common.py
@@ -13,6 +13,7 @@ from typing import Any
 import pytest
 
 import serialx
+from serialx.common import BaseSerialTransport
 
 SOCAT_BINARY = shutil.which("socat")
 
@@ -80,7 +81,7 @@ async def async_create_reader_writer(
     port: str | None,
     **kwargs: Any,
 ) -> AsyncIterator[
-    tuple[asyncio.StreamReader, serialx.SerialStreamWriter[serialx.SerialTransport]]
+    tuple[asyncio.StreamReader, serialx.SerialStreamWriter[BaseSerialTransport]]
 ]:
     """Create a single reader/writer pair."""
 
@@ -104,9 +105,9 @@ async def async_create_reader_writer_pair(
 ) -> AsyncIterator[
     tuple[
         asyncio.StreamReader,
-        serialx.SerialStreamWriter[serialx.SerialTransport],
+        serialx.SerialStreamWriter[BaseSerialTransport],
         asyncio.StreamReader,
-        serialx.SerialStreamWriter[serialx.SerialTransport],
+        serialx.SerialStreamWriter[BaseSerialTransport],
     ]
 ]:
     """Create reader/writer pairs for both sides of a socat connection.
@@ -133,9 +134,9 @@ async def async_create_dual_loopback(
 ) -> AsyncIterator[
     tuple[
         asyncio.StreamReader,
-        serialx.SerialStreamWriter[serialx.SerialTransport],
+        serialx.SerialStreamWriter[BaseSerialTransport],
         asyncio.StreamReader,
-        serialx.SerialStreamWriter[serialx.SerialTransport],
+        serialx.SerialStreamWriter[BaseSerialTransport],
     ]
 ]:
     """Create reader/writer pairs for dual loopback configuration.

--- a/tests/test_socket_async.py
+++ b/tests/test_socket_async.py
@@ -71,14 +71,23 @@ async def async_create_socket_pair() -> AsyncIterator[tuple[str, str]]:
                 if data is None:
                     return
 
-                writer.write(data)
-                await writer.drain()
-                LOGGER.debug(
-                    "forwarded %d bytes from %s to %s",
-                    len(data),
-                    peer_side,
-                    side,
-                )
+                try:
+                    writer.write(data)
+                    await writer.drain()
+                    LOGGER.debug(
+                        "forwarded %d bytes from %s to %s",
+                        len(data),
+                        peer_side,
+                        side,
+                    )
+                except (BrokenPipeError, ConnectionResetError, OSError):
+                    LOGGER.debug(
+                        "failed forwarding bytes from %s to %s",
+                        peer_side,
+                        side,
+                        exc_info=True,
+                    )
+                    return
 
         read_task = asyncio.create_task(reader_to_queue())
         write_task = asyncio.create_task(queue_to_writer())
@@ -95,6 +104,10 @@ async def async_create_socket_pair() -> AsyncIterator[tuple[str, str]]:
             await asyncio.gather(*pending, return_exceptions=True)
             await asyncio.gather(*done, return_exceptions=True)
         finally:
+            for relay_task in (read_task, write_task):
+                if not relay_task.done():
+                    relay_task.cancel()
+            await asyncio.gather(read_task, write_task, return_exceptions=True)
             writer.close()
             with contextlib.suppress(
                 ConnectionResetError,

--- a/tests/test_socket_async.py
+++ b/tests/test_socket_async.py
@@ -213,12 +213,15 @@ async def test_transport_close_before_connect_completes_async() -> None:
         def __init__(self) -> None:
             self.connection_made_calls = 0
             self.connection_lost_calls = 0
+            self.connection_lost_future = asyncio.get_running_loop().create_future()
 
         def connection_made(self, transport: asyncio.BaseTransport) -> None:
             self.connection_made_calls += 1
 
         def connection_lost(self, exc: Exception | None) -> None:
             self.connection_lost_calls += 1
+            if not self.connection_lost_future.done():
+                self.connection_lost_future.set_result(None)
 
     async with async_create_socket_pair() as (left, _right):
         loop = asyncio.get_running_loop()
@@ -230,6 +233,7 @@ async def test_transport_close_before_connect_completes_async() -> None:
         )
         transport.close()
         await connect_task
+        await asyncio.wait_for(protocol.connection_lost_future, timeout=5)
         await asyncio.sleep(0)
 
         # connection_made should never fire in this race path.
@@ -251,10 +255,17 @@ async def test_transport_backpressure_callbacks_async() -> None:
     output_resume_count = 0
 
     async with async_create_socket_pair(relay_read_delay=0.001) as (in_tty, out_tty):
+        loop = asyncio.get_running_loop()
+        input_lost = loop.create_future()
+        output_lost = loop.create_future()
 
         class Input(asyncio.Protocol):
             def data_received(self, data: bytes) -> None:
                 return
+
+            def connection_lost(self, exc: Exception | None) -> None:
+                if not input_lost.done():
+                    input_lost.set_result(None)
 
         class Output(asyncio.Protocol):
             _transport: SocketSerialTransport
@@ -271,7 +282,10 @@ async def test_transport_backpressure_callbacks_async() -> None:
                 nonlocal output_resume_count
                 output_resume_count += 1
 
-        loop = asyncio.get_running_loop()
+            def connection_lost(self, exc: Exception | None) -> None:
+                if not output_lost.done():
+                    output_lost.set_result(None)
+
         in_transport, _ = await create_serial_connection(
             loop, Input, in_tty, baudrate=115200
         )
@@ -294,6 +308,7 @@ async def test_transport_backpressure_callbacks_async() -> None:
 
         out_transport.close()
         in_transport.close()
+        await asyncio.gather(input_lost, output_lost)
 
 
 async def test_transport_close_is_idempotent_async() -> None:
@@ -771,6 +786,9 @@ async def test_remove_writer() -> None:
     COUNT = 8 * 1024
     output_resume_event = asyncio.Event()
     data_received_count = 0
+    loop = asyncio.get_running_loop()
+    input_lost = loop.create_future()
+    output_lost = loop.create_future()
 
     async with async_create_socket_pair() as (in_tty, out_tty):
 
@@ -785,6 +803,10 @@ async def test_remove_writer() -> None:
                 nonlocal data_received_count
                 data_received_count += len(data)
                 self._transport.write(data)
+
+            def connection_lost(self, exc: Exception | None) -> None:
+                if not input_lost.done():
+                    input_lost.set_result(None)
 
         class Output(asyncio.Protocol):
             """Provides backpressure to writer via output_resume_event."""
@@ -802,7 +824,9 @@ async def test_remove_writer() -> None:
             def resume_writing(self) -> None:
                 output_resume_event.set()
 
-        loop = asyncio.get_running_loop()
+            def connection_lost(self, exc: Exception | None) -> None:
+                if not output_lost.done():
+                    output_lost.set_result(None)
 
         in_transport, _ = await create_serial_connection(
             loop, Input, in_tty, baudrate=115200
@@ -831,6 +855,7 @@ async def test_remove_writer() -> None:
 
         out_transport.close()
         in_transport.close()
+        await asyncio.gather(input_lost, output_lost)
 
 
 async def test_pause_resume() -> None:

--- a/tests/test_socket_async.py
+++ b/tests/test_socket_async.py
@@ -1,0 +1,713 @@
+"""Test async APIs with socket:// endpoints."""
+
+import asyncio
+from collections.abc import AsyncIterator
+import contextlib
+import logging
+import os
+import sys
+
+if sys.version_info >= (3, 11):
+    from asyncio import timeout as asyncio_timeout
+else:
+    from async_timeout import timeout as asyncio_timeout
+
+import pytest
+
+from serialx import (
+    ModemPins,
+    Parity,
+    PinState,
+    StopBits,
+    create_serial_connection,
+    get_serial_classes,
+)
+from serialx.platforms.serial_socket import SocketSerial, SocketSerialTransport
+from tests.common import async_create_reader_writer, async_create_reader_writer_pair
+
+LOGGER = logging.getLogger(__name__)
+
+
+@contextlib.asynccontextmanager
+async def async_create_socket_pair() -> AsyncIterator[tuple[str, str]]:
+    """Create two socket:// endpoints backed by a bidirectional relay."""
+    left_to_right: asyncio.Queue[bytes | None] = asyncio.Queue()
+    right_to_left: asyncio.Queue[bytes | None] = asyncio.Queue()
+    handler_tasks: set[asyncio.Task[None]] = set()
+
+    async def handle_client(
+        side: str,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        task = asyncio.current_task()
+        assert task is not None
+        handler_tasks.add(task)
+
+        peer_side = "right" if side == "left" else "left"
+        LOGGER.debug("accepted %s client connection", side)
+        outbound_queue = left_to_right if side == "left" else right_to_left
+        inbound_queue = right_to_left if side == "left" else left_to_right
+
+        async def reader_to_queue() -> None:
+            try:
+                while data := await reader.read(4096):
+                    await outbound_queue.put(data)
+                    LOGGER.debug(
+                        "queued %d bytes from %s to %s",
+                        len(data),
+                        side,
+                        peer_side,
+                    )
+            except (BrokenPipeError, ConnectionResetError):
+                LOGGER.debug("%s client disconnected abruptly", side)
+            finally:
+                await outbound_queue.put(None)
+                LOGGER.debug("%s client reached EOF", side)
+
+        async def queue_to_writer() -> None:
+            while True:
+                data = await inbound_queue.get()
+                if data is None:
+                    return
+
+                writer.write(data)
+                await writer.drain()
+                LOGGER.debug(
+                    "forwarded %d bytes from %s to %s",
+                    len(data),
+                    peer_side,
+                    side,
+                )
+
+        read_task = asyncio.create_task(reader_to_queue())
+        write_task = asyncio.create_task(queue_to_writer())
+
+        try:
+            done, pending = await asyncio.wait(
+                {read_task, write_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+
+            for pending_task in pending:
+                pending_task.cancel()
+
+            await asyncio.gather(*pending, return_exceptions=True)
+            await asyncio.gather(*done, return_exceptions=True)
+        finally:
+            writer.close()
+            with contextlib.suppress(
+                ConnectionResetError,
+                BrokenPipeError,
+                OSError,
+                asyncio.CancelledError,
+            ):
+                await writer.wait_closed()
+            handler_tasks.discard(task)
+            LOGGER.debug("closed %s client connection", side)
+
+    left_server = await asyncio.start_server(
+        lambda reader, writer: handle_client("left", reader, writer),
+        host="127.0.0.1",
+        port=0,
+    )
+    right_server = await asyncio.start_server(
+        lambda reader, writer: handle_client("right", reader, writer),
+        host="127.0.0.1",
+        port=0,
+    )
+
+    left_socket_info = left_server.sockets
+    right_socket_info = right_server.sockets
+    assert left_socket_info is not None and left_socket_info
+    assert right_socket_info is not None and right_socket_info
+
+    left_url = f"socket://127.0.0.1:{left_socket_info[0].getsockname()[1]}"
+    right_url = f"socket://127.0.0.1:{right_socket_info[0].getsockname()[1]}"
+    LOGGER.debug("started socket pair server left=%s right=%s", left_url, right_url)
+
+    try:
+        yield (left_url, right_url)
+    finally:
+        left_server.close()
+        right_server.close()
+        await asyncio.gather(left_server.wait_closed(), right_server.wait_closed())
+
+        if handler_tasks:
+            for task in list(handler_tasks):
+                task.cancel()
+            await asyncio.gather(*handler_tasks, return_exceptions=True)
+
+        LOGGER.debug("stopped socket pair servers")
+
+
+async def test_all_bytes_async() -> None:
+    """Test that all bytes 0-255 can be transmitted."""
+    async with (
+        async_create_socket_pair() as (left, right),
+        async_create_reader_writer_pair(left, right, baudrate=115200) as (
+            reader_left,
+            writer_left,
+            reader_right,
+            writer_right,
+        ),
+    ):
+        # Create a byte array with all possible byte values
+        data = bytes(range(256))
+
+        writer_left.write(data)
+        result = await reader_right.readexactly(len(data))
+
+        assert result == data
+
+
+def test_socket_url_uses_dedicated_socket_platform() -> None:
+    """Test socket:// uses dedicated socket serial and transport classes."""
+    serial_cls, transport_cls = get_serial_classes("socket://127.0.0.1:12345")
+
+    assert serial_cls is SocketSerial
+    assert transport_cls is SocketSerialTransport
+
+
+async def test_segmented_binary_data_async() -> None:
+    """Test binary data sent in segments."""
+    async with (
+        async_create_socket_pair() as (left, right),
+        async_create_reader_writer_pair(left, right, baudrate=115200) as (
+            reader_left,
+            writer_left,
+            reader_right,
+            writer_right,
+        ),
+    ):
+        # Send all bytes in smaller segments
+        segment_size = 16
+        data = bytes(range(256))
+
+        for i in range(0, 256, segment_size):
+            segment = data[i : i + segment_size]
+            writer_left.write(segment)
+            result = await reader_right.readexactly(len(segment))
+            assert result == segment
+
+
+@pytest.mark.parametrize(
+    "size",
+    [1, 16, 64, 256, 512, 1024],
+)
+async def test_binary_payload_sizes_async(size: int) -> None:
+    """Test various binary payload sizes."""
+    async with (
+        async_create_socket_pair() as (left, right),
+        async_create_reader_writer_pair(left, right, baudrate=115200) as (
+            reader_left,
+            writer_left,
+            reader_right,
+            writer_right,
+        ),
+    ):
+        # Create binary data with repeating pattern
+        data = bytes([i % 256 for i in range(size)])
+
+        writer_left.write(data)
+        result = await reader_right.readexactly(len(data))
+
+        assert result == data
+
+
+async def test_null_bytes_async() -> None:
+    """Test that null bytes (0x00) can be transmitted."""
+    async with (
+        async_create_socket_pair() as (left, right),
+        async_create_reader_writer_pair(left, right, baudrate=115200) as (
+            reader_left,
+            writer_left,
+            reader_right,
+            writer_right,
+        ),
+    ):
+        # Send a bunch of null bytes
+        null_data = b"\x00" * 64
+
+        writer_left.write(null_data)
+        result = await reader_right.readexactly(len(null_data))
+
+        assert result == null_data
+
+
+async def test_overlapping_read_write_async() -> None:
+    """Test that read and write can overlap, data is buffered."""
+    async with (
+        async_create_socket_pair() as (left, right),
+        async_create_reader_writer_pair(left, right, baudrate=115200) as (
+            reader_left,
+            writer_left,
+            reader_right,
+            writer_right,
+        ),
+    ):
+        data = bytes(range(256))
+        read = b""
+
+        writer_left.write(data[:100])
+        read += await reader_right.readexactly(10)
+        writer_left.write(data[100:150])
+        read += await reader_right.readexactly(10)
+        writer_left.write(data[150:])
+        read += await reader_right.readexactly(10)
+        read += await reader_right.readexactly(256 - 30)
+
+        assert read == data
+
+
+@pytest.mark.parametrize(
+    ("baudrate", "chunk_size"),
+    [
+        (9600, 1),
+        (9600, 16),
+        (115200, 1),
+        (115200, 16),
+        (115200, 64),
+        (921600, 1),
+        (921600, 16),
+        (921600, 256),
+        (921600, 1024),
+    ],
+)
+async def test_random_large_async(baudrate: int, chunk_size: int) -> None:
+    """Test random read/write at various speeds."""
+    async with (
+        async_create_socket_pair() as (left, right),
+        async_create_reader_writer_pair(left, right, baudrate=baudrate) as (
+            reader_left,
+            writer_left,
+            reader_right,
+            writer_right,
+        ),
+    ):
+        data = os.urandom(chunk_size)
+        writer_left.write(data)
+
+        read_data = await reader_right.readexactly(chunk_size)
+        assert read_data == data
+
+
+@pytest.mark.parametrize(
+    "iterations",
+    [16, 32, 64],
+)
+async def test_repeated_write_read_cycles_async(iterations: int) -> None:
+    """Test repeated write/read cycles."""
+    async with (
+        async_create_socket_pair() as (left, right),
+        async_create_reader_writer_pair(left, right, baudrate=115200) as (
+            reader_left,
+            writer_left,
+            reader_right,
+            writer_right,
+        ),
+    ):
+        data = bytes(range(256))
+
+        for _i in range(iterations):
+            writer_left.write(data)
+            result = await reader_right.readexactly(len(data))
+            assert result == data
+
+
+async def test_buffered_writes_then_read_async() -> None:
+    """Test multiple writes followed by a single read."""
+    async with (
+        async_create_socket_pair() as (left, right),
+        async_create_reader_writer_pair(left, right, baudrate=115200) as (
+            reader_left,
+            writer_left,
+            reader_right,
+            writer_right,
+        ),
+    ):
+        chunk = bytes(range(256))
+        iterations = 4
+
+        # Write multiple chunks
+        for _ in range(iterations):
+            writer_left.write(chunk)
+
+        # Read all data back
+        total_size = len(chunk) * iterations
+        result = await reader_right.readexactly(total_size)
+
+        # Verify all data was received correctly
+        expected = chunk * iterations
+        assert result == expected
+
+
+@pytest.mark.parametrize(
+    "payload_size",
+    [1024, 2048],  # Kernel buffers are typically ~4KB, stay well below that
+)
+async def test_large_payload_async(payload_size: int) -> None:
+    """Test large payload transmission."""
+    async with (
+        async_create_socket_pair() as (left, right),
+        async_create_reader_writer_pair(left, right, baudrate=921600) as (
+            reader_left,
+            writer_left,
+            reader_right,
+            writer_right,
+        ),
+    ):
+        data = bytes([i % 256 for i in range(payload_size)])
+
+        writer_left.write(data)
+        result = await reader_right.readexactly(len(data))
+
+        assert result == data
+
+
+async def test_rapid_small_writes_async() -> None:
+    """Test rapid succession of small writes."""
+    async with (
+        async_create_socket_pair() as (left, right),
+        async_create_reader_writer_pair(left, right, baudrate=115200) as (
+            reader_left,
+            writer_left,
+            reader_right,
+            writer_right,
+        ),
+    ):
+        # Send many small writes
+        iterations = 256
+        received = bytearray()
+
+        for i in range(iterations):
+            data = bytes([i % 256])
+            writer_left.write(data)
+            result = await reader_right.readexactly(1)
+            received.extend(result)
+
+        # Verify all bytes were received in order
+        expected = bytes([i % 256 for i in range(iterations)])
+        assert bytes(received) == expected
+
+
+@pytest.mark.parametrize(
+    ("baudrate", "iterations"),
+    [
+        (9600, 8),
+        (115200, 64),
+        (921600, 512),
+    ],
+)
+async def test_sustained_throughput_async(baudrate: int, iterations: int) -> None:
+    """Test sustained data throughput at various baudrates."""
+    async with (
+        async_create_socket_pair() as (left, right),
+        async_create_reader_writer_pair(left, right, baudrate=baudrate) as (
+            reader_left,
+            writer_left,
+            reader_right,
+            writer_right,
+        ),
+    ):
+        chunk = os.urandom(1024)
+
+        for _ in range(iterations):
+            writer_left.write(chunk)
+            result = await reader_right.readexactly(len(chunk))
+            assert result == chunk
+
+
+@pytest.mark.parametrize(
+    "baudrate",
+    [9600, 19200, 38400, 57600, 115200, 230400, 460800, 921600],
+)
+async def test_valid_baudrates_async(baudrate: int) -> None:
+    """Test that valid baudrates are accepted."""
+    async with (
+        async_create_socket_pair() as (left, right),
+        async_create_reader_writer(left, baudrate=baudrate) as (reader, writer),
+    ):
+        # Verify baudrate was set (check transport)
+        assert writer.transport.baudrate == baudrate
+        writer.write(b"test")
+
+
+@pytest.mark.parametrize(
+    "parity",
+    [Parity.NONE, Parity.ODD, Parity.EVEN, Parity.MARK, Parity.SPACE],
+)
+async def test_valid_parity_async(parity: Parity) -> None:
+    """Test that valid parity settings are accepted."""
+    async with (
+        async_create_socket_pair() as (left, right),
+        async_create_reader_writer(left, baudrate=115200, parity=parity) as (
+            reader,
+            writer,
+        ),
+    ):
+        assert writer.transport.parity == parity
+        writer.write(b"test")
+
+
+@pytest.mark.parametrize(
+    ("stopbits", "expected"),
+    [
+        (StopBits.ONE, StopBits.ONE),
+        (StopBits.ONE_POINT_FIVE, StopBits.ONE_POINT_FIVE),
+        (StopBits.TWO, StopBits.TWO),
+        (1, StopBits.ONE),
+        (1.5, StopBits.ONE_POINT_FIVE),
+        (2, StopBits.TWO),
+    ],
+)
+async def test_valid_stopbits_async(
+    stopbits: StopBits | int | float,
+    expected: StopBits,
+) -> None:
+    """Test that valid stopbits settings are accepted."""
+    async with (
+        async_create_socket_pair() as (left, right),
+        async_create_reader_writer(left, baudrate=115200, stopbits=stopbits) as (
+            reader,
+            writer,
+        ),
+    ):
+        assert writer.transport.stopbits == expected
+        writer.write(b"test")
+
+
+@pytest.mark.parametrize("byte_size", [5, 6, 7, 8])
+async def test_valid_byte_size_async(byte_size: int) -> None:
+    """Test that valid byte sizes are accepted."""
+    async with (
+        async_create_socket_pair() as (left, right),
+        async_create_reader_writer(left, baudrate=115200, byte_size=byte_size) as (
+            reader,
+            writer,
+        ),
+    ):
+        writer.write(b"test")
+
+
+@pytest.mark.parametrize("xonxoff", [True, False])
+async def test_xonxoff_setting_async(xonxoff: bool) -> None:
+    """Test that xonxoff setting is accepted."""
+    async with (
+        async_create_socket_pair() as (left, right),
+        async_create_reader_writer(left, baudrate=115200, xonxoff=xonxoff) as (
+            reader,
+            writer,
+        ),
+    ):
+        writer.write(b"test")
+
+
+@pytest.mark.parametrize(
+    "rtscts",
+    [True, False],
+)
+async def test_rtscts_setting_async(rtscts: bool) -> None:
+    """Test that rtscts setting is accepted."""
+    async with (
+        async_create_socket_pair() as (left, right),
+        async_create_reader_writer(left, baudrate=115200, rtscts=rtscts) as (
+            reader,
+            writer,
+        ),
+    ):
+        writer.write(b"test")
+
+
+async def test_concurrent_writes_async() -> None:
+    """Test concurrent writes from multiple tasks."""
+    async with (
+        async_create_socket_pair() as (left, right),
+        async_create_reader_writer_pair(left, right, baudrate=115200) as (
+            reader_left,
+            writer_left,
+            reader_right,
+            writer_right,
+        ),
+    ):
+
+        async def write_data(data: bytes) -> None:
+            writer_left.write(data)
+
+        # Write different data concurrently
+        data1 = b"A" * 100
+        data2 = b"B" * 100
+        data3 = b"C" * 100
+
+        await asyncio.gather(
+            write_data(data1),
+            write_data(data2),
+            write_data(data3),
+        )
+
+        # Read all data back
+        total_data = await reader_right.readexactly(300)
+        assert total_data == b"A" * 100 + b"B" * 100 + b"C" * 100
+
+
+async def test_read_with_timeout_async() -> None:
+    """Test reading with timeout."""
+    async with (
+        async_create_socket_pair() as (left, right),
+        async_create_reader_writer_pair(left, right, baudrate=115200) as (
+            reader_left,
+            writer_left,
+            reader_right,
+            writer_right,
+        ),
+    ):
+        # Write some data
+        writer_left.write(b"test")
+
+        # Read with timeout should succeed
+        result = await asyncio.wait_for(reader_right.readexactly(4), timeout=1.0)
+        assert result == b"test"
+
+        # Reading without data should timeout
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(reader_right.readexactly(1), timeout=0.1)
+
+
+async def test_get_modem_pins_async() -> None:
+    """Test reading modem control bits."""
+    async with (
+        async_create_socket_pair() as (left, right),
+        async_create_reader_writer(left, baudrate=115200) as (reader, writer),
+    ):
+        modem_pins = await writer.transport.get_modem_pins()
+
+        # Verify we get a ModemPins object
+        assert isinstance(modem_pins, ModemPins)
+
+        # All modem pins should be PinState enum values
+        for field in ["le", "dtr", "rts", "st", "sr", "cts", "car", "rng", "dsr"]:
+            value = getattr(modem_pins, field)
+            assert value in (PinState.HIGH, PinState.LOW, PinState.UNDEFINED)
+
+
+async def test_set_modem_pins_async() -> None:
+    """Test setting modem control bits with socat pair."""
+    async with (
+        async_create_socket_pair() as (left, right),
+        async_create_reader_writer(left, baudrate=115200) as (reader, writer),
+    ):
+        # Note: socat pairs don't support modem control signals properly
+        # These calls should not raise errors, but values may be None
+        await writer.transport.set_modem_pins(dtr=True, rts=True)
+        modem_pins = await writer.transport.get_modem_pins()
+        # Verify we get a ModemPins object, values may be None with socat
+        assert isinstance(modem_pins, ModemPins)
+
+        await writer.transport.set_modem_pins(dtr=False)
+        modem_pins = await writer.transport.get_modem_pins()
+        assert isinstance(modem_pins, ModemPins)
+
+        await writer.transport.set_modem_pins(dtr=False, rts=False)
+        modem_pins = await writer.transport.get_modem_pins()
+        assert isinstance(modem_pins, ModemPins)
+
+
+# Source: https://github.com/home-assistant-libs/pyserial-asyncio-fast/pull/36
+async def test_remove_writer() -> None:
+    """Test that large writes with backpressure are handled correctly.
+
+    This test catches three issue categories:
+    1. AssertionError from writer not being removed when buffer empties
+    2. Deadlock (via timeout) from direct writes blocking indefinitely
+    3. Timing failures from writer not being added when buffering data
+    """
+    TEXT = b"Hello, World!"
+    COUNT = 8 * 1024
+    output_resume_event = asyncio.Event()
+    data_received_count = 0
+
+    async with async_create_socket_pair() as (in_tty, out_tty):
+
+        class Input(asyncio.Protocol):
+            _transport: SocketSerialTransport
+
+            def connection_made(self, transport: asyncio.BaseTransport) -> None:
+                assert isinstance(transport, SocketSerialTransport)
+                self._transport = transport
+
+            def data_received(self, data: bytes) -> None:
+                nonlocal data_received_count
+                data_received_count += len(data)
+                self._transport.write(data)
+
+        class Output(asyncio.Protocol):
+            """Provides backpressure to writer via output_resume_event."""
+
+            _transport: SocketSerialTransport
+
+            def connection_made(self, transport: asyncio.BaseTransport) -> None:
+                assert isinstance(transport, SocketSerialTransport)
+                self._transport = transport
+                output_resume_event.set()
+
+            def pause_writing(self) -> None:
+                output_resume_event.clear()
+
+            def resume_writing(self) -> None:
+                output_resume_event.set()
+
+        loop = asyncio.get_running_loop()
+
+        in_transport, _ = await create_serial_connection(
+            loop, Input, in_tty, baudrate=115200
+        )
+        out_transport, _ = await create_serial_connection(
+            loop, Output, out_tty, baudrate=115200
+        )
+        await asyncio.sleep(0)
+
+        # Write a bunch of data so that we create a buffer and trigger backpressure
+        for i in range(COUNT):
+            async with asyncio_timeout(5):
+                await output_resume_event.wait()
+
+            out_transport.write(TEXT)
+            if i % 128 == 0:
+                await asyncio.sleep(0)
+
+        # Ensure that the write buffer eventually drains completely
+        async with asyncio_timeout(5):
+            while out_transport.get_write_buffer_size() > 0:
+                await asyncio.sleep(0.1)
+
+        # Verify we received some data on the input side
+        assert data_received_count > 0
+
+        out_transport.close()
+        in_transport.close()
+
+
+async def test_pause_resume() -> None:
+    """Test transport pause and resume."""
+
+    async with (
+        async_create_socket_pair() as (left, right),
+        async_create_reader_writer_pair(left, right, baudrate=115200) as (
+            reader_left,
+            writer_left,
+            reader_right,
+            writer_right,
+        ),
+    ):
+        writer_left.transport.pause_reading()
+
+        writer_right.write(b"A long message")
+        await writer_right.drain()
+
+        # Nothing can be read
+        with pytest.raises(asyncio.TimeoutError):
+            async with asyncio_timeout(1):
+                await reader_left.read(1)
+
+        writer_left.transport.resume_reading()
+        assert (await reader_left.read(14)) == b"A long message"

--- a/tests/test_socket_async.py
+++ b/tests/test_socket_async.py
@@ -193,6 +193,58 @@ def test_socket_url_uses_dedicated_socket_platform() -> None:
     assert transport_cls is SocketSerialTransport
 
 
+async def test_invalid_socket_uri_async() -> None:
+    """Test invalid socket URI is rejected by public async API."""
+    loop = asyncio.get_running_loop()
+
+    with pytest.raises(ValueError, match="expected both host and port"):
+        await create_serial_connection(
+            loop,
+            asyncio.Protocol,
+            "socket://127.0.0.1",
+            baudrate=115200,
+        )
+
+
+async def test_transport_close_before_connect_completes_async() -> None:
+    """Test close-before-connect race is handled without duplicate callbacks."""
+
+    class ProbeProtocol(asyncio.Protocol):
+        def __init__(self) -> None:
+            self.connection_made_calls = 0
+            self.connection_lost_calls = 0
+
+        def connection_made(self, transport: asyncio.BaseTransport) -> None:
+            self.connection_made_calls += 1
+
+        def connection_lost(self, exc: Exception | None) -> None:
+            self.connection_lost_calls += 1
+
+    async with async_create_socket_pair() as (left, _right):
+        loop = asyncio.get_running_loop()
+        protocol = ProbeProtocol()
+        transport = SocketSerialTransport(loop, protocol)
+
+        connect_task = asyncio.create_task(
+            transport.connect(path=left, baudrate=115200)
+        )
+        transport.close()
+        await connect_task
+        await asyncio.sleep(0)
+
+        # connection_made should never fire in this race path.
+        assert protocol.connection_made_calls == 0
+        # close-before-connect should notify connection_lost exactly once.
+        assert protocol.connection_lost_calls == 1
+        assert transport.is_closing() is True
+        assert transport.get_write_buffer_size() == 0
+
+        # Additional closes are idempotent after connection_lost.
+        transport.close()
+        await asyncio.sleep(0)
+        assert protocol.connection_lost_calls == 1
+
+
 async def test_transport_backpressure_callbacks_async() -> None:
     """Test backpressure pause/resume callbacks through public async APIs."""
     output_pause_count = 0

--- a/tests/test_socket_async.py
+++ b/tests/test_socket_async.py
@@ -29,7 +29,9 @@ LOGGER = logging.getLogger(__name__)
 
 
 @contextlib.asynccontextmanager
-async def async_create_socket_pair() -> AsyncIterator[tuple[str, str]]:
+async def async_create_socket_pair(
+    relay_read_delay: float = 0.0,
+) -> AsyncIterator[tuple[str, str]]:
     """Create two socket:// endpoints backed by a bidirectional relay."""
     left_to_right: asyncio.Queue[bytes | None] = asyncio.Queue()
     right_to_left: asyncio.Queue[bytes | None] = asyncio.Queue()
@@ -59,6 +61,8 @@ async def async_create_socket_pair() -> AsyncIterator[tuple[str, str]]:
                         side,
                         peer_side,
                     )
+                    if relay_read_delay > 0:
+                        await asyncio.sleep(relay_read_delay)
             except (BrokenPipeError, ConnectionResetError):
                 LOGGER.debug("%s client disconnected abruptly", side)
             finally:
@@ -142,14 +146,16 @@ async def async_create_socket_pair() -> AsyncIterator[tuple[str, str]]:
     try:
         yield (left_url, right_url)
     finally:
+        wait_closed_coros = []
         for server in (left_server, right_server):
             try:
                 server.close()
             except OSError:  # noqa: PERF203
                 continue
+            wait_closed_coros.append(server.wait_closed())
 
-        await left_server.wait_closed()
-        await right_server.wait_closed()
+        if wait_closed_coros:
+            await asyncio.gather(*wait_closed_coros)
 
         if handler_tasks:
             for task in list(handler_tasks):
@@ -185,6 +191,76 @@ def test_socket_url_uses_dedicated_socket_platform() -> None:
 
     assert serial_cls is SocketSerial
     assert transport_cls is SocketSerialTransport
+
+
+async def test_transport_backpressure_callbacks_async() -> None:
+    """Test backpressure pause/resume callbacks through public async APIs."""
+    output_pause_count = 0
+    output_resume_count = 0
+
+    async with async_create_socket_pair(relay_read_delay=0.001) as (in_tty, out_tty):
+
+        class Input(asyncio.Protocol):
+            def data_received(self, data: bytes) -> None:
+                return
+
+        class Output(asyncio.Protocol):
+            _transport: SocketSerialTransport
+
+            def connection_made(self, transport: asyncio.BaseTransport) -> None:
+                assert isinstance(transport, SocketSerialTransport)
+                self._transport = transport
+
+            def pause_writing(self) -> None:
+                nonlocal output_pause_count
+                output_pause_count += 1
+
+            def resume_writing(self) -> None:
+                nonlocal output_resume_count
+                output_resume_count += 1
+
+        loop = asyncio.get_running_loop()
+        in_transport, _ = await create_serial_connection(
+            loop, Input, in_tty, baudrate=115200
+        )
+        out_transport, _ = await create_serial_connection(
+            loop, Output, out_tty, baudrate=115200
+        )
+        await asyncio.sleep(0)
+
+        payload = b"X" * 65536
+        for _ in range(64):
+            out_transport.write(payload)
+
+        async with asyncio_timeout(10):
+            while out_transport.get_write_buffer_size() > 0:
+                await asyncio.sleep(0.05)
+
+        await asyncio.sleep(0.1)
+        assert output_pause_count > 0
+        assert output_resume_count > 0
+
+        out_transport.close()
+        in_transport.close()
+
+
+async def test_transport_close_is_idempotent_async() -> None:
+    """Test closing socket writer multiple times is safe and drains buffer state."""
+    async with (
+        async_create_socket_pair() as (left, right),
+        async_create_reader_writer_pair(left, right, baudrate=115200) as (
+            reader_left,
+            writer_left,
+            reader_right,
+            writer_right,
+        ),
+    ):
+        writer_left.close()
+        await writer_left.wait_closed()
+        assert writer_left.transport.get_write_buffer_size() == 0
+
+        writer_left.close()
+        await writer_left.wait_closed()
 
 
 async def test_segmented_binary_data_async() -> None:

--- a/tests/test_socket_async.py
+++ b/tests/test_socket_async.py
@@ -129,9 +129,14 @@ async def async_create_socket_pair() -> AsyncIterator[tuple[str, str]]:
     try:
         yield (left_url, right_url)
     finally:
-        left_server.close()
-        right_server.close()
-        await asyncio.gather(left_server.wait_closed(), right_server.wait_closed())
+        for server in (left_server, right_server):
+            try:
+                server.close()
+            except OSError:  # noqa: PERF203
+                continue
+
+        await left_server.wait_closed()
+        await right_server.wait_closed()
 
         if handler_tasks:
             for task in list(handler_tasks):

--- a/tests/test_socket_sync.py
+++ b/tests/test_socket_sync.py
@@ -1,0 +1,718 @@
+"""Test sync APIs with socket:// endpoints."""
+
+from collections.abc import Iterator
+import contextlib
+import logging
+import os
+import queue
+import socket
+import threading
+import time
+
+import pytest
+
+from serialx import ModemPins, Parity, PinState, StopBits, get_serial_classes
+from serialx.platforms.serial_socket import SocketSerial, SocketSerialTransport
+
+LOGGER = logging.getLogger(__name__)
+
+
+class _SocketPairRelay:
+    def __init__(self) -> None:
+        self.left_to_right: queue.Queue[bytes] = queue.Queue()
+        self.right_to_left: queue.Queue[bytes] = queue.Queue()
+        self.stop_event = threading.Event()
+        self.active_connections: dict[str, socket.socket | None] = {
+            "left": None,
+            "right": None,
+        }
+        self.active_lock = threading.Lock()
+        self.relay_threads: list[threading.Thread] = []
+        self.left_server = self._make_server()
+        self.right_server = self._make_server()
+        self.left_url = f"socket://127.0.0.1:{self.left_server.getsockname()[1]}"
+        self.right_url = f"socket://127.0.0.1:{self.right_server.getsockname()[1]}"
+
+    @staticmethod
+    def _close_socket(sock: socket.socket | None) -> None:
+        if sock is None:
+            return
+        with contextlib.suppress(OSError):
+            sock.shutdown(socket.SHUT_RDWR)
+        with contextlib.suppress(OSError):
+            sock.close()
+
+    @staticmethod
+    def _make_server() -> socket.socket:
+        server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        server.bind(("127.0.0.1", 0))
+        server.listen()
+        server.settimeout(0.1)
+        return server
+
+    def _set_active_connection(self, side: str, conn: socket.socket) -> None:
+        with self.active_lock:
+            previous = self.active_connections[side]
+            self.active_connections[side] = conn
+        if previous is not conn:
+            self._close_socket(previous)
+
+    def _clear_active_connection(self, side: str, conn: socket.socket) -> None:
+        with self.active_lock:
+            if self.active_connections[side] is conn:
+                self.active_connections[side] = None
+
+    def _get_active_connection(self, side: str) -> socket.socket | None:
+        with self.active_lock:
+            return self.active_connections[side]
+
+    def _reader_loop(
+        self,
+        side: str,
+        conn: socket.socket,
+        outbound_queue: queue.Queue[bytes],
+        peer_side: str,
+    ) -> None:
+        try:
+            while not self.stop_event.is_set():
+                data = conn.recv(4096)
+                if not data:
+                    LOGGER.debug("%s client reached EOF", side)
+                    return
+                outbound_queue.put(data)
+                LOGGER.debug(
+                    "queued %d bytes from %s to %s",
+                    len(data),
+                    side,
+                    peer_side,
+                )
+        except OSError:
+            LOGGER.debug("%s client disconnected abruptly", side, exc_info=True)
+        finally:
+            self._clear_active_connection(side, conn)
+            self._close_socket(conn)
+            LOGGER.debug("closed %s client connection", side)
+
+    def _accept_loop(
+        self,
+        side: str,
+        server_sock: socket.socket,
+        outbound_queue: queue.Queue[bytes],
+        peer_side: str,
+    ) -> None:
+        while not self.stop_event.is_set():
+            try:
+                conn, _ = server_sock.accept()
+            except TimeoutError:
+                continue
+            except OSError:
+                if not self.stop_event.is_set():
+                    LOGGER.debug("%s server accept failed", side, exc_info=True)
+                return
+
+            LOGGER.debug("accepted %s client connection", side)
+            self._set_active_connection(side, conn)
+
+            reader_thread = threading.Thread(
+                target=self._reader_loop,
+                args=(side, conn, outbound_queue, peer_side),
+                daemon=True,
+            )
+            self.relay_threads.append(reader_thread)
+            reader_thread.start()
+
+    def _writer_loop(
+        self,
+        side: str,
+        inbound_queue: queue.Queue[bytes],
+        peer_side: str,
+    ) -> None:
+        while not self.stop_event.is_set():
+            try:
+                data = inbound_queue.get(timeout=0.1)
+            except queue.Empty:
+                continue
+
+            conn = self._get_active_connection(side)
+            while conn is None and not self.stop_event.is_set():
+                time.sleep(0.001)
+                conn = self._get_active_connection(side)
+            if conn is None:
+                continue
+
+            try:
+                conn.sendall(data)
+                LOGGER.debug(
+                    "forwarded %d bytes from %s to %s",
+                    len(data),
+                    peer_side,
+                    side,
+                )
+            except OSError:
+                self._clear_active_connection(side, conn)
+                self._close_socket(conn)
+                LOGGER.debug(
+                    "failed forwarding bytes from %s to %s",
+                    peer_side,
+                    side,
+                    exc_info=True,
+                )
+
+    def start(self) -> None:
+        LOGGER.debug(
+            "started socket pair server left=%s right=%s",
+            self.left_url,
+            self.right_url,
+        )
+        self.relay_threads.extend(
+            [
+                threading.Thread(
+                    target=self._accept_loop,
+                    args=("left", self.left_server, self.left_to_right, "right"),
+                    daemon=True,
+                ),
+                threading.Thread(
+                    target=self._accept_loop,
+                    args=("right", self.right_server, self.right_to_left, "left"),
+                    daemon=True,
+                ),
+                threading.Thread(
+                    target=self._writer_loop,
+                    args=("left", self.right_to_left, "right"),
+                    daemon=True,
+                ),
+                threading.Thread(
+                    target=self._writer_loop,
+                    args=("right", self.left_to_right, "left"),
+                    daemon=True,
+                ),
+            ]
+        )
+        for relay_thread in self.relay_threads:
+            relay_thread.start()
+
+    def close(self) -> None:
+        self.stop_event.set()
+        self._close_socket(self.left_server)
+        self._close_socket(self.right_server)
+        with self.active_lock:
+            connections = list(self.active_connections.values())
+            self.active_connections["left"] = None
+            self.active_connections["right"] = None
+        for conn in connections:
+            self._close_socket(conn)
+        for relay_thread in self.relay_threads:
+            relay_thread.join(timeout=1)
+        LOGGER.debug("stopped socket pair servers")
+
+
+@contextlib.contextmanager
+def create_socket_pair() -> Iterator[tuple[str, str]]:
+    """Create two socket:// endpoints backed by a bidirectional relay."""
+    relay = _SocketPairRelay()
+    relay.start()
+    try:
+        yield (relay.left_url, relay.right_url)
+    finally:
+        relay.close()
+
+
+def test_socket_url_uses_dedicated_socket_platform() -> None:
+    """Test socket:// uses dedicated socket serial and transport classes."""
+    serial_cls, transport_cls = get_serial_classes("socket://127.0.0.1:12345")
+
+    assert serial_cls is SocketSerial
+    assert transport_cls is SocketSerialTransport
+
+
+def test_all_bytes_socket() -> None:
+    """Test that all bytes 0-255 can be transmitted."""
+    with (
+        create_socket_pair() as (left, right),
+        SocketSerial(left, baudrate=115200) as serial_left,
+        SocketSerial(right, baudrate=115200) as serial_right,
+    ):
+        # Create a byte array with all possible byte values
+        data = bytes(range(256))
+
+        serial_left.write(data)
+        result = serial_right.readexactly(len(data))
+
+        assert result == data
+
+
+def test_segmented_binary_data_socket() -> None:
+    """Test binary data sent in segments."""
+    with (
+        create_socket_pair() as (left, right),
+        SocketSerial(left, baudrate=115200) as serial_left,
+        SocketSerial(right, baudrate=115200) as serial_right,
+    ):
+        # Send all bytes in smaller segments
+        segment_size = 16
+        data = bytes(range(256))
+
+        for i in range(0, 256, segment_size):
+            segment = data[i : i + segment_size]
+            serial_left.write(segment)
+            result = serial_right.readexactly(len(segment))
+            assert result == segment
+
+
+@pytest.mark.parametrize(
+    "size",
+    [1, 16, 64, 256, 512, 1024],
+)
+def test_binary_payload_sizes_socket(size: int) -> None:
+    """Test various binary payload sizes."""
+    with (
+        create_socket_pair() as (left, right),
+        SocketSerial(left, baudrate=115200) as serial_left,
+        SocketSerial(right, baudrate=115200) as serial_right,
+    ):
+        # Create binary data with repeating pattern
+        data = bytes([i % 256 for i in range(size)])
+
+        serial_left.write(data)
+        result = serial_right.readexactly(len(data))
+
+        assert result == data
+
+
+def test_null_bytes_socket() -> None:
+    """Test that null bytes (0x00) can be transmitted."""
+    with (
+        create_socket_pair() as (left, right),
+        SocketSerial(left, baudrate=115200) as serial_left,
+        SocketSerial(right, baudrate=115200) as serial_right,
+    ):
+        # Send a bunch of null bytes
+        null_data = b"\x00" * 64
+
+        serial_left.write(null_data)
+        result = serial_right.readexactly(len(null_data))
+
+        assert result == null_data
+
+
+def test_overlapping_read_write_socket() -> None:
+    """Test that read and write can overlap, data is buffered."""
+    with (
+        create_socket_pair() as (left, right),
+        SocketSerial(left, baudrate=115200) as serial_left,
+        SocketSerial(right, baudrate=115200) as serial_right,
+    ):
+        data = bytes(range(256))
+        read = b""
+
+        serial_left.write(data[:100])
+        read += serial_right.readexactly(10)
+        serial_left.write(data[100:150])
+        read += serial_right.readexactly(10)
+        serial_left.write(data[150:])
+        read += serial_right.readexactly(10)
+        read += serial_right.readexactly(256 - 30)
+
+        assert read == data
+
+
+@pytest.mark.parametrize(
+    ("baudrate", "chunk_size"),
+    [
+        (9600, 1),
+        (9600, 16),
+        (115200, 1),
+        (115200, 16),
+        (115200, 64),
+        (921600, 1),
+        (921600, 16),
+        (921600, 256),
+        (921600, 1024),
+    ],
+)
+def test_random_large_socket(baudrate: int, chunk_size: int) -> None:
+    """Test loopback adapter random read/write."""
+    with (
+        create_socket_pair() as (left, right),
+        SocketSerial(left, baudrate=baudrate) as serial_left,
+        SocketSerial(right, baudrate=baudrate) as serial_right,
+    ):
+        data = os.urandom(chunk_size)
+        serial_left.write(data)
+
+        read_data = serial_right.readexactly(chunk_size)
+        assert read_data == data
+
+
+@pytest.mark.parametrize(
+    "iterations",
+    [16, 32, 64],
+)
+def test_repeated_write_read_cycles_socket(iterations: int) -> None:
+    """Test repeated write/read cycles."""
+    with (
+        create_socket_pair() as (left, right),
+        SocketSerial(left, baudrate=115200) as serial_left,
+        SocketSerial(right, baudrate=115200) as serial_right,
+    ):
+        data = bytes(range(256))
+
+        for _i in range(iterations):
+            serial_left.write(data)
+            result = serial_right.readexactly(len(data))
+            assert result == data
+
+
+def test_buffered_writes_then_read_socket() -> None:
+    """Test multiple writes followed by a single read."""
+    with (
+        create_socket_pair() as (left, right),
+        SocketSerial(left, baudrate=115200) as serial_left,
+        SocketSerial(right, baudrate=115200) as serial_right,
+    ):
+        chunk = bytes(range(256))
+        iterations = 4
+
+        # Write multiple chunks
+        for _ in range(iterations):
+            serial_left.write(chunk)
+
+        # Read all data back
+        total_size = len(chunk) * iterations
+        result = serial_right.readexactly(total_size)
+
+        # Verify all data was received correctly
+        expected = chunk * iterations
+        assert result == expected
+
+
+@pytest.mark.parametrize(
+    "payload_size",
+    [1024, 2048],  # Kernel buffers are typically ~4KB, stay well below that
+)
+def test_large_payload_socket(payload_size: int) -> None:
+    """Test large payload transmission."""
+    with (
+        create_socket_pair() as (left, right),
+        SocketSerial(left, baudrate=921600) as serial_left,
+        SocketSerial(right, baudrate=921600) as serial_right,
+    ):
+        data = bytes([i % 256 for i in range(payload_size)])
+
+        serial_left.write(data)
+        result = serial_right.readexactly(len(data))
+
+        assert result == data
+
+
+def test_rapid_small_writes_socket() -> None:
+    """Test rapid succession of small writes."""
+    with (
+        create_socket_pair() as (left, right),
+        SocketSerial(left, baudrate=115200) as serial_left,
+        SocketSerial(right, baudrate=115200) as serial_right,
+    ):
+        # Send many small writes
+        iterations = 256
+        received = bytearray()
+
+        for i in range(iterations):
+            data = bytes([i % 256])
+            serial_left.write(data)
+            result = serial_right.readexactly(1)
+            received.extend(result)
+
+        # Verify all bytes were received in order
+        expected = bytes([i % 256 for i in range(iterations)])
+        assert bytes(received) == expected
+
+
+@pytest.mark.parametrize(
+    ("baudrate", "iterations"),
+    [
+        (9600, 8),
+        (115200, 64),
+        (921600, 512),
+    ],
+)
+def test_sustained_throughput_socket(baudrate: int, iterations: int) -> None:
+    """Test sustained data throughput at various baudrates."""
+    with (
+        create_socket_pair() as (left, right),
+        SocketSerial(left, baudrate=baudrate) as serial_left,
+        SocketSerial(right, baudrate=baudrate) as serial_right,
+    ):
+        chunk = os.urandom(1024)
+
+        for _ in range(iterations):
+            serial_left.write(chunk)
+            result = serial_right.readexactly(len(chunk))
+            assert result == chunk
+
+
+@pytest.mark.parametrize(
+    "baudrate",
+    [9600, 19200, 38400, 57600, 115200, 230400, 460800, 921600],
+)
+def test_valid_baudrates_socket(baudrate: int) -> None:
+    """Test that valid baudrates are accepted."""
+    with (
+        create_socket_pair() as (left, right),
+        SocketSerial(left, baudrate=baudrate) as serial,
+    ):
+        assert serial.baudrate == baudrate
+        serial.write(b"test")
+
+
+@pytest.mark.parametrize(
+    "parity",
+    [Parity.NONE, Parity.ODD, Parity.EVEN, Parity.MARK, Parity.SPACE],
+)
+def test_valid_parity_socket(parity: Parity) -> None:
+    """Test that valid parity settings are accepted."""
+    with (
+        create_socket_pair() as (left, right),
+        SocketSerial(left, baudrate=115200, parity=parity) as serial,
+    ):
+        assert serial.parity == parity
+        serial.write(b"test")
+
+
+@pytest.mark.parametrize(
+    ("stopbits", "expected"),
+    [
+        (StopBits.ONE, StopBits.ONE),
+        (StopBits.ONE_POINT_FIVE, StopBits.ONE_POINT_FIVE),
+        (StopBits.TWO, StopBits.TWO),
+        (1, StopBits.ONE),
+        (1.5, StopBits.ONE_POINT_FIVE),
+        (2, StopBits.TWO),
+    ],
+)
+def test_valid_stopbits_socket(
+    stopbits: StopBits | int | float,
+    expected: StopBits,
+) -> None:
+    """Test that valid stopbits settings are accepted."""
+    with (
+        create_socket_pair() as (left, right),
+        SocketSerial(left, baudrate=115200, stopbits=stopbits) as serial,
+    ):
+        assert serial.stopbits == expected
+        serial.write(b"test")
+
+
+@pytest.mark.parametrize("byte_size", [5, 6, 7, 8])
+def test_valid_byte_size_socket(byte_size: int) -> None:
+    """Test that valid byte sizes are accepted."""
+    with (
+        create_socket_pair() as (left, right),
+        SocketSerial(left, baudrate=115200, byte_size=byte_size) as serial,
+    ):
+        serial.write(b"test")
+
+
+@pytest.mark.parametrize("xonxoff", [True, False])
+def test_xonxoff_setting_socket(xonxoff: bool) -> None:
+    """Test that xonxoff setting is accepted."""
+    with (
+        create_socket_pair() as (left, right),
+        SocketSerial(left, baudrate=115200, xonxoff=xonxoff) as serial,
+    ):
+        serial.write(b"test")
+
+
+@pytest.mark.parametrize(
+    "rtscts",
+    [True, False],
+)
+def test_rtscts_setting_socket(rtscts: bool) -> None:
+    """Test that rtscts setting is accepted."""
+    with (
+        create_socket_pair() as (left, right),
+        SocketSerial(left, baudrate=115200, rtscts=rtscts) as serial,
+    ):
+        serial.write(b"test")
+
+
+def test_exclusive_socket() -> None:
+    """Test that exclusive setting is respected."""
+    with create_socket_pair() as (left, right):
+        with SocketSerial(left, baudrate=115200, exclusive=True) as serial:
+            assert serial.exclusive is True
+
+            # Socket endpoints are not lockable tty devices, so this should still open.
+            with SocketSerial(left, baudrate=115200, exclusive=True) as serial_2:
+                assert serial_2.exclusive is True
+
+
+def test_exclusive_disabled_socket() -> None:
+    """Test that exclusive setting is respected."""
+    with create_socket_pair() as (left, right):
+        with SocketSerial(left, baudrate=115200, exclusive=False) as serial1:
+            assert serial1.exclusive is False
+
+            # Can open the same port again without exclusive
+            with SocketSerial(left, baudrate=115200, exclusive=False) as serial2:
+                assert serial2.exclusive is False
+                # Both can write without error
+                serial2.write(b"test")
+
+
+def test_context_manager_multiple_times_socket() -> None:
+    """Test that context manager can be used multiple times."""
+    with create_socket_pair() as (left, right):
+        serial_left = SocketSerial(left, baudrate=115200)
+        serial_right = SocketSerial(right, baudrate=115200)
+
+        # First context
+        with serial_left, serial_right:
+            serial_left.write(b"test1")
+            result = serial_right.readexactly(5)
+            assert result == b"test1"
+
+        # Second context
+        with serial_left, serial_right:
+            serial_left.write(b"test2")
+            result = serial_right.readexactly(5)
+            assert result == b"test2"
+
+
+def test_open_close_cycles_socket() -> None:
+    """Test multiple open/close cycles."""
+    with create_socket_pair() as (left, right):
+        serial_left = SocketSerial(left, baudrate=115200)
+        serial_right = SocketSerial(right, baudrate=115200)
+
+        # Cycle 1
+        serial_left.open()
+        serial_left.configure_port()
+        serial_right.open()
+        serial_right.configure_port()
+        serial_left.write(b"1")
+        assert serial_right.readexactly(1) == b"1"
+        serial_left.close()
+        serial_right.close()
+
+        # Cycle 2
+        serial_left.open()
+        serial_left.configure_port()
+        serial_right.open()
+        serial_right.configure_port()
+        serial_left.write(b"2")
+        assert serial_right.readexactly(1) == b"2"
+        serial_left.close()
+        serial_right.close()
+
+        # Cycle 3
+        serial_left.open()
+        serial_left.configure_port()
+        serial_right.open()
+        serial_right.configure_port()
+        serial_left.write(b"3")
+        assert serial_right.readexactly(1) == b"3"
+        serial_left.close()
+        serial_right.close()
+
+
+def test_flush_after_write_socket() -> None:
+    """Test flushing after write operation."""
+    with (
+        create_socket_pair() as (left, right),
+        SocketSerial(left, baudrate=115200) as serial_left,
+        SocketSerial(right, baudrate=115200) as serial_right,
+    ):
+        serial_left.flush()
+
+        data = b"Test flush operation"
+        serial_left.write(data)
+        serial_left.flush()
+
+        result = serial_right.readexactly(len(data))
+        assert result == data
+
+
+def test_multiple_flush_calls_socket() -> None:
+    """Test multiple consecutive flush calls."""
+    with (
+        create_socket_pair() as (left, right),
+        SocketSerial(left, baudrate=115200) as serial_left,
+        SocketSerial(right, baudrate=115200) as serial_right,
+    ):
+        data = b""
+
+        for i in range(5):
+            chunk = f"Test data {i}".encode("ascii")
+            data += chunk
+
+            serial_left.write(chunk)
+            serial_left.flush()
+
+        result = serial_right.readexactly(len(data))
+        assert result == data
+
+
+def test_get_modem_pins_socket() -> None:
+    """Test reading modem control bits with loopback adapter."""
+    with (
+        create_socket_pair() as (left, right),
+        SocketSerial(left, baudrate=115200) as serial,
+    ):
+        modem_pins = serial.get_modem_pins()
+
+        # Verify we get a ModemPins object
+        assert isinstance(modem_pins, ModemPins)
+
+        # All modem pins should be PinState enum values
+        for field in ["le", "dtr", "rts", "st", "sr", "cts", "car", "rng", "dsr"]:
+            value = getattr(modem_pins, field)
+            assert value in (PinState.HIGH, PinState.LOW, PinState.UNDEFINED)
+
+
+def test_set_modem_pins_socket() -> None:
+    """Test setting modem control bits with socket pair."""
+    with (
+        create_socket_pair() as (left, right),
+        SocketSerial(left, baudrate=115200) as serial,
+    ):
+        # Note: socket pairs don't support modem control signals properly
+        # These calls should not raise errors, but values may be None
+        serial.set_modem_pins(dtr=True, rts=True)
+        modem_pins = serial.get_modem_pins()
+        # Verify we get a ModemPins object, values may be None with socket
+        assert isinstance(modem_pins, ModemPins)
+
+        serial.set_modem_pins(dtr=False)
+        modem_pins = serial.get_modem_pins()
+        assert isinstance(modem_pins, ModemPins)
+
+        serial.set_modem_pins(dtr=False, rts=False)
+        modem_pins = serial.get_modem_pins()
+        assert isinstance(modem_pins, ModemPins)
+
+
+def test_deprecated_dtr_property_socket() -> None:
+    """Test DTR property (deprecated alias) with socket pair."""
+    with (
+        create_socket_pair() as (left, right),
+        SocketSerial(left, baudrate=115200) as serial,
+    ):
+        # Note: socket pairs don't support modem control signals properly
+        # These calls should not raise errors, but values may be None with socket
+        serial.dtr = True
+        # DTR may be None with socket, just verify no error occurs
+        serial.dtr = False
+
+
+def test_deprecated_rts_property_socket() -> None:
+    """Test RTS property (deprecated alias) with socket pair."""
+    with (
+        create_socket_pair() as (left, right),
+        SocketSerial(left, baudrate=115200) as serial,
+    ):
+        # Note: socket pairs don't support modem control signals properly
+        # These calls should not raise errors, but values may be None with socket
+        serial.rts = True
+        # RTS may be None with socket, just verify no error occurs
+        serial.rts = False


### PR DESCRIPTION
In preparation for merging ESPHome support (https://github.com/puddly/serialx/pull/23), this PR splits `socket://` handling into a dedicated platform instead of merely passing through `loop.create_connection()`.