### PR TITLE
Implement timeouts for synchronous APIs

### DIFF
--- a/serialx/common.py
+++ b/serialx/common.py
@@ -186,7 +186,7 @@ class BaseSerial(io.RawIOBase):
         raise NotImplementedError
 
     @property
-    def timeout(self) -> float | None:
+    def read_timeout(self) -> float | None:
         """Get the read timeout in seconds."""
         return self._read_timeout
 

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -164,7 +164,12 @@ class BaseSerial(io.RawIOBase):
     def open(self) -> None:
         """Open the serial port."""
         self._open()
-        self._configure_port()
+
+        try:
+            self._configure_port()
+        except BaseException:
+            self.close()
+            raise
 
     def configure_port(self) -> None:
         """Configure the serial port settings."""

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -130,6 +130,7 @@ class BaseSerial(io.RawIOBase):
         rtscts: bool = False,
         byte_size: int = 8,
         *,
+        timeout: float | None = None,
         buffer_character_count: int = 1,
         buffer_burst_timeout: float = 0.01,
         rtsdtr_on_open: PinState = PinState.HIGH,
@@ -153,6 +154,7 @@ class BaseSerial(io.RawIOBase):
         self._parity = parity
         self._byte_size = byte_size
         self._exclusive = exclusive
+        self._timeout = timeout
 
         self._rtsdtr_on_open = rtsdtr_on_open
         self._rtsdtr_on_close = rtsdtr_on_close
@@ -170,6 +172,17 @@ class BaseSerial(io.RawIOBase):
     def configure_port(self) -> None:
         """Configure the serial port settings."""
         raise NotImplementedError
+
+    @property
+    def timeout(self) -> float | None:
+        """Get the read timeout in seconds."""
+        return self._timeout
+
+    @timeout.setter
+    def timeout(self, value: float | None) -> None:
+        """Set the read timeout in seconds."""
+        self._timeout = value
+        self.configure_port()
 
     def get_modem_pins(self) -> ModemPins:
         """Get modem control bits, internal."""

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -178,12 +178,6 @@ class BaseSerial(io.RawIOBase):
         """Get the read timeout in seconds."""
         return self._timeout
 
-    @timeout.setter
-    def timeout(self, value: float | None) -> None:
-        """Set the read timeout in seconds."""
-        self._timeout = value
-        self.configure_port()
-
     def get_modem_pins(self) -> ModemPins:
         """Get modem control bits, internal."""
         return self._get_modem_pins()

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -130,7 +130,7 @@ class BaseSerial(io.RawIOBase):
         rtscts: bool = False,
         byte_size: int = 8,
         *,
-        timeout: float | None = None,
+        read_timeout: float | None = None,
         write_timeout: float | None = None,
         rtsdtr_on_open: PinState = PinState.HIGH,
         rtsdtr_on_close: PinState = PinState.LOW,
@@ -153,7 +153,7 @@ class BaseSerial(io.RawIOBase):
         self._parity = parity
         self._byte_size = byte_size
         self._exclusive = exclusive
-        self._read_timeout = timeout
+        self._read_timeout = read_timeout
         self._write_timeout = write_timeout
 
         self._rtsdtr_on_open = rtsdtr_on_open

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -161,14 +161,23 @@ class BaseSerial(io.RawIOBase):
 
         self._auto_close = False
 
-    @abstractmethod
     def open(self) -> None:
         """Open the serial port."""
+        self._open()
+        self._configure_port()
+
+    def configure_port(self) -> None:
+        """Configure the serial port settings."""
+        self._configure_port()
+
+    @abstractmethod
+    def _open(self) -> None:
+        """Open the serial port (platform-specific)."""
         raise NotImplementedError
 
     @abstractmethod
-    def configure_port(self) -> None:
-        """Configure the serial port settings."""
+    def _configure_port(self) -> None:
+        """Configure the serial port settings (platform-specific)."""
         raise NotImplementedError
 
     @property
@@ -315,13 +324,6 @@ class BaseSerial(io.RawIOBase):
     def __enter__(self) -> Self:
         """Enter context manager."""
         self.open()
-
-        try:
-            self.configure_port()
-        except BaseException:
-            self.close()
-            raise
-
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -153,7 +153,7 @@ class BaseSerial(io.RawIOBase):
         self._parity = parity
         self._byte_size = byte_size
         self._exclusive = exclusive
-        self._timeout = timeout
+        self._read_timeout = timeout
         self._write_timeout = write_timeout
 
         self._rtsdtr_on_open = rtsdtr_on_open
@@ -174,7 +174,7 @@ class BaseSerial(io.RawIOBase):
     @property
     def timeout(self) -> float | None:
         """Get the read timeout in seconds."""
-        return self._timeout
+        return self._read_timeout
 
     @property
     def write_timeout(self) -> float | None:

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -131,8 +131,6 @@ class BaseSerial(io.RawIOBase):
         byte_size: int = 8,
         *,
         timeout: float | None = None,
-        buffer_character_count: int = 1,
-        buffer_burst_timeout: float = 0.01,
         rtsdtr_on_open: PinState = PinState.HIGH,
         rtsdtr_on_close: PinState = PinState.LOW,
         exclusive: bool = True,
@@ -159,8 +157,6 @@ class BaseSerial(io.RawIOBase):
         self._rtsdtr_on_open = rtsdtr_on_open
         self._rtsdtr_on_close = rtsdtr_on_close
 
-        self._buffer_character_count = buffer_character_count
-        self._buffer_burst_timeout = buffer_burst_timeout
         self._auto_close = False
 
     @abstractmethod

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -131,6 +131,7 @@ class BaseSerial(io.RawIOBase):
         byte_size: int = 8,
         *,
         timeout: float | None = None,
+        write_timeout: float | None = None,
         rtsdtr_on_open: PinState = PinState.HIGH,
         rtsdtr_on_close: PinState = PinState.LOW,
         exclusive: bool = True,
@@ -153,6 +154,7 @@ class BaseSerial(io.RawIOBase):
         self._byte_size = byte_size
         self._exclusive = exclusive
         self._timeout = timeout
+        self._write_timeout = write_timeout
 
         self._rtsdtr_on_open = rtsdtr_on_open
         self._rtsdtr_on_close = rtsdtr_on_close
@@ -173,6 +175,11 @@ class BaseSerial(io.RawIOBase):
     def timeout(self) -> float | None:
         """Get the read timeout in seconds."""
         return self._timeout
+
+    @property
+    def write_timeout(self) -> float | None:
+        """Get the write timeout in seconds."""
+        return self._write_timeout
 
     def get_modem_pins(self) -> ModemPins:
         """Get modem control bits, internal."""

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -186,6 +186,15 @@ class BaseSerial(io.RawIOBase):
         """Configure the serial port settings (platform-specific)."""
         raise NotImplementedError
 
+    def close(self) -> None:
+        """Close the serial port."""
+        self._close()
+
+    @abstractmethod
+    def _close(self) -> None:
+        """Close the serial port, internal."""
+        raise NotImplementedError
+
     @property
     def read_timeout(self) -> float | None:
         """Get the read timeout in seconds."""

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 import asyncio
+from asyncio import IncompleteReadError
 import dataclasses
 from enum import Enum
 import io
@@ -196,7 +197,7 @@ class BaseSerial(io.RawIOBase):
         return self._write_timeout
 
     def get_modem_pins(self) -> ModemPins:
-        """Get modem control bits, internal."""
+        """Get modem control bits."""
         return self._get_modem_pins()
 
     def set_modem_pins(
@@ -213,7 +214,7 @@ class BaseSerial(io.RawIOBase):
         rng: PinState | bool | None = PinState.UNDEFINED,
         dsr: PinState | bool | None = PinState.UNDEFINED,
     ) -> None:
-        """Set modem control bits, internal."""
+        """Set modem control bits."""
         if modem_pins is None:
             modem_pins = ModemPins(
                 le=PinState.convert(le),
@@ -320,8 +321,9 @@ class BaseSerial(io.RawIOBase):
             remaining -= read
 
             if read == 0:
-                raise EOFError(
-                    f"Read only {n - remaining} bytes, expected {n} bytes: {buffer!r}"
+                # `IncompleteReadError` is a subclass of `EOFError`
+                raise IncompleteReadError(
+                    expected=n, partial=bytes(buffer[: n - remaining])
                 )
 
         return bytes(buffer)

--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -450,7 +450,7 @@ class PosixSerial(BaseSerial):
         LOGGER.debug("Flushing file descriptor %r", self._fileno)
         termios.tcdrain(self._fileno)
 
-    def close(self) -> None:
+    def _close(self) -> None:
         """Close the serial port."""
         if self._fileno is not None:
             if self._exclusive:

--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -508,6 +508,12 @@ class PosixSerial(BaseSerial):
         """Write bytes to serial port."""
         LOGGER.debug("Writing %d bytes: %r", len(data), data)  # type: ignore[arg-type]
         assert self._fileno is not None
+
+        if self._write_timeout is not None:
+            _, ready, _ = select.select([], [self._fileno], [], self._write_timeout)
+            if not ready:
+                raise TimeoutError("Write timeout")
+
         return os.write(self._fileno, data)  # type: ignore[arg-type]
 
 

--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -136,12 +136,16 @@ class PosixSerial(BaseSerial):
         *args,
         fileno: int | None = None,
         low_latency: bool = True,
+        inter_byte_timeout: float = 0.01,
+        min_read_size: int = 1,
         **kwargs,
     ):
         """Initialize POSIX serial port."""
         super().__init__(*args, **kwargs)
         self._fileno: int | None = fileno
         self._low_latency: bool = low_latency
+        self._inter_byte_timeout = inter_byte_timeout
+        self._min_read_size = min_read_size
 
     def open(self) -> None:
         """Open the serial port."""
@@ -297,17 +301,17 @@ class PosixSerial(BaseSerial):
 
         # Only emit reads if VMIN characters have been read, after no more data comes in
         # for VTIME seconds
-        vmin = self._buffer_character_count
-        vtime = int(self._buffer_burst_timeout * 10)
+        vmin = self._min_read_size
+        vtime = int(self._inter_byte_timeout * 10)
 
         if not 0 <= vmin <= 255:
             raise ValueError(
-                f"VMIN must be in range 0-255 (buffer_character_count={self._buffer_character_count})"
+                f"VMIN must be in range 0-255 (min_read_size={self._min_read_size})"
             )
 
         if not 0 <= vtime <= 255:
             raise ValueError(
-                f"VTIME must be in range 0-255 (buffer_burst_timeout={self._buffer_burst_timeout})"
+                f"VTIME must be in range 0-255 (inter_byte_timeout={self._inter_byte_timeout})"
             )
 
         try:
@@ -522,8 +526,8 @@ class PosixSerialTransport(DescriptorTransport, BaseSerialTransport):
             # `DescriptorTransport` opened the port
             fileno=self._fileno,
             # Nonblocking mode
-            buffer_character_count=0,
-            buffer_burst_timeout=0,
+            min_read_size=0,
+            inter_byte_timeout=0,
         )
         self._extra["serial"] = self._serial
 

--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -10,6 +10,7 @@ import fcntl
 import logging
 import os
 from pathlib import Path
+import select
 import sys
 import termios
 import time
@@ -464,6 +465,13 @@ class PosixSerial(BaseSerial):
 
         def readinto(self, b: Buffer) -> int:
             """Read bytes from serial port into buffer."""
+            assert self._fileno is not None
+
+            if self._timeout is not None:
+                ready, _, _ = select.select([self._fileno], [], [], self._timeout)
+                if not ready:
+                    return 0
+
             n = os.readinto(self._fileno, b)
             LOGGER.debug("Read %d bytes", n)
 
@@ -474,6 +482,11 @@ class PosixSerial(BaseSerial):
         def readinto(self, b: Buffer) -> int:
             """Read bytes from serial port into buffer."""
             assert self._fileno is not None
+
+            if self._timeout is not None:
+                ready, _, _ = select.select([self._fileno], [], [], self._timeout)
+                if not ready:
+                    return 0
 
             m = memoryview(b).cast("B")
             size = len(m)

--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -471,8 +471,8 @@ class PosixSerial(BaseSerial):
             """Read bytes from serial port into buffer."""
             assert self._fileno is not None
 
-            if self._timeout is not None:
-                ready, _, _ = select.select([self._fileno], [], [], self._timeout)
+            if self._read_timeout is not None:
+                ready, _, _ = select.select([self._fileno], [], [], self._read_timeout)
                 if not ready:
                     return 0
 
@@ -487,8 +487,8 @@ class PosixSerial(BaseSerial):
             """Read bytes from serial port into buffer."""
             assert self._fileno is not None
 
-            if self._timeout is not None:
-                ready, _, _ = select.select([self._fileno], [], [], self._timeout)
+            if self._read_timeout is not None:
+                ready, _, _ = select.select([self._fileno], [], [], self._read_timeout)
                 if not ready:
                     return 0
 

--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -147,7 +147,7 @@ class PosixSerial(BaseSerial):
         self._inter_byte_timeout = inter_byte_timeout
         self._min_read_size = min_read_size
 
-    def open(self) -> None:
+    def _open(self) -> None:
         """Open the serial port."""
         LOGGER.debug("Opening serial port %r", self._path)
 
@@ -226,7 +226,7 @@ class PosixSerial(BaseSerial):
         )
         fcntl.ioctl(self._fileno, TCSETS2, buffer)
 
-    def configure_port(self) -> None:  # noqa: C901
+    def _configure_port(self) -> None:  # noqa: C901
         """Configure the serial port settings."""
         LOGGER.debug("Configuring serial port %r", self._path)
 

--- a/serialx/platforms/serial_socket.py
+++ b/serialx/platforms/serial_socket.py
@@ -54,10 +54,14 @@ class SocketSerial(BaseSerial):
         """Open the socket connection."""
         assert self._host is not None
         assert self._port is not None
-        self._socket = socket.create_connection((self._host, self._port))
+        self._socket = socket.create_connection(
+            (self._host, self._port), timeout=self._timeout
+        )
 
     def configure_port(self) -> None:
         """Configure the serial port settings (no-op for sockets)."""
+        if self._socket is not None:
+            self._socket.settimeout(self._timeout)
 
     def _set_modem_pins(self, modem_pins: ModemPins) -> None:
         pass
@@ -81,7 +85,10 @@ class SocketSerial(BaseSerial):
         assert self._socket is not None
 
         m = memoryview(b).cast("B")
-        return self._socket.recv_into(m)
+        try:
+            return self._socket.recv_into(m)
+        except TimeoutError:
+            return 0
 
     def close(self) -> None:
         """Close the socket."""

--- a/serialx/platforms/serial_socket.py
+++ b/serialx/platforms/serial_socket.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from pathlib import Path
 import socket
 import urllib.parse
 
@@ -20,32 +19,19 @@ class SocketSerial(BaseSerial):
 
     def __init__(
         self,
-        path: str | Path,
-        baudrate: int,
-        parity: Parity = Parity.NONE,
-        stopbits: StopBits | int | float = StopBits.ONE,
-        xonxoff: bool = False,
-        rtscts: bool = False,
-        byte_size: int = 8,
+        *args,
         # Socket-specific kwargs
         connect_timeout: float | None = None,
         **kwargs,
     ) -> None:
         """Initialize socket serial port."""
-        super().__init__(
-            path=path,
-            baudrate=baudrate,
-            parity=parity,
-            stopbits=stopbits,
-            xonxoff=xonxoff,
-            rtscts=rtscts,
-            byte_size=byte_size,
-            **kwargs,
-        )
+        super().__init__(*args, **kwargs)
 
-        parsed = urllib.parse.urlparse(str(path))
+        parsed = urllib.parse.urlparse(str(self._path))
         if parsed.hostname is None or parsed.port is None:
-            raise ValueError(f"Invalid socket URI, expected both host and port: {path}")
+            raise ValueError(
+                f"Invalid socket URI, expected both host and port: {self._path}"
+            )
 
         self._host = parsed.hostname
         self._port = parsed.port

--- a/serialx/platforms/serial_socket.py
+++ b/serialx/platforms/serial_socket.py
@@ -69,7 +69,7 @@ class SocketSerial(BaseSerial):
 
     def _get_effective_socket_timeout(self) -> float | None:
         """Calculate effective socket timeout as min of read and write timeouts."""
-        read_t = self._timeout
+        read_t = self._read_timeout
         write_t = self._write_timeout
 
         if read_t is None:

--- a/serialx/platforms/serial_socket.py
+++ b/serialx/platforms/serial_socket.py
@@ -69,22 +69,21 @@ class SocketSerial(BaseSerial):
 
     def _get_effective_socket_timeout(self) -> float | None:
         """Calculate effective socket timeout as min of read and write timeouts."""
-        read_t = self._read_timeout
-        write_t = self._write_timeout
+        if self._read_timeout is None:
+            return self._write_timeout
 
-        if read_t is None:
-            return write_t
-        if write_t is None:
-            return read_t
+        if self._write_timeout is None:
+            return self._read_timeout
 
-        effective = min(read_t, write_t)
-        if read_t != write_t:
+        effective = min(self._read_timeout, self._write_timeout)
+
+        if self._read_timeout != self._write_timeout:
             LOGGER.debug(
-                "SocketSerial using shared timeout %s (min of read=%s, write=%s)",
-                effective,
-                read_t,
-                write_t,
+                "Serial over TCP accepts only a single timeout, taking the min of read=%s and write=%s",
+                self._read_timeout,
+                self._write_timeout,
             )
+
         return effective
 
     def configure_port(self) -> None:

--- a/serialx/platforms/serial_socket.py
+++ b/serialx/platforms/serial_socket.py
@@ -61,18 +61,36 @@ class SocketSerial(BaseSerial):
         self._socket = socket.create_connection(
             (self._host, self._port), timeout=self._connect_timeout
         )
-        if self._timeout is not None:
-            self._socket.settimeout(self._timeout)
 
     @property
     def connect_timeout(self) -> float | None:
         """Get the connection timeout in seconds."""
         return self._connect_timeout
 
+    def _get_effective_socket_timeout(self) -> float | None:
+        """Calculate effective socket timeout as min of read and write timeouts."""
+        read_t = self._timeout
+        write_t = self._write_timeout
+
+        if read_t is None:
+            return write_t
+        if write_t is None:
+            return read_t
+
+        effective = min(read_t, write_t)
+        if read_t != write_t:
+            LOGGER.debug(
+                "SocketSerial using shared timeout %s (min of read=%s, write=%s)",
+                effective,
+                read_t,
+                write_t,
+            )
+        return effective
+
     def configure_port(self) -> None:
-        """Configure the serial port settings (no-op for sockets)."""
+        """Configure the serial port settings."""
         if self._socket is not None:
-            self._socket.settimeout(self._timeout)
+            self._socket.settimeout(self._get_effective_socket_timeout())
 
     def _set_modem_pins(self, modem_pins: ModemPins) -> None:
         pass

--- a/serialx/platforms/serial_socket.py
+++ b/serialx/platforms/serial_socket.py
@@ -104,7 +104,7 @@ class SocketSerial(BaseSerial):
         except TimeoutError:
             return 0
 
-    def close(self) -> None:
+    def _close(self) -> None:
         """Close the socket."""
         if self._socket is not None:
             self._socket.close()

--- a/serialx/platforms/serial_socket.py
+++ b/serialx/platforms/serial_socket.py
@@ -27,6 +27,8 @@ class SocketSerial(BaseSerial):
         xonxoff: bool = False,
         rtscts: bool = False,
         byte_size: int = 8,
+        # Socket-specific kwargs
+        connect_timeout: float | None = None,
         **kwargs,
     ) -> None:
         """Initialize socket serial port."""
@@ -47,6 +49,7 @@ class SocketSerial(BaseSerial):
 
         self._host = parsed.hostname
         self._port = parsed.port
+        self._connect_timeout = connect_timeout
 
         self._socket: socket.socket | None = None
 
@@ -54,9 +57,17 @@ class SocketSerial(BaseSerial):
         """Open the socket connection."""
         assert self._host is not None
         assert self._port is not None
+
         self._socket = socket.create_connection(
-            (self._host, self._port), timeout=self._timeout
+            (self._host, self._port), timeout=self._connect_timeout
         )
+        if self._timeout is not None:
+            self._socket.settimeout(self._timeout)
+
+    @property
+    def connect_timeout(self) -> float | None:
+        """Get the connection timeout in seconds."""
+        return self._connect_timeout
 
     def configure_port(self) -> None:
         """Configure the serial port settings (no-op for sockets)."""

--- a/serialx/platforms/serial_socket.py
+++ b/serialx/platforms/serial_socket.py
@@ -53,7 +53,7 @@ class SocketSerial(BaseSerial):
 
         self._socket: socket.socket | None = None
 
-    def open(self) -> None:
+    def _open(self) -> None:
         """Open the socket connection."""
         assert self._host is not None
         assert self._port is not None
@@ -86,7 +86,7 @@ class SocketSerial(BaseSerial):
 
         return effective
 
-    def configure_port(self) -> None:
+    def _configure_port(self) -> None:
         """Configure the serial port settings."""
         if self._socket is not None:
             self._socket.settimeout(self._get_effective_socket_timeout())

--- a/serialx/platforms/serial_win32.py
+++ b/serialx/platforms/serial_win32.py
@@ -324,8 +324,8 @@ class Win32Serial(BaseSerial):
         if rc == ERROR_IO_PENDING:
             # IO is pending, wait for it
             timeout_ms = INFINITE
-            if self._timeout is not None:
-                timeout_ms = int(self._timeout * 1000)
+            if self._read_timeout is not None:
+                timeout_ms = int(self._read_timeout * 1000)
 
             res = WaitForSingleObject(self._overlapped_read.hEvent, timeout_ms)
 

--- a/serialx/platforms/serial_win32.py
+++ b/serialx/platforms/serial_win32.py
@@ -251,7 +251,7 @@ class Win32Serial(BaseSerial):
         assert self._handle is not None
         return int(self._handle)
 
-    def close(self):
+    def _close(self):
         """Close the serial port and release all handles."""
         if self._handle is not None:
             # Windows has no way to automatically do this on close, we do it manually

--- a/serialx/platforms/serial_win32.py
+++ b/serialx/platforms/serial_win32.py
@@ -315,11 +315,7 @@ class Win32Serial(BaseSerial):
         try:
             rc, _ = ReadFile(self._handle, b, self._overlapped_read)
         except pywintypes.error as e:
-            if e.winerror != ERROR_IO_PENDING:
-                raise OSError(e.winerror, e.strerror) from e
-
-            # Might not be reached if ReadFile returns result instead of raising
-            rc = ERROR_IO_PENDING
+            raise OSError(e.winerror, e.strerror) from e
 
         if rc == ERROR_IO_PENDING:
             # IO is pending, wait for it
@@ -351,11 +347,7 @@ class Win32Serial(BaseSerial):
         try:
             err, n = WriteFile(self._handle, data, self._overlapped_write)
         except pywintypes.error as e:
-            if e.winerror != ERROR_IO_PENDING:
-                raise OSError(e.winerror, e.strerror) from e
-
-            # Might not be reached if WriteFile returns result instead of raising
-            err = ERROR_IO_PENDING
+            raise OSError(e.winerror, e.strerror) from e
 
         if err == ERROR_IO_PENDING:
             # IO is pending, wait for it

--- a/serialx/platforms/serial_win32.py
+++ b/serialx/platforms/serial_win32.py
@@ -29,7 +29,13 @@ from win32con import (
     SPACEPARITY,
     TWOSTOPBITS,
 )
-from win32event import INFINITE, CreateEvent, ResetEvent, WaitForSingleObject
+from win32event import (
+    INFINITE,
+    WAIT_TIMEOUT,
+    CreateEvent,
+    ResetEvent,
+    WaitForSingleObject,
+)
 from win32file import (
     OVERLAPPED,
     PURGE_RXABORT,
@@ -309,7 +315,17 @@ class Win32Serial(BaseSerial):
 
         if rc == ERROR_IO_PENDING:
             # IO is pending, wait for it
-            WaitForSingleObject(self._overlapped_read.hEvent, INFINITE)
+            timeout_ms = INFINITE
+            if self._timeout is not None:
+                timeout_ms = int(self._timeout * 1000)
+
+            res = WaitForSingleObject(self._overlapped_read.hEvent, timeout_ms)
+
+            if res == WAIT_TIMEOUT:
+                CancelIo(self._handle)
+                # Wait for cancellation to complete to avoid data corruption or races
+                WaitForSingleObject(self._overlapped_read.hEvent, INFINITE)
+                return 0
 
         # Get the actual number of bytes read
         try:

--- a/serialx/platforms/serial_win32.py
+++ b/serialx/platforms/serial_win32.py
@@ -354,7 +354,18 @@ class Win32Serial(BaseSerial):
             if e.winerror != ERROR_IO_PENDING:
                 raise OSError(e.winerror, e.strerror) from e
 
-            WaitForSingleObject(self._overlapped_write.hEvent, INFINITE)
+            timeout_ms = INFINITE
+            if self._write_timeout is not None:
+                timeout_ms = int(self._write_timeout * 1000)
+
+            res = WaitForSingleObject(self._overlapped_write.hEvent, timeout_ms)
+
+            if res == WAIT_TIMEOUT:
+                CancelIo(self._handle)
+                # Wait for cancellation to complete
+                WaitForSingleObject(self._overlapped_write.hEvent, INFINITE)
+                raise TimeoutError("Write timeout") from None
+
             n = GetOverlappedResult(self._handle, self._overlapped_write, True)
 
         return n

--- a/serialx/platforms/serial_win32.py
+++ b/serialx/platforms/serial_win32.py
@@ -137,7 +137,7 @@ class Win32Serial(BaseSerial):
         self._overlapped_read: OVERLAPPED | None = None
         self._overlapped_write: OVERLAPPED | None = None
 
-    def open(self) -> None:
+    def _open(self) -> None:
         """Open the serial port."""
         LOGGER.debug("Opening serial port %r", self._path)
 
@@ -168,7 +168,7 @@ class Win32Serial(BaseSerial):
 
         self._auto_close = True
 
-    def configure_port(self) -> None:
+    def _configure_port(self) -> None:
         """Configure the serial port settings."""
         try:
             interval = int(1000 * self._inter_byte_timeout)

--- a/serialx/platforms/serial_win32.py
+++ b/serialx/platforms/serial_win32.py
@@ -123,12 +123,19 @@ def _safe_close_handle(handle) -> None:
 class Win32Serial(BaseSerial):
     """Windows serial port implementation using Win32 API."""
 
-    def __init__(self, *args, handle=None, **kwargs):
+    def __init__(
+        self,
+        *args,
+        handle: int | None = None,
+        inter_byte_timeout: float = 0.01,
+        **kwargs,
+    ):
         """Initialize the Windows serial port."""
         super().__init__(*args, **kwargs)
         self._handle = handle
-        self._overlapped_read = None
-        self._overlapped_write = None
+        self._inter_byte_timeout = inter_byte_timeout
+        self._overlapped_read: OVERLAPPED | None = None
+        self._overlapped_write: OVERLAPPED | None = None
 
     def open(self) -> None:
         """Open the serial port."""
@@ -164,8 +171,8 @@ class Win32Serial(BaseSerial):
     def configure_port(self) -> None:
         """Configure the serial port settings."""
         try:
-            interval = int(1000 * self._buffer_burst_timeout)
-            if interval <= 0 and self._buffer_burst_timeout > 0:
+            interval = int(1000 * self._inter_byte_timeout)
+            if interval <= 0 and self._inter_byte_timeout > 0:
                 interval = 1  # Minimum 1ms if burst timeout is set but small
 
             timeouts = (
@@ -241,6 +248,7 @@ class Win32Serial(BaseSerial):
 
     def fileno(self) -> int:
         """Return the file descriptor."""
+        assert self._handle is not None
         return int(self._handle)
 
     def close(self):
@@ -452,19 +460,17 @@ class Win32SerialTransport(BaseSerialTransport):
         await self._open(path)
 
         try:
-            # Ensure buffer_burst_timeout is set to a small value to enable
+            # Ensure inter_byte_timeout is set to a small value to enable
             # "Wait for first byte, then return on gap" behavior for ReadFile.
             # If 0 (default), ReadFile with default timeouts might wait for full buffer.
-            original_burst_timeout = kwargs.get("buffer_burst_timeout", 0)
-            if original_burst_timeout == 0:
-                kwargs["buffer_burst_timeout"] = 0.01
+            original_inter_byte_timeout = kwargs.get("inter_byte_timeout", 0)
+            if original_inter_byte_timeout == 0:
+                kwargs["inter_byte_timeout"] = 0.01
 
             self._serial = Win32Serial(
                 **kwargs,
                 path=path,
                 handle=self._handle,
-                # buffer_character_count is not used by Proactor transport
-                buffer_character_count=0,
             )
             self._extra["serial"] = self._serial
 

--- a/serialx/platforms/serial_win32.py
+++ b/serialx/platforms/serial_win32.py
@@ -354,6 +354,11 @@ class Win32Serial(BaseSerial):
             if e.winerror != ERROR_IO_PENDING:
                 raise OSError(e.winerror, e.strerror) from e
 
+            # Might not be reached if WriteFile returns result instead of raising
+            err = ERROR_IO_PENDING
+
+        if err == ERROR_IO_PENDING:
+            # IO is pending, wait for it
             timeout_ms = INFINITE
             if self._write_timeout is not None:
                 timeout_ms = int(self._write_timeout * 1000)
@@ -366,7 +371,11 @@ class Win32Serial(BaseSerial):
                 WaitForSingleObject(self._overlapped_write.hEvent, INFINITE)
                 raise TimeoutError("Write timeout") from None
 
+        # Get the actual number of bytes written
+        try:
             n = GetOverlappedResult(self._handle, self._overlapped_write, True)
+        except pywintypes.error as e:
+            raise OSError(e.winerror, e.strerror) from e
 
         return n
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,7 +1,7 @@
 """Shared test utilities and fixtures."""
 
 import asyncio
-from collections.abc import AsyncIterator, Iterator
+from collections.abc import AsyncIterator, Callable, Iterator
 import contextlib
 import os
 import shutil
@@ -197,3 +197,21 @@ def create_dual_loopback(
         serialx.Serial(right_port, **kwargs) as serial_right,
     ):
         yield (serial_left, serial_right)
+
+
+@contextlib.contextmanager
+def measure_time() -> Iterator[Callable[[], float]]:
+    """Measure elapsed time in a context."""
+    start = time.monotonic()
+    end = None
+
+    def get_result() -> float:
+        if end is None:
+            raise RuntimeError("Context has not exited yet")
+
+        return end - start
+
+    try:
+        yield get_result
+    finally:
+        end = time.monotonic()

--- a/tests/test_loopback_dual_sync.py
+++ b/tests/test_loopback_dual_sync.py
@@ -321,8 +321,10 @@ def test_xonxoff_setting_dual(adapter_pair: tuple[str, str], xonxoff: bool) -> N
 def test_rtscts_setting_dual(adapter_pair: tuple[str, str], rtscts: bool) -> None:
     """Test that rtscts setting is accepted."""
     left_port, right_port = adapter_pair
-    with Serial(adapter_pair[0], baudrate=115200, rtscts=rtscts) as serial:
-        serial.write(b"test")
+    with Serial(adapter_pair[0], baudrate=115200, rtscts=rtscts) as serial_left:
+        with Serial(adapter_pair[1], baudrate=115200) as serial_right:
+            serial_right.set_modem_pins(dtr=True)
+            serial_left.write(b"test")
 
 
 def test_exclusive_dual(adapter_pair: tuple[str, str]) -> None:
@@ -552,6 +554,31 @@ def test_dtr_cts_dual(adapter_pair: tuple[str, str]) -> None:
 
         serial_right.set_modem_pins(dtr=False)
         assert serial_left.get_modem_pins().cts is PinState.LOW
+
+
+@pytest.mark.skipif(
+    sys.platform != "win32", reason="CTS flow control test requires com0com"
+)
+def test_write_timeout_cts_held_dual(adapter_pair: tuple[str, str]) -> None:
+    """Test that write timeout fires when CTS is deasserted (flow control hold)."""
+    left_port, right_port = adapter_pair
+
+    # Open right side first and deassert DTR so left's CTS goes low
+    with Serial(right_port, baudrate=9600) as serial_right:
+        serial_right.set_modem_pins(dtr=False)
+
+        with Serial(
+            left_port,
+            baudrate=9600,
+            rtscts=True,
+            write_timeout=0.5,
+        ) as serial_left:
+            with measure_time() as elapsed:
+                with pytest.raises(TimeoutError):
+                    # Write enough data to fill the tiny com0com buffer and block
+                    serial_left.write(b"x" * 1024)
+
+            assert 0.5 <= elapsed() < 1.5
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="CloseHandle resets modem signals")

--- a/tests/test_loopback_dual_sync.py
+++ b/tests/test_loopback_dual_sync.py
@@ -1,12 +1,13 @@
 """Test sync APIs with dual loopback hardware."""
 
+from asyncio import IncompleteReadError
 import os
 import sys
 
 import pytest
 
 from serialx import Parity, PinState, Serial, StopBits
-from tests.common import create_dual_loopback
+from tests.common import create_dual_loopback, measure_time
 
 
 def test_all_bytes_dual(adapter_pair: tuple[str, str]) -> None:
@@ -437,6 +438,61 @@ def test_multiple_flush_calls_dual(adapter_pair: tuple[str, str]) -> None:
 
         result = serial_right.readexactly(len(data))
         assert result == data
+
+
+def test_read_timeout_dual(adapter_pair: tuple[str, str]) -> None:
+    """Test that reading with a timeout returns 0 bytes after the timeout."""
+    left_port, _right_port = adapter_pair
+
+    with Serial(left_port, baudrate=115200, read_timeout=0.2) as serial:
+        assert serial.read_timeout == 0.2
+
+        with measure_time() as elapsed:
+            result = serial.read(10)
+
+        assert len(result) == 0
+        assert elapsed() >= 0.15
+
+
+def test_read_timeout_with_data_dual(adapter_pair: tuple[str, str]) -> None:
+    """Test that reading with a timeout returns available data immediately."""
+    left_port, right_port = adapter_pair
+
+    with create_dual_loopback(
+        left_port, right_port, baudrate=115200, read_timeout=2.0
+    ) as (
+        serial_left,
+        serial_right,
+    ):
+        data = b"hello"
+        serial_left.write(data)
+
+        with measure_time() as elapsed:
+            result = serial_right.readexactly(len(data))
+
+        assert result == data
+        assert elapsed() < 1.0
+
+
+def test_readexactly_partial_timeout_dual(adapter_pair: tuple[str, str]) -> None:
+    """Test that readexactly(10) with only 5 bytes raises IncompleteReadError."""
+    left_port, right_port = adapter_pair
+
+    with create_dual_loopback(
+        left_port, right_port, baudrate=115200, read_timeout=0.5
+    ) as (
+        serial_left,
+        serial_right,
+    ):
+        serial_left.write(b"hello")
+        serial_left.flush()
+
+        with measure_time() as elapsed:
+            with pytest.raises(IncompleteReadError) as exc_info:
+                serial_right.readexactly(10)
+
+        assert exc_info.value.partial == b"hello"
+        assert 0.5 <= elapsed() < 1.0
 
 
 def test_fast_open_close(adapter_pair: tuple[str, str]) -> None:

--- a/tests/test_loopback_dual_sync.py
+++ b/tests/test_loopback_dual_sync.py
@@ -379,9 +379,7 @@ def test_open_close_cycles_dual(adapter_pair: tuple[str, str]) -> None:
 
     # Cycle 1
     serial_left.open()
-    serial_left.configure_port()
     serial_right.open()
-    serial_right.configure_port()
     serial_left.write(b"1")
     assert serial_right.readexactly(1) == b"1"
     serial_left.close()
@@ -389,9 +387,7 @@ def test_open_close_cycles_dual(adapter_pair: tuple[str, str]) -> None:
 
     # Cycle 2
     serial_left.open()
-    serial_left.configure_port()
     serial_right.open()
-    serial_right.configure_port()
     serial_left.write(b"2")
     assert serial_right.readexactly(1) == b"2"
     serial_left.close()
@@ -399,9 +395,7 @@ def test_open_close_cycles_dual(adapter_pair: tuple[str, str]) -> None:
 
     # Cycle 3
     serial_left.open()
-    serial_left.configure_port()
     serial_right.open()
-    serial_right.configure_port()
     serial_left.write(b"3")
     assert serial_right.readexactly(1) == b"3"
     serial_left.close()

--- a/tests/test_loopback_sync.py
+++ b/tests/test_loopback_sync.py
@@ -308,21 +308,18 @@ def test_open_close_cycles_loopback(loopback_adapter: str) -> None:
 
     # Cycle 1
     serial.open()
-    serial.configure_port()
     serial.write(b"1")
     assert serial.readexactly(1) == b"1"
     serial.close()
 
     # Cycle 2
     serial.open()
-    serial.configure_port()
     serial.write(b"2")
     assert serial.readexactly(1) == b"2"
     serial.close()
 
     # Cycle 3
     serial.open()
-    serial.configure_port()
     serial.write(b"3")
     assert serial.readexactly(1) == b"3"
     serial.close()

--- a/tests/test_serial_linux.py
+++ b/tests/test_serial_linux.py
@@ -75,12 +75,12 @@ async def test_async_linux_race_condition_connect_close() -> None:
     resume_configuring = threading.Event()
 
     class SlowConfigureSerial(PosixSerial):
-        def configure_port(self) -> None:
+        def _configure_port(self) -> None:
             started_configuring.set()
             if not resume_configuring.wait(timeout=5.0):
                 raise RuntimeError("Timeout waiting for resume signal")
 
-            super().configure_port()
+            super()._configure_port()
 
     class TestTransport(PosixSerialTransport):
         _serial_cls = SlowConfigureSerial

--- a/tests/test_serial_socket.py
+++ b/tests/test_serial_socket.py
@@ -1,0 +1,39 @@
+"""Socket serial port tests."""
+
+import pytest
+
+from serialx import serial_for_url
+from serialx.platforms.serial_socket import SocketSerial
+from tests.socket_relay import create_socket_pair
+
+
+def test_socket_connect_timeout_property() -> None:
+    """Test that connect_timeout property is accessible."""
+    serial = SocketSerial(
+        path="socket://127.0.0.1:1234",
+        baudrate=115200,
+        connect_timeout=0.5,
+    )
+    assert serial.connect_timeout == 0.5
+
+
+def test_socket_effective_timeout_mismatched() -> None:
+    """Test that mismatched read/write timeouts use min for socket timeout."""
+    with create_socket_pair() as (left_url, _right_url):
+        serial = serial_for_url(
+            left_url, baudrate=115200, read_timeout=2.0, write_timeout=1.0
+        )
+        assert isinstance(serial, SocketSerial)
+
+        with serial:
+            assert serial._socket is not None
+            assert serial._socket.gettimeout() == 1.0
+
+
+def test_socket_invalid_uri() -> None:
+    """Test that invalid URIs raise ValueError."""
+    with pytest.raises(ValueError, match="expected both host and port"):
+        SocketSerial(path="socket://127.0.0.1", baudrate=115200)
+
+    with pytest.raises(ValueError, match="expected both host and port"):
+        SocketSerial(path="socket://:1234", baudrate=115200)

--- a/tests/test_sync_transports.py
+++ b/tests/test_sync_transports.py
@@ -3,6 +3,7 @@
 from collections.abc import Iterator
 import logging
 import os
+import time
 
 import pytest
 
@@ -441,3 +442,66 @@ def test_sync_deprecated_rts_property(sync_transport_pair: tuple[str, str]) -> N
     with serial_for_url(left_path, baudrate=115200) as serial:
         serial.rts = True
         serial.rts = False
+
+
+def test_sync_read_timeout(sync_transport_pair: tuple[str, str]) -> None:
+    """Test that reading with a timeout returns 0 bytes after the timeout."""
+    left_path, _ = sync_transport_pair
+
+    with serial_for_url(left_path, baudrate=115200, timeout=0.1) as serial:
+        start_time = time.time()
+        # Try to read 10 bytes when no data is available
+        result = serial.read(10)
+        end_time = time.time()
+
+        # Should return 0 bytes
+        assert len(result) == 0
+        # Should have taken at least 0.1 seconds (allowing for some OS jitter)
+        assert end_time - start_time >= 0.09
+
+
+def test_sync_read_timeout_with_partial_data(
+    sync_transport_pair: tuple[str, str],
+) -> None:
+    """Test that reading with a timeout returns available data immediately."""
+    left_path, right_path = sync_transport_pair
+
+    with (
+        serial_for_url(left_path, baudrate=115200, timeout=1.0) as serial_left,
+        serial_for_url(right_path, baudrate=115200, timeout=1.0) as serial_right,
+    ):
+        # Write 5 bytes from one side
+        data = b"hello"
+        serial_left.write(data)
+
+        start_time = time.time()
+        # Try to read 5 bytes (matching what we wrote)
+        result = serial_right.read(5)
+        end_time = time.time()
+
+        # Should return 5 bytes immediately
+        assert result == data
+        # Should have taken much less than 1.0 seconds
+        assert end_time - start_time < 0.2
+
+
+def test_socket_connect_timeout() -> None:
+    """Test that connect_timeout is respected by SocketSerial."""
+    # We use a non-routable IP to trigger a timeout (TEST-NET-1)
+    # 192.0.2.1 is reserved for documentation and shouldn't be reachable
+    url = "socket://192.0.2.1:1234"
+
+    start_time = time.time()
+
+    with pytest.raises((OSError, TimeoutError)):
+        # connect_timeout is passed to SocketSerial constructor via kwargs
+        with serial_for_url(url, baudrate=115200, connect_timeout=0.2):
+            pass
+
+    end_time = time.time()
+
+    # Should have timed out after ~0.2s
+    # Note: On some systems, "no route to host" might return instantly,
+    # so we primarily check that it didn't hang forever.
+    duration = end_time - start_time
+    assert duration < 1.0

--- a/tests/test_sync_transports.py
+++ b/tests/test_sync_transports.py
@@ -505,3 +505,44 @@ def test_socket_connect_timeout() -> None:
     # so we primarily check that it didn't hang forever.
     duration = end_time - start_time
     assert duration < 1.0
+
+
+def test_sync_write_timeout(sync_transport_pair: tuple[str, str]) -> None:
+    """Test that write timeout works when buffer is full."""
+    left_path, _ = sync_transport_pair
+
+    # Open with a short write timeout
+    with serial_for_url(left_path, baudrate=115200, write_timeout=0.1) as serial:
+        # We need to write enough data to fill the kernel buffers.
+        # OS buffers can be quite large (e.g. 16KB-64KB).
+        # We'll try to write a significant amount.
+        data = b"x" * 1024
+
+        start_time = time.time()
+        try:
+            # Write continuously until we hit a timeout or write a lot of data
+            # 1MB should be enough to fill most buffers if no one is reading
+            for _ in range(1000):
+                serial.write(data)
+        except TimeoutError:
+            # Success: we timed out
+            pass
+        except OSError as e:
+            # On some systems, non-blocking write to full buffer might raise EAGAIN/EWOULDBLOCK
+            # which might surface as OSError if not caught inside write().
+            # But our implementation catches it (implicitly via select or WaitForSingleObject).
+            # On sockets, it might behave differently.
+            if "Resource temporarily unavailable" not in str(e):
+                raise
+        else:
+            # If we didn't timeout, it means either the buffer is HUGE or data is being drained
+            # (which shouldn't happen as we didn't open the other side).
+            # However, for socket pairs, if the other side is not "open",
+            # writing might fail with BrokenPipe or similar, or just buffer locally.
+            # Socat might drain to its internal buffer.
+            # This test is best-effort.
+            pass
+
+        end_time = time.time()
+        # We don't assert specific timing because we might have filled the buffer quickly
+        # and then timed out, or timed out immediately on the Nth write.

--- a/tests/test_sync_transports.py
+++ b/tests/test_sync_transports.py
@@ -3,13 +3,12 @@
 from collections.abc import Iterator
 import logging
 import os
-import time
 
 import pytest
 
 from serialx import ModemPins, Parity, PinState, Serial, StopBits, serial_for_url
 from serialx.common import BaseSerial
-from tests.common import SOCAT_BINARY, create_socat_pair
+from tests.common import SOCAT_BINARY, create_socat_pair, measure_time
 from tests.socket_relay import create_socket_pair
 
 LOGGER = logging.getLogger(__name__)
@@ -449,15 +448,14 @@ def test_sync_read_timeout(sync_transport_pair: tuple[str, str]) -> None:
     with serial_for_url(left_path, baudrate=115200, read_timeout=0.1) as serial:
         assert serial.read_timeout == 0.1
 
-        start_time = time.time()
-        # Try to read 10 bytes when no data is available
-        result = serial.read(10)
-        end_time = time.time()
+        with measure_time() as elapsed:
+            # Try to read 10 bytes when no data is available
+            result = serial.read(10)
 
         # Should return 0 bytes
         assert len(result) == 0
         # Should have taken at least 0.1 seconds (allowing for some OS jitter)
-        assert end_time - start_time >= 0.09
+        assert elapsed() >= 0.09
 
 
 def test_sync_read_timeout_with_partial_data(
@@ -474,15 +472,14 @@ def test_sync_read_timeout_with_partial_data(
         data = b"hello"
         serial_left.write(data)
 
-        start_time = time.time()
-        # Try to read 5 bytes (matching what we wrote)
-        result = serial_right.read(5)
-        end_time = time.time()
+        with measure_time() as elapsed:
+            # Try to read 5 bytes (matching what we wrote)
+            result = serial_right.read(5)
 
         # Should return 5 bytes immediately
         assert result == data
         # Should have taken much less than 1.0 seconds
-        assert end_time - start_time < 0.2
+        assert elapsed() < 0.2
 
 
 def test_socket_connect_timeout() -> None:
@@ -491,20 +488,16 @@ def test_socket_connect_timeout() -> None:
     # 192.0.2.1 is reserved for documentation and shouldn't be reachable
     url = "socket://192.0.2.1:1234"
 
-    start_time = time.time()
-
-    with pytest.raises((OSError, TimeoutError)):
-        # connect_timeout is passed to SocketSerial constructor via kwargs
-        with serial_for_url(url, baudrate=115200, connect_timeout=0.2):
-            pass
-
-    end_time = time.time()
+    with measure_time() as elapsed:
+        with pytest.raises((OSError, TimeoutError)):
+            # connect_timeout is passed to SocketSerial constructor via kwargs
+            with serial_for_url(url, baudrate=115200, connect_timeout=0.2):
+                pass
 
     # Should have timed out after ~0.2s
     # Note: On some systems, "no route to host" might return instantly,
     # so we primarily check that it didn't hang forever.
-    duration = end_time - start_time
-    assert duration < 1.0
+    assert elapsed() < 1.0
 
 
 def test_sync_write_timeout(sync_transport_pair: tuple[str, str]) -> None:

--- a/tests/test_sync_transports.py
+++ b/tests/test_sync_transports.py
@@ -448,7 +448,7 @@ def test_sync_read_timeout(sync_transport_pair: tuple[str, str]) -> None:
     """Test that reading with a timeout returns 0 bytes after the timeout."""
     left_path, _ = sync_transport_pair
 
-    with serial_for_url(left_path, baudrate=115200, timeout=0.1) as serial:
+    with serial_for_url(left_path, baudrate=115200, read_timeout=0.1) as serial:
         start_time = time.time()
         # Try to read 10 bytes when no data is available
         result = serial.read(10)
@@ -467,8 +467,8 @@ def test_sync_read_timeout_with_partial_data(
     left_path, right_path = sync_transport_pair
 
     with (
-        serial_for_url(left_path, baudrate=115200, timeout=1.0) as serial_left,
-        serial_for_url(right_path, baudrate=115200, timeout=1.0) as serial_right,
+        serial_for_url(left_path, baudrate=115200, read_timeout=1.0) as serial_left,
+        serial_for_url(right_path, baudrate=115200, read_timeout=1.0) as serial_right,
     ):
         # Write 5 bytes from one side
         data = b"hello"

--- a/tests/test_sync_transports.py
+++ b/tests/test_sync_transports.py
@@ -447,6 +447,8 @@ def test_sync_read_timeout(sync_transport_pair: tuple[str, str]) -> None:
     left_path, _ = sync_transport_pair
 
     with serial_for_url(left_path, baudrate=115200, read_timeout=0.1) as serial:
+        assert serial.read_timeout == 0.1
+
         start_time = time.time()
         # Try to read 10 bytes when no data is available
         result = serial.read(10)

--- a/tests/test_sync_transports.py
+++ b/tests/test_sync_transports.py
@@ -361,9 +361,7 @@ def test_sync_open_close_cycles(sync_transport_pair: tuple[str, str]) -> None:
 
     for i in range(1, 4):
         serial_left.open()
-        serial_left.configure_port()
         serial_right.open()
-        serial_right.configure_port()
 
         chunk = str(i).encode("ascii")
         serial_left.write(chunk)
@@ -511,7 +509,10 @@ def test_sync_write_timeout(sync_transport_pair: tuple[str, str]) -> None:
     """Test that write timeout works when buffer is full."""
     left_path, _ = sync_transport_pair
 
-    with serial_for_url(left_path, baudrate=115200, write_timeout=0.1) as serial:
+    if left_path.startswith("socket://"):
+        pytest.skip("Write timeout test is not applicable to socket transport")
+
+    with serial_for_url(left_path, baudrate=9600, write_timeout=0.1) as serial:
         data = b"x" * 1024
 
         with pytest.raises(TimeoutError):

--- a/tests/test_sync_transports.py
+++ b/tests/test_sync_transports.py
@@ -1,5 +1,6 @@
 """Sync transport tests."""
 
+from asyncio import IncompleteReadError
 from collections.abc import Iterator
 import logging
 import os
@@ -480,6 +481,26 @@ def test_sync_read_timeout_with_partial_data(
         assert result == data
         # Should have taken much less than 1.0 seconds
         assert elapsed() < 0.2
+
+
+def test_sync_readexactly_partial_timeout(
+    sync_transport_pair: tuple[str, str],
+) -> None:
+    """Test that readexactly(10) with only 5 bytes raises IncompleteReadError."""
+    left_path, right_path = sync_transport_pair
+
+    with (
+        serial_for_url(left_path, baudrate=115200, read_timeout=0.5) as serial_left,
+        serial_for_url(right_path, baudrate=115200, read_timeout=0.5) as serial_right,
+    ):
+        serial_left.write(b"hello")
+
+        with measure_time() as elapsed:
+            with pytest.raises(IncompleteReadError) as exc_info:
+                serial_right.readexactly(10)
+
+        assert exc_info.value.partial == b"hello"
+        assert 0.5 <= elapsed() < 1.0
 
 
 def test_socket_connect_timeout() -> None:

--- a/tests/test_sync_transports.py
+++ b/tests/test_sync_transports.py
@@ -511,38 +511,9 @@ def test_sync_write_timeout(sync_transport_pair: tuple[str, str]) -> None:
     """Test that write timeout works when buffer is full."""
     left_path, _ = sync_transport_pair
 
-    # Open with a short write timeout
     with serial_for_url(left_path, baudrate=115200, write_timeout=0.1) as serial:
-        # We need to write enough data to fill the kernel buffers.
-        # OS buffers can be quite large (e.g. 16KB-64KB).
-        # We'll try to write a significant amount.
         data = b"x" * 1024
 
-        start_time = time.time()
-        try:
-            # Write continuously until we hit a timeout or write a lot of data
-            # 1MB should be enough to fill most buffers if no one is reading
+        with pytest.raises(TimeoutError):
             for _ in range(1000):
                 serial.write(data)
-        except TimeoutError:
-            # Success: we timed out
-            pass
-        except OSError as e:
-            # On some systems, non-blocking write to full buffer might raise EAGAIN/EWOULDBLOCK
-            # which might surface as OSError if not caught inside write().
-            # But our implementation catches it (implicitly via select or WaitForSingleObject).
-            # On sockets, it might behave differently.
-            if "Resource temporarily unavailable" not in str(e):
-                raise
-        else:
-            # If we didn't timeout, it means either the buffer is HUGE or data is being drained
-            # (which shouldn't happen as we didn't open the other side).
-            # However, for socket pairs, if the other side is not "open",
-            # writing might fail with BrokenPipe or similar, or just buffer locally.
-            # Socat might drain to its internal buffer.
-            # This test is best-effort.
-            pass
-
-        end_time = time.time()
-        # We don't assert specific timing because we might have filled the buffer quickly
-        # and then timed out, or timed out immediately on the Nth write.


### PR DESCRIPTION
To fully expose platform-specific timeouts, we take a single `read_timeout` kwarg and then have platform-specific timeouts for all other platforms.

Individual platforms have more tuning:
- POSIX exposes `VMIN` as `min_read_size` and `VMAX` as `inter_byte_timeout`
- Windows exposes `inter_byte_timeout`
- Socket exposes `connect_timeout`
