### PR TITLE
Fix ESPHome transport by subscribing serial proxy instance

### DIFF
--- a/serialx/platforms/serial_esphome.py
+++ b/serialx/platforms/serial_esphome.py
@@ -81,6 +81,7 @@ class ESPHomeSerial(BaseSerial):
         self._read_buffer = bytearray()
         self._read_event = asyncio.Event()
         self._unsub: Callable[[], None] | None = None
+        self._instance_subscribed = False
 
     def _on_data(self, msg: aioesphomeapi.SerialProxyDataReceived) -> None:
         if msg.instance == self.instance:
@@ -91,6 +92,7 @@ class ESPHomeSerial(BaseSerial):
         """Open the serial port."""
         asyncio.run(self._async_open())
         assert self.api is not None
+        self._subscribe_instance()
         self._unsub = self.api.subscribe_serial_proxy_data(self._on_data)
 
     async def _async_open(self) -> None:
@@ -101,6 +103,27 @@ class ESPHomeSerial(BaseSerial):
             noise_psk=self._noise_psk,
         )
         await self.api.connect(login=True)
+
+    def _subscribe_instance(self) -> None:
+        """Subscribe serial proxy streaming for this instance if supported."""
+        if self.api is None or self._instance_subscribed:
+            return
+        subscribe = getattr(self.api, "serial_proxy_subscribe", None)
+        if subscribe is None:
+            return
+        subscribe(self.instance)
+        self._instance_subscribed = True
+
+    def _unsubscribe_instance(self) -> None:
+        """Unsubscribe serial proxy streaming for this instance if supported."""
+        if self.api is None or not self._instance_subscribed:
+            return
+        unsubscribe = getattr(self.api, "serial_proxy_unsubscribe", None)
+        if unsubscribe is None:
+            self._instance_subscribed = False
+            return
+        unsubscribe(self.instance)
+        self._instance_subscribed = False
 
     def configure_port(self) -> None:
         """Configure the serial port settings."""
@@ -170,6 +193,7 @@ class ESPHomeSerial(BaseSerial):
             self._unsub = None
 
         if self.api is not None:
+            self._unsubscribe_instance()
             asyncio.run(self.api.disconnect())
             self.api = None
 
@@ -213,6 +237,7 @@ class ESPHomeSerialTransport(BaseSerialTransport):
         self._serial.configure_port()
 
         assert self._serial.api is not None
+        self._serial._subscribe_instance()
         self._unsub = self._serial.api.subscribe_serial_proxy_data(self._on_data)
 
         self._protocol.connection_made(self)
@@ -240,6 +265,7 @@ class ESPHomeSerialTransport(BaseSerialTransport):
             self._unsub = None
 
         if self._serial is not None and self._serial.api is not None:
+            self._serial._unsubscribe_instance()
             api = self._serial.api
             self._serial.api = None
             self._loop.create_task(self._async_close(api))

--- a/tests/test_serial_esphome.py
+++ b/tests/test_serial_esphome.py
@@ -1,0 +1,136 @@
+"""Tests for ESPHome serial transport behavior."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+pytest.importorskip("aioesphomeapi")
+
+from serialx.platforms import serial_esphome
+
+
+class _DummyAPIClient:
+    """Simple API client test double."""
+
+    def __init__(self, *_args, **_kwargs) -> None:
+        self.connected = False
+        self.disconnected = False
+        self.serial_proxy_configure_calls: list[dict] = []
+        self.serial_proxy_subscribe_calls: list[int] = []
+        self.serial_proxy_unsubscribe_calls: list[int] = []
+        self.stream_subscribed = False
+        self.stream_unsubscribed = False
+
+    async def connect(self, *, login: bool = True) -> None:
+        self.connected = login
+
+    async def disconnect(self) -> None:
+        self.disconnected = True
+
+    def serial_proxy_configure(self, **kwargs) -> None:
+        self.serial_proxy_configure_calls.append(kwargs)
+
+    def serial_proxy_subscribe(self, instance: int) -> None:
+        self.serial_proxy_subscribe_calls.append(instance)
+
+    def serial_proxy_unsubscribe(self, instance: int) -> None:
+        self.serial_proxy_unsubscribe_calls.append(instance)
+
+    def subscribe_serial_proxy_data(self, _callback):
+        self.stream_subscribed = True
+
+        def _unsub() -> None:
+            self.stream_unsubscribed = True
+
+        return _unsub
+
+    def serial_proxy_write(self, *, instance: int, data: bytes) -> None:
+        _ = (instance, data)
+
+    async def serial_proxy_flush(self, *, instance: int) -> None:
+        _ = instance
+
+
+class _DummyAPIClientNoInstanceSubscription:
+    """API client without instance subscribe APIs (older aioesphomeapi)."""
+
+    def __init__(self, *_args, **_kwargs) -> None:
+        self.connected = False
+        self.disconnected = False
+        self.stream_subscribed = False
+        self.stream_unsubscribed = False
+
+    async def connect(self, *, login: bool = True) -> None:
+        self.connected = login
+
+    async def disconnect(self) -> None:
+        self.disconnected = True
+
+    def serial_proxy_configure(self, **_kwargs) -> None:
+        return
+
+    def subscribe_serial_proxy_data(self, _callback):
+        self.stream_subscribed = True
+
+        def _unsub() -> None:
+            self.stream_unsubscribed = True
+
+        return _unsub
+
+    def serial_proxy_write(self, *, instance: int, data: bytes) -> None:
+        _ = (instance, data)
+
+    async def serial_proxy_flush(self, *, instance: int) -> None:
+        _ = instance
+
+
+@pytest.mark.asyncio
+async def test_transport_subscribes_instance_and_unsubscribes_on_close(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ensure instance subscription is managed with the transport lifecycle."""
+    api = _DummyAPIClient()
+    monkeypatch.setattr(serial_esphome.aioesphomeapi, "APIClient", lambda *_a, **_k: api)
+
+    loop = asyncio.get_running_loop()
+    protocol = asyncio.Protocol()
+    transport = serial_esphome.ESPHomeSerialTransport(loop=loop, protocol=protocol)
+
+    await transport.connect(url="esphome://example-host/1", baudrate=9600)
+
+    assert api.connected
+    assert api.stream_subscribed
+    assert api.serial_proxy_subscribe_calls == [1]
+
+    transport.close()
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert api.stream_unsubscribed
+    assert api.serial_proxy_unsubscribe_calls == [1]
+    assert api.disconnected
+
+
+@pytest.mark.asyncio
+async def test_transport_works_without_instance_subscribe_api(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep compatibility when aioesphomeapi lacks instance subscribe methods."""
+    api = _DummyAPIClientNoInstanceSubscription()
+    monkeypatch.setattr(serial_esphome.aioesphomeapi, "APIClient", lambda *_a, **_k: api)
+
+    loop = asyncio.get_running_loop()
+    protocol = asyncio.Protocol()
+    transport = serial_esphome.ESPHomeSerialTransport(loop=loop, protocol=protocol)
+
+    await transport.connect(url="esphome://example-host/2", baudrate=9600)
+    transport.close()
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert api.connected
+    assert api.stream_subscribed
+    assert api.stream_unsubscribed
+    assert api.disconnected


### PR DESCRIPTION
I was messing around with the ESPHome proxy PR with serialx and ran into an issue.

Below is written by AI:

## Summary

Fix `esphome://` serial transports so they explicitly subscribe to the selected serial-proxy instance before expecting RX data.

This restores end-to-end behavior for ESPHome serial proxy setups where writes succeed but no inbound bytes are delivered unless `serial_proxy_subscribe(instance)` is called.

## Problem

With recent ESPHome serial proxy behavior, connecting and configuring a serial proxy instance is not enough to receive data events. The client must explicitly subscribe to that instance.

`serialx` currently:
- connects API client
- configures serial proxy port
- registers `subscribe_serial_proxy_data(...)` callback

…but never sends `serial_proxy_subscribe(instance)`.

### Observed failure mode

On a live setup (`connect-proxy-sendspin` at `192.168.1.227`, Denon AVR-X2700H on RS232):

- `serialx.open_serial_connection("esphome://192.168.1.227/1", baudrate=9600)`
- `writer.write(b"PW?\\r")`
- `reader.read(...)` timed out with empty bytes repeatedly

At the same time, the exact same command path worked immediately when sending `api.serial_proxy_subscribe(1)` manually first.

## Root Cause

`subscribe_serial_proxy_data(...)` registers a callback for data events, but does not itself request that the server begin streaming a specific serial instance.

The explicit instance request is done via:
- `serial_proxy_subscribe(instance)`
- and should be paired with `serial_proxy_unsubscribe(instance)` on close.

## Changes

### `serialx/platforms/serial_esphome.py`

- Add instance subscription lifecycle tracking:
  - `self._instance_subscribed`
  - `_subscribe_instance()`
  - `_unsubscribe_instance()`
- On open/connect:
  - call `_subscribe_instance()` before setting the data callback
- On close:
  - call `_unsubscribe_instance()` before API disconnect
- Apply this in both:
  - sync `ESPHomeSerial` path
  - async `ESPHomeSerialTransport` path

### Backward compatibility

Some older `aioesphomeapi` variants may not expose subscribe/unsubscribe helpers.

To avoid regressions, this patch uses `getattr(...)` and no-ops when those methods are unavailable.

## Tests

Added: `tests/test_serial_esphome.py`

1. `test_transport_subscribes_instance_and_unsubscribes_on_close`
   - verifies `serial_proxy_subscribe(instance)` is called on connect
   - verifies `serial_proxy_unsubscribe(instance)` is called on close
2. `test_transport_works_without_instance_subscribe_api`
   - verifies behavior remains functional when subscribe APIs do not exist

## Verification

### Unit

- `pytest -q -o addopts='' tests/test_serial_esphome.py`
- Result: `2 passed`

### Manual (live hardware)

On the setup above:

Before patch:
- `esphome://.../1` writes sent, but RX stayed empty.

After patch:
- `PW?\r` over `serialx` returns `PWON\r`
- higher-level Denon client connection succeeds and power queries return `PowerState.ON`

This confirms the fix in real-world traffic and not only mocked tests.
