### PR TITLE
Properly separate POSIX functionality from the Linux-specific platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,10 +285,34 @@ jobs:
           include-hidden-files: true
           path: .coverage
 
+  pytest-freebsd:
+    runs-on: ubuntu-latest
+    name: Run tests (FreeBSD)
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v4
+      - name: Run tests on FreeBSD
+        uses: vmactions/freebsd-vm@v1
+        with:
+          usesh: true
+          prepare: |
+            pkg install -y python3 socat git
+          run: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install -e .[dev] pytest-cov
+            pytest --timeout=20 --cov=serialx tests
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-freebsd-latest
+          include-hidden-files: true
+          path: .coverage
+
   coverage:
     name: Process test coverage
     runs-on: ubuntu-latest
-    needs: [pytest, pytest-macos, pytest-windows]
+    needs: [pytest, pytest-macos, pytest-windows, pytest-freebsd]
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,34 +285,10 @@ jobs:
           include-hidden-files: true
           path: .coverage
 
-  pytest-freebsd:
-    runs-on: ubuntu-latest
-    name: Run tests (FreeBSD)
-    steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@v4
-      - name: Run tests on FreeBSD
-        uses: vmactions/freebsd-vm@v1
-        with:
-          usesh: true
-          prepare: |
-            pkg install -y python3 socat git
-          run: |
-            python3 -m venv venv
-            . venv/bin/activate
-            pip install -e .[dev] pytest-cov
-            pytest --timeout=20 --cov=serialx tests
-      - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-freebsd-latest
-          include-hidden-files: true
-          path: .coverage
-
   coverage:
     name: Process test coverage
     runs-on: ubuntu-latest
-    needs: [pytest, pytest-macos, pytest-windows, pytest-freebsd]
+    needs: [pytest, pytest-macos, pytest-windows]
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v4

--- a/serialx/__init__.py
+++ b/serialx/__init__.py
@@ -13,8 +13,10 @@ from .common import (
     ModemPins,
     Parity,
     PinState,
+    SerialException,
     SerialPortInfo,
     StopBits,
+    UnsupportedSetting,
     get_serial_classes,
 )
 from .platforms import Serial, SerialTransport, list_serial_ports
@@ -30,6 +32,8 @@ __all__ = [
     "BaseSerial",
     "BaseSerialTransport",
     "Serial",
+    "SerialException",
+    "UnsupportedSetting",
     "SerialPortInfo",
     "SerialStreamWriter",
     "SerialTransport",
@@ -44,14 +48,6 @@ def patch_pyserial():
 
     for module in _MODULES_TO_PATCH:
         sys.modules[module] = sys.modules[__name__]
-
-
-class SerialException(Exception):
-    pass
-
-
-class UnsupportedSetting(SerialException):
-    """Raised when an unsupported serial port setting is used."""
 
 
 def serial_for_url(url, *args, **kwargs) -> BaseSerial:

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -17,6 +17,14 @@ import warnings
 from typing_extensions import Self
 
 
+class SerialException(Exception):
+    """Base serial exception."""
+
+
+class UnsupportedSetting(SerialException):
+    """Raised when an unsupported serial port setting is used."""
+
+
 class StopBits(Enum):
     """Stop bits configuration."""
 

--- a/serialx/platforms/__init__.py
+++ b/serialx/platforms/__init__.py
@@ -28,11 +28,19 @@ elif sys.platform == "darwin":
         darwin_list_serial_ports as list_serial_ports,
     )
 elif maybe_posix:
-    from .serial_posix import (
-        PosixSerial as Serial,
-        PosixSerialTransport as SerialTransport,
-        posix_list_serial_ports as list_serial_ports,
-    )
+    from .serial_extended_posix import is_extended_posix
+
+    if is_extended_posix():
+        from .serial_extended_posix import (
+            ExtendedPosixSerial as Serial,
+            ExtendedPosixSerialTransport as SerialTransport,
+        )
+    else:
+        from .serial_posix import (
+            PosixSerial as Serial,
+            PosixSerialTransport as SerialTransport,
+        )
+    from .serial_posix import posix_list_serial_ports as list_serial_ports
 else:
     raise RuntimeError(f"Unsupported platform: {sys.platform}")
 

--- a/serialx/platforms/__init__.py
+++ b/serialx/platforms/__init__.py
@@ -2,23 +2,36 @@
 
 import sys
 
+try:
+    import termios  # noqa: F401
+except ImportError:
+    maybe_posix = False
+else:
+    maybe_posix = True
+
 if sys.platform == "win32":
     from .serial_win32 import (
         Win32Serial as Serial,
         Win32SerialTransport as SerialTransport,
         win32_list_serial_ports as list_serial_ports,
     )
-elif sys.platform == "linux" or sys.platform == "freebsd":
-    from .serial_posix import (
-        PosixSerial as Serial,
-        PosixSerialTransport as SerialTransport,
-        posix_list_serial_ports as list_serial_ports,
+elif sys.platform == "linux":
+    from .serial_linux import (
+        LinuxSerial as Serial,
+        LinuxSerialTransport as SerialTransport,
+        linux_list_serial_ports as list_serial_ports,
     )
 elif sys.platform == "darwin":
     from .serial_darwin import (
         DarwinSerial as Serial,
         DarwinSerialTransport as SerialTransport,
         darwin_list_serial_ports as list_serial_ports,
+    )
+elif maybe_posix:
+    from .serial_posix import (
+        PosixSerial as Serial,
+        PosixSerialTransport as SerialTransport,
+        posix_list_serial_ports as list_serial_ports,
     )
 else:
     raise RuntimeError(f"Unsupported platform: {sys.platform}")

--- a/serialx/platforms/serial_darwin.py
+++ b/serialx/platforms/serial_darwin.py
@@ -11,7 +11,7 @@ import termios
 from serialx._serialx_rust import list_serial_ports_darwin_impl
 from serialx.common import SerialPortInfo
 
-from .serial_posix import PosixSerial, PosixSerialTransport
+from .serial_extended_posix import ExtendedPosixSerial, ExtendedPosixSerialTransport
 
 LOGGER = logging.getLogger(__name__)
 
@@ -22,7 +22,7 @@ IOSSIOSPEED = 0x80045402
 NON_POSIX_FALLBACK_BAUDRATE_CONST = termios.B115200
 
 
-class DarwinSerial(PosixSerial):
+class DarwinSerial(ExtendedPosixSerial):
     """Darwin serial port implementation."""
 
     def _build_ispeed(self) -> int:
@@ -61,7 +61,7 @@ class DarwinSerial(PosixSerial):
             self._set_non_posix_baudrate(self._baudrate)
 
 
-class DarwinSerialTransport(PosixSerialTransport):
+class DarwinSerialTransport(ExtendedPosixSerialTransport):
     """Darwin asyncio serial port transport."""
 
     _serial_cls = DarwinSerial

--- a/serialx/platforms/serial_darwin.py
+++ b/serialx/platforms/serial_darwin.py
@@ -6,6 +6,7 @@ import array
 import errno
 import fcntl
 import logging
+import termios
 
 from serialx._serialx_rust import list_serial_ports_darwin_impl
 from serialx.common import SerialPortInfo
@@ -16,21 +17,48 @@ LOGGER = logging.getLogger(__name__)
 
 IOSSIOSPEED = 0x80045402
 
+# When we need to set a non-POSIX baudrate, we set the baudrates to a known default and
+# then override
+NON_POSIX_FALLBACK_BAUDRATE_CONST = termios.B115200
+
 
 class DarwinSerial(PosixSerial):
     """Darwin serial port implementation."""
+
+    def _build_ispeed(self) -> int:
+        return (
+            NON_POSIX_FALLBACK_BAUDRATE_CONST
+            if self._has_non_posix_baudrate
+            else getattr(termios, f"B{self._baudrate}")
+        )
+
+    def _build_ospeed(self) -> int:
+        return (
+            NON_POSIX_FALLBACK_BAUDRATE_CONST
+            if self._has_non_posix_baudrate
+            else getattr(termios, f"B{self._baudrate}")
+        )
+
+    @property
+    def _has_non_posix_baudrate(self) -> bool:
+        return hasattr(termios, f"B{self._baudrate}")
 
     def _set_non_posix_baudrate(self, baudrate: int) -> None:
         """Set the baudrate of the serial port."""
         assert self._fileno is not None
 
-        buffer = array.array("i", [self._baudrate])
+        buffer = array.array("i", [baudrate])
 
         try:
             fcntl.ioctl(self._fileno, IOSSIOSPEED, buffer)
         except OSError as exc:
             if exc.errno == errno.ENOTTY:
                 LOGGER.debug("Device is not a serial port, cannot set baudrate")
+
+    def _after_configure_port(self) -> None:  # noqa: C901
+        if self._has_non_posix_baudrate:
+            LOGGER.debug("Setting non-POSIX baudrate %d", self._baudrate)
+            self._set_non_posix_baudrate(self._baudrate)
 
 
 class DarwinSerialTransport(PosixSerialTransport):

--- a/serialx/platforms/serial_darwin.py
+++ b/serialx/platforms/serial_darwin.py
@@ -41,7 +41,7 @@ class DarwinSerial(PosixSerial):
 
     @property
     def _has_non_posix_baudrate(self) -> bool:
-        return hasattr(termios, f"B{self._baudrate}")
+        return not hasattr(termios, f"B{self._baudrate}")
 
     def _set_non_posix_baudrate(self, baudrate: int) -> None:
         """Set the baudrate of the serial port."""

--- a/serialx/platforms/serial_extended_posix.py
+++ b/serialx/platforms/serial_extended_posix.py
@@ -1,0 +1,40 @@
+"""Extended POSIX serial port implementation.
+
+Adds non-POSIX features that are available on all major UNIX-like platforms.
+"""
+
+from __future__ import annotations
+
+import termios
+
+from .serial_posix import PosixSerial, PosixSerialTransport
+
+CRTSCTS = getattr(termios, "CRTSCTS", getattr(termios, "CNEW_RTSCTS", None))
+
+
+def is_extended_posix() -> bool:
+    """Check if the platform supports extended POSIX serial features."""
+    return CRTSCTS is not None
+
+
+class ExtendedPosixSerial(PosixSerial):
+    """Extended POSIX serial port with CRTSCTS support."""
+
+    def _build_flow_control_flags(self) -> tuple[int, int]:
+        iflag = 0x00000000
+        cflag = 0x00000000
+
+        if self._xonxoff:
+            iflag |= termios.IXON | termios.IXOFF | termios.IXANY
+
+        if self._rtscts:
+            assert CRTSCTS is not None
+            cflag |= CRTSCTS
+
+        return (iflag, cflag)
+
+
+class ExtendedPosixSerialTransport(PosixSerialTransport):
+    """Extended POSIX serial port transport with CRTSCTS support."""
+
+    _serial_cls = ExtendedPosixSerial

--- a/serialx/platforms/serial_linux.py
+++ b/serialx/platforms/serial_linux.py
@@ -104,8 +104,8 @@ class LinuxSerial(PosixSerial):
             ) from exc
 
         termios2_speed_struct = Termios2SpeedStruct.from_buffer(buffer, offset)
-        termios2_speed_struct.c_ispeed = self._baudrate
-        termios2_speed_struct.c_ospeed = self._baudrate
+        termios2_speed_struct.c_ispeed = baudrate
+        termios2_speed_struct.c_ospeed = baudrate
 
         # The ctypes structures mutate the buffer in place
         LOGGER.debug(

--- a/serialx/platforms/serial_linux.py
+++ b/serialx/platforms/serial_linux.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import termios
 
 from ..common import Parity, SerialPortInfo, UnsupportedSetting
-from .serial_posix import PosixSerial, PosixSerialTransport
+from .serial_extended_posix import ExtendedPosixSerial, ExtendedPosixSerialTransport
 
 LOGGER = logging.getLogger(__name__)
 
@@ -28,7 +28,6 @@ TIOCGSERIAL = getattr(termios, "TIOCGSERIAL", None)
 TIOCSSERIAL = getattr(termios, "TIOCSSERIAL", None)
 CBAUD = getattr(termios, "CBAUD", 0o00010017)
 CBAUDEX = getattr(termios, "CBAUDEX", 0o00010000)
-CRTSCTS = getattr(termios, "CRTSCTS", getattr(termios, "CNEW_RTSCTS", None))
 
 # When we need to set a non-POSIX baudrate, we set the baudrates to a known default and
 # then override
@@ -58,7 +57,7 @@ class Termios2SpeedStruct(ctypes.Structure):
     ]
 
 
-class LinuxSerial(PosixSerial):
+class LinuxSerial(ExtendedPosixSerial):
     """Linux serial port implementation."""
 
     def __init__(
@@ -128,23 +127,6 @@ class LinuxSerial(PosixSerial):
         else:
             raise UnsupportedSetting(f"Unsupported parity {self._parity}")
 
-    def _build_flow_control_flags(self) -> tuple[int, int]:
-        iflag = 0x00000000
-        cflag = 0x00000000
-
-        if self._xonxoff:
-            iflag |= termios.IXON | termios.IXOFF | termios.IXANY
-
-        if self._rtscts:
-            if CRTSCTS is None:
-                raise UnsupportedSetting(
-                    "RTS/CTS flow control not supported on this platform"
-                )
-            else:
-                cflag |= CRTSCTS
-
-        return (iflag, cflag)
-
     @property
     def _has_non_posix_baudrate(self) -> bool:
         return not hasattr(termios, f"B{self._baudrate}")
@@ -197,7 +179,7 @@ class LinuxSerial(PosixSerial):
         fcntl.ioctl(self._fileno, TIOCSSERIAL, buffer)
 
 
-class LinuxSerialTransport(PosixSerialTransport):
+class LinuxSerialTransport(ExtendedPosixSerialTransport):
     """Linux serial port transport using asyncio."""
 
     _serial_cls = LinuxSerial

--- a/serialx/platforms/serial_linux.py
+++ b/serialx/platforms/serial_linux.py
@@ -1,0 +1,298 @@
+"""Linux serial port implementation."""
+
+from __future__ import annotations
+
+import array
+import ctypes
+import errno
+import fcntl
+import logging
+from pathlib import Path
+import termios
+
+from .. import UnsupportedSetting
+from ..common import Parity, SerialPortInfo
+from .serial_posix import PosixSerial, PosixSerialTransport
+
+LOGGER = logging.getLogger(__name__)
+
+SYS_ROOT = Path("/sys")
+DEV_ROOT = Path("/dev")
+
+ASYNC_LOW_LATENCY = 1 << 13
+CMSPAR = 0o10000000000
+TCGETS = 0x5401
+TCGETS2 = 0x802C542A
+TCSETS2 = 0x402C542B
+
+TIOCGSERIAL = getattr(termios, "TIOCGSERIAL", None)
+TIOCSSERIAL = getattr(termios, "TIOCSSERIAL", None)
+CBAUD = getattr(termios, "CBAUD", 0o00010017)
+CBAUDEX = getattr(termios, "CBAUDEX", 0o00010000)
+CRTSCTS = getattr(termios, "CRTSCTS", getattr(termios, "CNEW_RTSCTS", None))
+
+# When we need to set a non-POSIX baudrate, we set the baudrates to a known default and
+# then override
+NON_POSIX_FALLBACK_BAUDRATE = 115200
+NON_POSIX_FALLBACK_BAUDRATE_CONST = termios.B115200
+
+
+class TermiosStruct(ctypes.Structure):
+    """The `termios` struct."""
+
+    _fields_ = [
+        ("c_iflag", ctypes.c_uint32),
+        ("c_oflag", ctypes.c_uint32),
+        ("c_cflag", ctypes.c_uint32),
+        ("c_lflag", ctypes.c_uint32),
+        ("c_line", ctypes.c_uint8),
+        ("c_cc", ctypes.c_uint8 * 64),  # NCCS is usually 19 bytes, let's be safe
+    ]
+
+
+class Termios2SpeedStruct(ctypes.Structure):
+    """The extra `c_ispeed` and `c_ospeed` members at the end of `struct termios2`."""
+
+    _fields_ = [
+        ("c_ispeed", ctypes.c_uint32),
+        ("c_ospeed", ctypes.c_uint32),
+    ]
+
+
+class LinuxSerial(PosixSerial):
+    """POSIX serial port implementation."""
+
+    def __init__(
+        self,
+        *args,
+        low_latency: bool = True,
+        **kwargs,
+    ):
+        """Initialize POSIX serial port."""
+        super().__init__(*args, **kwargs)
+        self._low_latency = low_latency
+
+    def _set_non_posix_baudrate(self, baudrate: int) -> None:
+        """Set the baudrate of the serial port, must be called after `tcsetattr`."""
+        assert self._fileno is not None
+
+        # The termios2 struct is going to be smaller than the sum of these two objects
+        buffer = bytearray(
+            ctypes.sizeof(TermiosStruct) + ctypes.sizeof(Termios2SpeedStruct)
+        )
+        fcntl.ioctl(self._fileno, TCGETS2, buffer)
+
+        # The POSIX baudrates are stored in the lower bits of `c_cflag`. We clear them.
+        termios_struct = TermiosStruct.from_buffer(buffer)
+        termios_struct.c_cflag &= ~CBAUD
+        termios_struct.c_cflag |= CBAUDEX
+
+        # `termios2` extends `termios` with two extra fields. The problem is that these
+        # fields appear *after* the `c_cc` array, which has a length defined by `NCCS`,
+        # a constant that we do not have access to. We overcome this by searching for
+        # the speed fields directly, since we set them to a known value earlier.
+        try:
+            temp_speed_buffer = bytearray(ctypes.sizeof(Termios2SpeedStruct))
+            temp_speed_struct = Termios2SpeedStruct.from_buffer(temp_speed_buffer)
+            temp_speed_struct.c_ispeed = NON_POSIX_FALLBACK_BAUDRATE
+            temp_speed_struct.c_ospeed = NON_POSIX_FALLBACK_BAUDRATE
+
+            offset = buffer.index(temp_speed_buffer)
+        except ValueError as exc:
+            raise RuntimeError(
+                f"Could not determine offset of termios2 speed fields: {buffer.hex()}"
+            ) from exc
+
+        termios2_speed_struct = Termios2SpeedStruct.from_buffer(buffer, offset)
+        termios2_speed_struct.c_ispeed = self._baudrate
+        termios2_speed_struct.c_ospeed = self._baudrate
+
+        # The ctypes structures mutate the buffer in place
+        LOGGER.debug(
+            "Writing termios2 struct (c_ispeed offset %d bytes): %r",
+            offset,
+            buffer.hex(),
+        )
+        fcntl.ioctl(self._fileno, TCSETS2, buffer)
+
+    def _build_parity_flags(self) -> int:
+        if self._parity == Parity.NONE:
+            return 0
+        elif self._parity == Parity.EVEN:
+            return termios.PARENB
+        elif self._parity == Parity.ODD:
+            return termios.PARENB | termios.PARODD
+        elif self._parity == Parity.MARK:
+            return termios.PARENB | termios.PARODD | CMSPAR
+        elif self._parity == Parity.SPACE:
+            return termios.PARENB | CMSPAR
+        else:
+            raise UnsupportedSetting(f"Unsupported parity {self._parity}")
+
+    def _build_flow_control_flags(self) -> tuple[int, int]:
+        iflag = 0x00000000
+        cflag = 0x00000000
+
+        if self._xonxoff:
+            iflag |= termios.IXON | termios.IXOFF | termios.IXANY
+
+        if self._rtscts:
+            if CRTSCTS is None:
+                raise UnsupportedSetting(
+                    "RTS/CTS flow control not supported on this platform"
+                )
+            else:
+                cflag |= CRTSCTS
+
+        return (iflag, cflag)
+
+    @property
+    def _has_non_posix_baudrate(self) -> bool:
+        return hasattr(termios, f"B{self._baudrate}")
+
+    def _build_ispeed(self) -> int:
+        return (
+            NON_POSIX_FALLBACK_BAUDRATE_CONST
+            if self._has_non_posix_baudrate
+            else getattr(termios, f"B{self._baudrate}")
+        )
+
+    def _build_ospeed(self) -> int:
+        return (
+            NON_POSIX_FALLBACK_BAUDRATE_CONST
+            if self._has_non_posix_baudrate
+            else getattr(termios, f"B{self._baudrate}")
+        )
+
+    def _after_configure_port(self) -> None:  # noqa: C901
+        if self._has_non_posix_baudrate:
+            LOGGER.debug("Setting non-POSIX baudrate %d", self._baudrate)
+            self._set_non_posix_baudrate(self._baudrate)
+
+        if TIOCSSERIAL is not None:
+            try:
+                self._set_low_latency(self._low_latency)
+            except OSError as exc:
+                if exc.errno in (errno.ENOTTY, errno.EOPNOTSUPP):
+                    LOGGER.debug("Device does not support setting low latency")
+                else:
+                    raise
+
+        self.set_modem_pins(dtr=self._rtsdtr_on_open, rts=self._rtsdtr_on_open)
+
+        # Flush input and output buffers to discard stale data
+        assert self._fileno is not None
+        termios.tcflush(self._fileno, termios.TCIOFLUSH)
+
+    def _set_low_latency(self, value: bool) -> None:
+        """Set low latency mode."""
+        assert self._fileno is not None
+        assert TIOCGSERIAL is not None
+        assert TIOCSSERIAL is not None
+
+        LOGGER.debug("Setting low latency mode: %r", value)
+
+        buffer = array.array("i", [0x00000000] * 19 * 8)
+
+        fcntl.ioctl(self._fileno, TIOCGSERIAL, buffer)
+
+        if self._low_latency:
+            buffer[4] |= ASYNC_LOW_LATENCY
+        else:
+            buffer[4] &= ~ASYNC_LOW_LATENCY
+
+        fcntl.ioctl(self._fileno, TIOCSSERIAL, buffer)
+
+
+class LinuxSerialTransport(PosixSerialTransport):
+    """POSIX serial port transport using asyncio."""
+
+    _serial_cls = LinuxSerial
+
+
+def linux_list_serial_ports() -> list[SerialPortInfo]:
+    """List serial ports on Linux."""
+    by_id_symlinks = {}
+    by_id_path = DEV_ROOT / "serial/by-id"
+
+    if by_id_path.exists():
+        for symlink in by_id_path.iterdir():
+            by_id_symlinks[symlink.resolve()] = symlink
+
+    results = []
+
+    for path in (SYS_ROOT / "class/tty").iterdir():
+        if not path.name.startswith("tty"):
+            continue
+
+        tty_device = path / "device"
+        if not (tty_device / "driver").exists():
+            continue
+
+        device = DEV_ROOT / path.name
+        resolved = tty_device.resolve()
+        subsystem = (resolved / "subsystem").resolve().name
+        unique_device = by_id_symlinks.get(device, device)
+
+        if subsystem == "usb-serial":
+            # USB-serial chips
+            usb_interface = resolved.parent
+            usb_device = usb_interface.parent
+            interface_file = usb_interface / "interface"
+            info = SerialPortInfo(
+                device=unique_device,
+                resolved_device=device,
+                vid=int((usb_device / "idVendor").read_text(), 16),
+                pid=int((usb_device / "idProduct").read_text(), 16),
+                serial_number=(usb_device / "serial").read_text()[:-1],
+                manufacturer=(usb_device / "manufacturer").read_text()[:-1],
+                product=(usb_device / "product").read_text()[:-1],
+                bcd_device=int((usb_device / "bcdDevice").read_text(), 16),
+                interface_description=(
+                    interface_file.read_text()[:-1] if interface_file.exists() else None
+                ),
+                interface_num=int((usb_interface / "bInterfaceNumber").read_text(), 16),
+            )
+        elif subsystem == "usb":
+            # CDC ACM devices
+            usb_interface = resolved
+            usb_device = usb_interface.parent
+            interface_file = usb_interface / "interface"
+            info = SerialPortInfo(
+                device=unique_device,
+                resolved_device=device,
+                vid=int((usb_device / "idVendor").read_text(), 16),
+                pid=int((usb_device / "idProduct").read_text(), 16),
+                serial_number=(usb_device / "serial").read_text()[:-1],
+                manufacturer=(usb_device / "manufacturer").read_text()[:-1],
+                product=(usb_device / "product").read_text()[:-1],
+                bcd_device=int((usb_device / "bcdDevice").read_text(), 16),
+                interface_description=(
+                    interface_file.read_text()[:-1] if interface_file.exists() else None
+                ),
+                interface_num=int((usb_interface / "bInterfaceNumber").read_text(), 16),
+            )
+        elif subsystem == "serial-base":
+            # Native serial ports
+            info = SerialPortInfo(
+                device=unique_device,
+                resolved_device=device,
+                vid=None,
+                pid=None,
+                serial_number=None,
+                manufacturer=None,
+                product=None,
+                bcd_device=None,
+                interface_description=None,
+                interface_num=None,
+            )
+        else:
+            LOGGER.warning(
+                "Unknown serial device subsystem %r for device %r",
+                subsystem,
+                device,
+            )
+
+        results.append(info)
+
+    return results

--- a/serialx/platforms/serial_linux.py
+++ b/serialx/platforms/serial_linux.py
@@ -148,7 +148,7 @@ class LinuxSerial(PosixSerial):
 
     @property
     def _has_non_posix_baudrate(self) -> bool:
-        return hasattr(termios, f"B{self._baudrate}")
+        return not hasattr(termios, f"B{self._baudrate}")
 
     def _build_ispeed(self) -> int:
         return (

--- a/serialx/platforms/serial_linux.py
+++ b/serialx/platforms/serial_linux.py
@@ -10,8 +10,7 @@ import logging
 from pathlib import Path
 import termios
 
-from .. import UnsupportedSetting
-from ..common import Parity, SerialPortInfo
+from ..common import Parity, SerialPortInfo, UnsupportedSetting
 from .serial_posix import PosixSerial, PosixSerialTransport
 
 LOGGER = logging.getLogger(__name__)
@@ -60,7 +59,7 @@ class Termios2SpeedStruct(ctypes.Structure):
 
 
 class LinuxSerial(PosixSerial):
-    """POSIX serial port implementation."""
+    """Linux serial port implementation."""
 
     def __init__(
         self,
@@ -68,7 +67,7 @@ class LinuxSerial(PosixSerial):
         low_latency: bool = True,
         **kwargs,
     ):
-        """Initialize POSIX serial port."""
+        """Initialize Linux serial port."""
         super().__init__(*args, **kwargs)
         self._low_latency = low_latency
 
@@ -164,7 +163,7 @@ class LinuxSerial(PosixSerial):
             else getattr(termios, f"B{self._baudrate}")
         )
 
-    def _after_configure_port(self) -> None:  # noqa: C901
+    def _after_configure_port(self) -> None:
         if self._has_non_posix_baudrate:
             LOGGER.debug("Setting non-POSIX baudrate %d", self._baudrate)
             self._set_non_posix_baudrate(self._baudrate)
@@ -177,12 +176,6 @@ class LinuxSerial(PosixSerial):
                     LOGGER.debug("Device does not support setting low latency")
                 else:
                     raise
-
-        self.set_modem_pins(dtr=self._rtsdtr_on_open, rts=self._rtsdtr_on_open)
-
-        # Flush input and output buffers to discard stale data
-        assert self._fileno is not None
-        termios.tcflush(self._fileno, termios.TCIOFLUSH)
 
     def _set_low_latency(self, value: bool) -> None:
         """Set low latency mode."""
@@ -205,7 +198,7 @@ class LinuxSerial(PosixSerial):
 
 
 class LinuxSerialTransport(PosixSerialTransport):
-    """POSIX serial port transport using asyncio."""
+    """Linux serial port transport using asyncio."""
 
     _serial_cls = LinuxSerial
 

--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -20,8 +20,15 @@ else:
 
 from typing_extensions import Buffer
 
-from .. import UnsupportedSetting
-from ..common import BaseSerial, ModemPins, Parity, PinState, SerialPortInfo, StopBits
+from ..common import (
+    BaseSerial,
+    ModemPins,
+    Parity,
+    PinState,
+    SerialPortInfo,
+    StopBits,
+    UnsupportedSetting,
+)
 from ..descriptor_transport import DescriptorTransport
 
 LOGGER = logging.getLogger(__name__)

--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -173,9 +173,7 @@ class PosixSerial(BaseSerial):
         elif self._stopbits == StopBits.TWO:
             return termios.CSTOPB
         elif self._stopbits == StopBits.ONE_POINT_FIVE:
-            raise UnsupportedSetting(
-                "1.5 stop bits not supported on POSIX, using 1 stop bit"
-            )
+            raise UnsupportedSetting("1.5 stop bits not supported on POSIX")
         else:
             raise UnsupportedSetting(f"Unsupported stop bits {self._stopbits}")
 
@@ -185,6 +183,11 @@ class PosixSerial(BaseSerial):
 
         if self._xonxoff:
             iflag |= termios.IXON | termios.IXOFF | termios.IXANY
+
+        if self._rtscts:
+            raise UnsupportedSetting(
+                "RTS/CTS hardware flow control is not supported on this POSIX platform"
+            )
 
         return (iflag, cflag)
 

--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -2,18 +2,16 @@
 
 from __future__ import annotations
 
-import array
 import asyncio
-import ctypes
 import errno
 import fcntl
 import logging
 import os
-from pathlib import Path
 import select
 import sys
 import termios
 import time
+from typing import NamedTuple
 
 if sys.version_info >= (3, 11):
     from asyncio import timeout as asyncio_timeout
@@ -22,13 +20,11 @@ else:
 
 from typing_extensions import Buffer
 
+from .. import UnsupportedSetting
 from ..common import BaseSerial, ModemPins, Parity, PinState, SerialPortInfo, StopBits
 from ..descriptor_transport import DescriptorTransport
 
 LOGGER = logging.getLogger(__name__)
-
-SYS_ROOT = Path("/sys")
-DEV_ROOT = Path("/dev")
 
 FLUSH_TIMEOUT = 10.0
 
@@ -36,23 +32,6 @@ FLUSH_TIMEOUT = 10.0
 # `TCIOFLUSH`. Otherwise, the flush operation does not work reliably and stale data may
 # be read.
 AFTER_OPEN_DELAY = 0.01
-
-ASYNC_LOW_LATENCY = 1 << 13
-CMSPAR = 0o10000000000
-TCGETS = 0x5401
-TCGETS2 = 0x802C542A
-TCSETS2 = 0x402C542B
-
-TIOCGSERIAL = getattr(termios, "TIOCGSERIAL", None)
-TIOCSSERIAL = getattr(termios, "TIOCSSERIAL", None)
-CBAUD = getattr(termios, "CBAUD", 0o00010017)
-CBAUDEX = getattr(termios, "CBAUDEX", 0o00010000)
-CRTSCTS = getattr(termios, "CRTSCTS", getattr(termios, "CNEW_RTSCTS", None))
-
-# When we need to set a non-POSIX baudrate, we set the baudrates to a known default and
-# then override
-NON_POSIX_FALLBACK_BAUDRATE = 115200
-NON_POSIX_FALLBACK_BAUDRATE_CONST = termios.B115200
 
 MODEM_BIT_MAPPING = {
     "le": termios.TIOCM_LE,
@@ -67,34 +46,18 @@ MODEM_BIT_MAPPING = {
 }
 assert MODEM_BIT_MAPPING.keys() == ModemPins.__annotations__.keys()
 
-POSIX_CHARACTER_SIZE_MAPPING = {
-    5: termios.CS5,
-    6: termios.CS6,
-    7: termios.CS7,
-    8: termios.CS8,
-}
 
+class TcsetattrFlags(NamedTuple):
+    """Flags for `termios.tcsetattr`."""
 
-class TermiosStruct(ctypes.Structure):
-    """The `termios` struct."""
-
-    _fields_ = [
-        ("c_iflag", ctypes.c_uint32),
-        ("c_oflag", ctypes.c_uint32),
-        ("c_cflag", ctypes.c_uint32),
-        ("c_lflag", ctypes.c_uint32),
-        ("c_line", ctypes.c_uint8),
-        ("c_cc", ctypes.c_uint8 * 64),  # NCCS is usually 19 bytes, let's be safe
-    ]
-
-
-class Termios2SpeedStruct(ctypes.Structure):
-    """The extra `c_ispeed` and `c_ospeed` members at the end of `struct termios2`."""
-
-    _fields_ = [
-        ("c_ispeed", ctypes.c_uint32),
-        ("c_ospeed", ctypes.c_uint32),
-    ]
+    iflag: int
+    oflag: int
+    cflag: int
+    lflag: int
+    ispeed: int
+    ospeed: int
+    cc_vmin: int
+    cc_vtime: int
 
 
 def modem_pins_mask_of_value(modem_pins: ModemPins, mask: PinState) -> int:
@@ -127,7 +90,6 @@ class PosixSerial(BaseSerial):
         self,
         *args,
         fileno: int | None = None,
-        low_latency: bool = True,
         inter_byte_timeout: float = 0.01,
         min_read_size: int = 1,
         **kwargs,
@@ -135,7 +97,6 @@ class PosixSerial(BaseSerial):
         """Initialize POSIX serial port."""
         super().__init__(*args, **kwargs)
         self._fileno: int | None = fileno
-        self._low_latency: bool = low_latency
         self._inter_byte_timeout = inter_byte_timeout
         self._min_read_size = min_read_size
 
@@ -175,57 +136,68 @@ class PosixSerial(BaseSerial):
         assert self._fileno is not None
         fcntl.flock(self._fileno, fcntl.LOCK_UN)
 
-    def _set_non_posix_baudrate(self, baudrate: int) -> None:
-        """Set the baudrate of the serial port, must be called after `tcsetattr`."""
-        assert self._fileno is not None
+    def _build_parity_flags(self) -> int:
+        if self._parity == Parity.NONE:
+            return 0
+        elif self._parity == Parity.EVEN:
+            return termios.PARENB
+        elif self._parity == Parity.ODD:
+            return termios.PARENB | termios.PARODD
+        else:
+            raise UnsupportedSetting(f"Unsupported parity {self._parity}")
 
-        # The termios2 struct is going to be smaller than the sum of these two objects
-        buffer = bytearray(
-            ctypes.sizeof(TermiosStruct) + ctypes.sizeof(Termios2SpeedStruct)
-        )
-        fcntl.ioctl(self._fileno, TCGETS2, buffer)
+    def _build_character_size_flags(self) -> int:
+        if self._byte_size == 5:
+            return termios.CS5
+        elif self._byte_size == 6:
+            return termios.CS6
+        elif self._byte_size == 7:
+            return termios.CS7
+        elif self._byte_size == 8:
+            return termios.CS8
+        else:
+            raise UnsupportedSetting(
+                f"Unsupported byte size {self._byte_size}, must be 5, 6, 7, or 8"
+            )
 
-        # The POSIX baudrates are stored in the lower bits of `c_cflag`. We clear them.
-        termios_struct = TermiosStruct.from_buffer(buffer)
-        termios_struct.c_cflag &= ~CBAUD
-        termios_struct.c_cflag |= CBAUDEX
+    def _build_stopbits_flags(self) -> int:
+        if self._stopbits == StopBits.ONE:
+            return 0
+        elif self._stopbits == StopBits.TWO:
+            return termios.CSTOPB
+        elif self._stopbits == StopBits.ONE_POINT_FIVE:
+            raise UnsupportedSetting(
+                "1.5 stop bits not supported on POSIX, using 1 stop bit"
+            )
+        else:
+            raise UnsupportedSetting(f"Unsupported stop bits {self._stopbits}")
 
-        # `termios2` extends `termios` with two extra fields. The problem is that these
-        # fields appear *after* the `c_cc` array, which has a length defined by `NCCS`,
-        # a constant that we do not have access to. We overcome this by searching for
-        # the speed fields directly, since we set them to a known value earlier.
-        try:
-            temp_speed_buffer = bytearray(ctypes.sizeof(Termios2SpeedStruct))
-            temp_speed_struct = Termios2SpeedStruct.from_buffer(temp_speed_buffer)
-            temp_speed_struct.c_ispeed = NON_POSIX_FALLBACK_BAUDRATE
-            temp_speed_struct.c_ospeed = NON_POSIX_FALLBACK_BAUDRATE
-
-            offset = buffer.index(temp_speed_buffer)
-        except ValueError as exc:
-            raise RuntimeError(
-                f"Could not determine offset of termios2 speed fields: {buffer.hex()}"
-            ) from exc
-
-        termios2_speed_struct = Termios2SpeedStruct.from_buffer(buffer, offset)
-        termios2_speed_struct.c_ispeed = self._baudrate
-        termios2_speed_struct.c_ospeed = self._baudrate
-
-        # The ctypes structures mutate the buffer in place
-        LOGGER.debug(
-            "Writing termios2 struct (c_ispeed offset %d bytes): %r",
-            offset,
-            buffer.hex(),
-        )
-        fcntl.ioctl(self._fileno, TCSETS2, buffer)
-
-    def _configure_port(self) -> None:  # noqa: C901
-        """Configure the serial port settings."""
-        LOGGER.debug("Configuring serial port %r", self._path)
-
-        if self._fileno is None:
-            raise ValueError("Cannot configure, serial port is not open")
-
+    def _build_flow_control_flags(self) -> tuple[int, int]:
+        iflag = 0x00000000
         cflag = 0x00000000
+
+        if self._xonxoff:
+            iflag |= termios.IXON | termios.IXOFF | termios.IXANY
+
+        return (iflag, cflag)
+
+    def _build_ispeed(self) -> int:
+        try:
+            return getattr(termios, f"B{self._baudrate}")
+        except AttributeError as exc:
+            raise UnsupportedSetting(f"Unsupported baudrate {self._baudrate}") from exc
+
+    def _build_ospeed(self) -> int:
+        try:
+            return getattr(termios, f"B{self._baudrate}")
+        except AttributeError as exc:
+            raise UnsupportedSetting(f"Unsupported baudrate {self._baudrate}") from exc
+
+    def _build_tcsetattr_flags(self) -> TcsetattrFlags:
+        iflag = 0x00000000
+        oflag = 0x00000000
+        cflag = 0x00000000
+        lflag = 0x00000000
 
         # Enable receiver
         cflag |= termios.CREAD
@@ -237,59 +209,19 @@ class PosixSerial(BaseSerial):
         if self._rtsdtr_on_close is PinState.UNDEFINED:
             pass
         elif self._rtsdtr_on_close is PinState.HIGH:
-            LOGGER.warning("POSIX only supports setting RTS/DTR to LOW on close")
+            raise UnsupportedSetting(
+                "POSIX only supports setting RTS/DTR to LOW on close"
+            )
         else:
             cflag |= termios.HUPCL
 
-        # Character size
-        if self._byte_size == 5:
-            cflag |= termios.CS5
-        elif self._byte_size == 6:
-            cflag |= termios.CS6
-        elif self._byte_size == 7:
-            cflag |= termios.CS7
-        elif self._byte_size == 8:
-            cflag |= termios.CS8
-        else:
-            raise ValueError(
-                f"Unsupported byte size {self._byte_size}, must be 5, 6, 7, or 8"
-            )
+        cflag |= self._build_character_size_flags()
+        cflag |= self._build_parity_flags()
+        cflag |= self._build_stopbits_flags()
 
-        # Parity
-        if self._parity == Parity.NONE:
-            pass
-        elif self._parity == Parity.EVEN:
-            cflag |= termios.PARENB
-        elif self._parity == Parity.ODD:
-            cflag |= termios.PARENB | termios.PARODD
-        elif self._parity == Parity.MARK:
-            cflag |= termios.PARENB | termios.PARODD | CMSPAR
-        elif self._parity == Parity.SPACE:
-            cflag |= termios.PARENB | CMSPAR
-
-        # Stop bits
-        if self._stopbits == StopBits.TWO:
-            cflag |= termios.CSTOPB
-        elif self._stopbits == StopBits.ONE_POINT_FIVE:
-            LOGGER.warning("1.5 stop bits not supported on POSIX, using 1 stop bit")
-        elif self._stopbits == StopBits.ONE:
-            pass
-
-        # Hardware flow control
-        if self._rtscts:
-            if CRTSCTS is None:
-                LOGGER.warning("RTS/CTS flow control not supported on this platform")
-            else:
-                cflag |= CRTSCTS
-
-        iflag = 0x00000000
-
-        # Software flow control
-        if self._xonxoff:
-            iflag |= termios.IXON | termios.IXOFF | termios.IXANY
-
-        oflag = 0x00000000
-        lflag = 0x00000000
+        fc_iflag, fc_cflag = self._build_flow_control_flags()
+        cflag |= fc_cflag
+        iflag |= fc_iflag
 
         # Only emit reads if VMIN characters have been read, after no more data comes in
         # for VTIME seconds
@@ -306,17 +238,33 @@ class PosixSerial(BaseSerial):
                 f"VTIME must be in range 0-255 (inter_byte_timeout={self._inter_byte_timeout})"
             )
 
-        try:
-            # Set baudrate
-            ispeed = getattr(termios, f"B{self._baudrate}")
-            ospeed = getattr(termios, f"B{self._baudrate}")
-            non_posix_baudrate = False
-        except AttributeError:
-            # Non-POSIX baudrate, use defaults for `tcsetattr` and then override
-            ispeed = NON_POSIX_FALLBACK_BAUDRATE_CONST
-            ospeed = NON_POSIX_FALLBACK_BAUDRATE_CONST
-            non_posix_baudrate = True
+        ispeed = self._build_ispeed()
+        ospeed = self._build_ospeed()
 
+        return TcsetattrFlags(
+            iflag=iflag,
+            oflag=oflag,
+            cflag=cflag,
+            lflag=lflag,
+            ispeed=ispeed,
+            ospeed=ospeed,
+            cc_vmin=vmin,
+            cc_vtime=vtime,
+        )
+
+    def _after_configure_port(self) -> None:
+        pass
+
+    def _configure_port(self) -> None:
+        """Configure the serial port settings."""
+        LOGGER.debug("Configuring serial port %r", self._path)
+
+        if self._fileno is None:
+            raise ValueError("Cannot configure, serial port is not open")
+
+        tcsetattr = self._build_tcsetattr_flags()
+
+        # We need to overwrite VMIN and VTIME in the CC array
         (
             _iflag,
             _oflag,
@@ -327,57 +275,32 @@ class PosixSerial(BaseSerial):
             cc,
         ) = termios.tcgetattr(self._fileno)
 
-        cc[termios.VMIN] = vmin
-        cc[termios.VTIME] = vtime
+        cc[termios.VMIN] = tcsetattr.cc_vmin
+        cc[termios.VTIME] = tcsetattr.cc_vtime
 
-        LOGGER.debug(
-            "Configuring serial port: %r",
-            [iflag, oflag, cflag, lflag, ispeed, ospeed, cc],
-        )
+        LOGGER.debug("Configuring serial port: %r + cc=%r", tcsetattr, cc)
 
         # Finally, set up the serial port
         termios.tcsetattr(
             self._fileno,
             termios.TCSANOW,  # TODO: should we use TCSADRAIN or TCSAFLUSH instead?
-            [iflag, oflag, cflag, lflag, ispeed, ospeed, cc],
+            [
+                tcsetattr.iflag,
+                tcsetattr.oflag,
+                tcsetattr.cflag,
+                tcsetattr.lflag,
+                tcsetattr.ispeed,
+                tcsetattr.ospeed,
+                cc,
+            ],
         )
 
-        if non_posix_baudrate:
-            LOGGER.debug("Setting non-POSIX baudrate %d", self._baudrate)
-            self._set_non_posix_baudrate(self._baudrate)
-
-        if TIOCSSERIAL is not None:
-            try:
-                self._set_low_latency(self._low_latency)
-            except OSError as exc:
-                if exc.errno in (errno.ENOTTY, errno.EOPNOTSUPP):
-                    LOGGER.debug("Device does not support setting low latency")
-                else:
-                    raise
+        self._after_configure_port()
 
         self.set_modem_pins(dtr=self._rtsdtr_on_open, rts=self._rtsdtr_on_open)
 
         # Flush input and output buffers to discard stale data
         termios.tcflush(self._fileno, termios.TCIOFLUSH)
-
-    def _set_low_latency(self, value: bool) -> None:
-        """Set low latency mode."""
-        assert self._fileno is not None
-        assert TIOCGSERIAL is not None
-        assert TIOCSSERIAL is not None
-
-        LOGGER.debug("Setting low latency mode: %r", value)
-
-        buffer = array.array("i", [0x00000000] * 19 * 8)
-
-        fcntl.ioctl(self._fileno, TIOCGSERIAL, buffer)
-
-        if self._low_latency:
-            buffer[4] |= ASYNC_LOW_LATENCY
-        else:
-            buffer[4] &= ~ASYNC_LOW_LATENCY
-
-        fcntl.ioctl(self._fileno, TIOCSSERIAL, buffer)
 
     def _get_modem_pins(self) -> ModemPins:
         """Get current modem control bits."""
@@ -557,88 +480,5 @@ class PosixSerialTransport(DescriptorTransport):
 
 
 def posix_list_serial_ports() -> list[SerialPortInfo]:
-    """List serial ports on Linux."""
-    by_id_symlinks = {}
-    by_id_path = DEV_ROOT / "serial/by-id"
-
-    if by_id_path.exists():
-        for symlink in by_id_path.iterdir():
-            by_id_symlinks[symlink.resolve()] = symlink
-
-    results = []
-
-    for path in (SYS_ROOT / "class/tty").iterdir():
-        if not path.name.startswith("tty"):
-            continue
-
-        tty_device = path / "device"
-        if not (tty_device / "driver").exists():
-            continue
-
-        device = DEV_ROOT / path.name
-        resolved = tty_device.resolve()
-        subsystem = (resolved / "subsystem").resolve().name
-        unique_device = by_id_symlinks.get(device, device)
-
-        if subsystem == "usb-serial":
-            # USB-serial chips
-            usb_interface = resolved.parent
-            usb_device = usb_interface.parent
-            interface_file = usb_interface / "interface"
-            info = SerialPortInfo(
-                device=unique_device,
-                resolved_device=device,
-                vid=int((usb_device / "idVendor").read_text(), 16),
-                pid=int((usb_device / "idProduct").read_text(), 16),
-                serial_number=(usb_device / "serial").read_text()[:-1],
-                manufacturer=(usb_device / "manufacturer").read_text()[:-1],
-                product=(usb_device / "product").read_text()[:-1],
-                bcd_device=int((usb_device / "bcdDevice").read_text(), 16),
-                interface_description=(
-                    interface_file.read_text()[:-1] if interface_file.exists() else None
-                ),
-                interface_num=int((usb_interface / "bInterfaceNumber").read_text(), 16),
-            )
-        elif subsystem == "usb":
-            # CDC ACM devices
-            usb_interface = resolved
-            usb_device = usb_interface.parent
-            interface_file = usb_interface / "interface"
-            info = SerialPortInfo(
-                device=unique_device,
-                resolved_device=device,
-                vid=int((usb_device / "idVendor").read_text(), 16),
-                pid=int((usb_device / "idProduct").read_text(), 16),
-                serial_number=(usb_device / "serial").read_text()[:-1],
-                manufacturer=(usb_device / "manufacturer").read_text()[:-1],
-                product=(usb_device / "product").read_text()[:-1],
-                bcd_device=int((usb_device / "bcdDevice").read_text(), 16),
-                interface_description=(
-                    interface_file.read_text()[:-1] if interface_file.exists() else None
-                ),
-                interface_num=int((usb_interface / "bInterfaceNumber").read_text(), 16),
-            )
-        elif subsystem == "serial-base":
-            # Native serial ports
-            info = SerialPortInfo(
-                device=unique_device,
-                resolved_device=device,
-                vid=None,
-                pid=None,
-                serial_number=None,
-                manufacturer=None,
-                product=None,
-                bcd_device=None,
-                interface_description=None,
-                interface_num=None,
-            )
-        else:
-            LOGGER.warning(
-                "Unknown serial device subsystem %r for device %r",
-                subsystem,
-                device,
-            )
-
-        results.append(info)
-
-    return results
+    """List available serial ports on POSIX."""
+    return []

--- a/tests/common.py
+++ b/tests/common.py
@@ -38,6 +38,7 @@ class SerialPair(NamedTuple):
     left: str
     right: str
     backend: str  # "socat", "socket", "esphome", "adapter", or "com0com"
+    serial_class: str = serialx.Serial.__name__
 
 
 class BridgedSocatPair(NamedTuple):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,16 @@
 """Pytest configuration for serialx tests."""
 
 from collections.abc import Generator
+import importlib
 import re
 import sys
 import time
+from unittest.mock import patch
 
 import pytest
 
 import serialx
+import serialx.platforms
 from tests.common import (
     SOCAT_BINARY,
     SerialPair,
@@ -23,6 +26,30 @@ except ImportError:
     aioesphomeapi = None
 
 COM0COM_RE = re.compile(r"^CNC[A-Z]\d+$", re.IGNORECASE)
+
+
+def _get_posix_serial_classes() -> list[str]:
+    """Get extra POSIX serial class names to test on this platform.
+
+    On Linux (or any platform with a deeper class hierarchy), we also test
+    with the generic POSIX and extended POSIX backends by patching sys.platform
+    and is_extended_posix to force the fallback paths in serialx.platforms.
+    """
+    try:
+        import termios  # noqa: F401, PLC0415
+    except ImportError:
+        return []
+
+    from serialx.platforms.serial_extended_posix import (  # noqa: PLC0415
+        is_extended_posix,
+    )
+
+    result = ["PosixSerial"]
+
+    if is_extended_posix():
+        result.append("ExtendedPosixSerial")
+
+    return result
 
 
 def pytest_configure(config: pytest.Config) -> None:
@@ -87,7 +114,13 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
                     )
                 )
 
+            for cls_name in _get_posix_serial_classes():
+                params.append(pytest.param(("socat", cls_name), id=f"socat+{cls_name}"))
+
         params.append(pytest.param(("socket",), id="socket"))
+
+        for cls_name in _get_posix_serial_classes():
+            params.append(pytest.param(("socket", cls_name), id=f"socket+{cls_name}"))
 
         for left, right in _get_adapter_pairs(metafunc.config):
             if COM0COM_RE.match(left) or COM0COM_RE.match(right):
@@ -139,7 +172,36 @@ def serial_pair(request: pytest.FixtureRequest) -> Generator[SerialPair]:
         if backend not in marker.args:
             pytest.skip(f"Requires backend in {marker.args!r}, got {backend!r}")
 
-    if backend == "socat":
+    # Check if a serial class override is requested (e.g. "PosixSerial")
+    serial_class_override = (
+        backend_info[1]
+        if len(backend_info) > 1 and backend in ("socat", "socket")
+        else None
+    )
+
+    if serial_class_override:
+        is_extended = serial_class_override == "ExtendedPosixSerial"
+        with (
+            patch("sys.platform", "unknown"),
+            patch(
+                "serialx.platforms.serial_extended_posix.is_extended_posix",
+                return_value=is_extended,
+            ),
+        ):
+            importlib.reload(serialx.platforms)
+
+        serial_class = serialx.platforms.Serial.__name__
+
+        try:
+            if backend == "socat":
+                with create_socat_pair() as (left, right):
+                    yield SerialPair(left, right, "socat", serial_class)
+            elif backend == "socket":
+                with create_socket_pair() as (left, right):
+                    yield SerialPair(left, right, "socket", serial_class)
+        finally:
+            importlib.reload(serialx.platforms)
+    elif backend == "socat":
         with create_socat_pair() as (left, right):
             yield SerialPair(left, right, "socat")
     elif backend == "esphome":

--- a/tests/test_async_transports.py
+++ b/tests/test_async_transports.py
@@ -122,6 +122,13 @@ async def test_async_random_large(
     serial_pair: SerialPair, baudrate: int, chunk_size: int
 ) -> None:
     """Test random read/write at various speeds."""
+    if (
+        baudrate > 230400
+        and sys.platform == "darwin"
+        and serial_pair.serial_class in ("PosixSerial", "ExtendedPosixSerial")
+    ):
+        pytest.xfail("macOS termios lacks constants above B230400")
+
     async with async_create_reader_writer_pair(
         serial_pair.left, serial_pair.right, baudrate=baudrate
     ) as (_, writer_left, reader_right, _):
@@ -167,6 +174,12 @@ async def test_async_buffered_writes_then_read(serial_pair: SerialPair) -> None:
 @pytest.mark.parametrize("payload_size", [1024, 2048])
 async def test_async_large_payload(serial_pair: SerialPair, payload_size: int) -> None:
     """Test large payload transmission."""
+    if sys.platform == "darwin" and serial_pair.serial_class in (
+        "PosixSerial",
+        "ExtendedPosixSerial",
+    ):
+        pytest.xfail("macOS termios lacks constants above B230400")
+
     async with async_create_reader_writer_pair(
         serial_pair.left, serial_pair.right, baudrate=921600
     ) as (_, writer_left, reader_right, _):
@@ -201,6 +214,13 @@ async def test_async_sustained_throughput(
     serial_pair: SerialPair, baudrate: int, iterations: int
 ) -> None:
     """Test sustained data throughput at various baudrates."""
+    if (
+        baudrate > 230400
+        and sys.platform == "darwin"
+        and serial_pair.serial_class in ("PosixSerial", "ExtendedPosixSerial")
+    ):
+        pytest.xfail("macOS termios lacks constants above B230400")
+
     if (serial_pair.backend, baudrate, iterations) == ("esphome", 921600, 512):
         pytest.skip(
             "ESPHome backend is too slow for sustained throughput at 921600/512"
@@ -224,6 +244,13 @@ async def test_async_sustained_throughput(
 )
 async def test_async_valid_baudrates(serial_pair: SerialPair, baudrate: int) -> None:
     """Test that valid baudrates are accepted."""
+    if (
+        baudrate > 230400
+        and sys.platform == "darwin"
+        and serial_pair.serial_class in ("PosixSerial", "ExtendedPosixSerial")
+    ):
+        pytest.xfail("macOS termios lacks constants above B230400")
+
     async with async_create_reader_writer(serial_pair.left, baudrate=baudrate) as (
         _,
         writer,
@@ -307,6 +334,9 @@ async def test_async_xonxoff_setting(serial_pair: SerialPair, xonxoff: bool) -> 
 @pytest.mark.parametrize("rtscts", [True, False])
 async def test_async_rtscts_setting(serial_pair: SerialPair, rtscts: bool) -> None:
     """Test that rtscts setting is accepted."""
+    if rtscts and serial_pair.serial_class == "PosixSerial":
+        pytest.xfail("Strict POSIX backend does not support RTS/CTS flow control")
+
     async with async_create_reader_writer(serial_pair.right, baudrate=115200):
         async with async_create_reader_writer(
             serial_pair.left, baudrate=115200, rtscts=rtscts

--- a/tests/test_async_transports.py
+++ b/tests/test_async_transports.py
@@ -240,6 +240,9 @@ async def test_async_valid_parity(serial_pair: SerialPair, parity: Parity) -> No
     if serial_pair.backend == "esphome" and parity in (Parity.MARK, Parity.SPACE):
         pytest.xfail("ESPHome backend does not support MARK/SPACE parity")
 
+    if sys.platform == "darwin" and parity in (Parity.MARK, Parity.SPACE):
+        pytest.skip("MARK/SPACE parity not supported on macOS")
+
     async with async_create_reader_writer(
         serial_pair.left, baudrate=115200, parity=parity
     ) as (_, writer):
@@ -266,6 +269,9 @@ async def test_async_valid_stopbits(
     """Test that valid stopbits settings are accepted."""
     if serial_pair.backend == "esphome" and expected is StopBits.ONE_POINT_FIVE:
         pytest.xfail("ESPHome backend does not support 1.5 stop bits")
+
+    if sys.platform in ("linux", "darwin") and expected is StopBits.ONE_POINT_FIVE:
+        pytest.skip("1.5 stop bits not supported on POSIX")
 
     async with async_create_reader_writer(
         serial_pair.left, baudrate=115200, stopbits=stopbits

--- a/tests/test_async_transports.py
+++ b/tests/test_async_transports.py
@@ -240,8 +240,11 @@ async def test_async_valid_parity(serial_pair: SerialPair, parity: Parity) -> No
     if serial_pair.backend == "esphome" and parity in (Parity.MARK, Parity.SPACE):
         pytest.xfail("ESPHome backend does not support MARK/SPACE parity")
 
-    if sys.platform == "darwin" and parity in (Parity.MARK, Parity.SPACE):
-        pytest.skip("MARK/SPACE parity not supported on macOS")
+    if serial_pair.serial_class not in ("LinuxSerial", "Win32Serial") and parity in (
+        Parity.MARK,
+        Parity.SPACE,
+    ):
+        pytest.skip("MARK/SPACE parity requires CMSPAR (Linux) or Win32")
 
     async with async_create_reader_writer(
         serial_pair.left, baudrate=115200, parity=parity
@@ -270,8 +273,11 @@ async def test_async_valid_stopbits(
     if serial_pair.backend == "esphome" and expected is StopBits.ONE_POINT_FIVE:
         pytest.xfail("ESPHome backend does not support 1.5 stop bits")
 
-    if sys.platform in ("linux", "darwin") and expected is StopBits.ONE_POINT_FIVE:
-        pytest.skip("1.5 stop bits not supported on POSIX")
+    if (
+        serial_pair.serial_class not in ("Win32Serial",)
+        and expected is StopBits.ONE_POINT_FIVE
+    ):
+        pytest.skip("1.5 stop bits only supported on Win32")
 
     async with async_create_reader_writer(
         serial_pair.left, baudrate=115200, stopbits=stopbits

--- a/tests/test_list_serial_ports_linux.py
+++ b/tests/test_list_serial_ports_linux.py
@@ -13,8 +13,8 @@ from pathlib import Path
 from unittest.mock import patch
 
 from serialx.common import SerialPortInfo
-from serialx.platforms import serial_posix
-from serialx.platforms.serial_posix import posix_list_serial_ports
+from serialx.platforms import serial_linux
+from serialx.platforms.serial_linux import linux_list_serial_ports
 
 
 def create_usb_serial_device(
@@ -293,8 +293,8 @@ def fake_sysfs(tmp_path):
     )
 
     with (
-        patch.object(serial_posix, "SYS_ROOT", sys_root),
-        patch.object(serial_posix, "DEV_ROOT", dev_root),
+        patch.object(serial_linux, "SYS_ROOT", sys_root),
+        patch.object(serial_linux, "DEV_ROOT", dev_root),
     ):
         yield sys_root, dev_root
 
@@ -303,7 +303,7 @@ def test_list_serial_ports_linux(fake_sysfs) -> None:
     """Test listing all serial ports on a system mimicking test-yellow-core."""
     sys_root, dev_root = fake_sysfs
 
-    ports = posix_list_serial_ports()
+    ports = linux_list_serial_ports()
     assert len(ports) == 9
 
     ports_by_name = {Path(p.resolved_device).name: p for p in ports}

--- a/tests/test_serial_linux.py
+++ b/tests/test_serial_linux.py
@@ -16,15 +16,15 @@ import threading
 from typing import Any
 from unittest.mock import ANY, call, patch
 
-from serialx.platforms.serial_posix import PosixSerial, PosixSerialTransport
+from serialx.platforms.serial_linux import LinuxSerial, LinuxSerialTransport
 from tests.common import async_create_socat_pair, create_socat_pair
 
 TIOCSSERIAL = 0x0000541F
 TIOCGSERIAL = 0x0000541E
 
 
-@patch("serialx.platforms.serial_posix.TIOCGSERIAL", TIOCGSERIAL)
-@patch("serialx.platforms.serial_posix.TIOCSSERIAL", TIOCSSERIAL)
+@patch("serialx.platforms.serial_linux.TIOCGSERIAL", TIOCGSERIAL)
+@patch("serialx.platforms.serial_linux.TIOCSSERIAL", TIOCSSERIAL)
 def test_tiocgserial_ioctl_not_supported() -> None:
     """Test that TIOCGSERIAL ioctl not supported is handled gracefully."""
     ioctl_orig = fcntl.ioctl
@@ -36,18 +36,18 @@ def test_tiocgserial_ioctl_not_supported() -> None:
         return ioctl_orig(fd, request, arg, mutate_flag)
 
     with patch(
-        "serialx.platforms.serial_posix.fcntl.ioctl", side_effect=ioctl
+        "serialx.platforms.serial_linux.fcntl.ioctl", side_effect=ioctl
     ) as mock_ioctl:
         with create_socat_pair() as (left, _right):
-            with PosixSerial(left, baudrate=115200):
+            with LinuxSerial(left, baudrate=115200):
                 # The serial port still opens
                 pass
 
     assert call(ANY, TIOCGSERIAL, ANY) in mock_ioctl.mock_calls
 
 
-@patch("serialx.platforms.serial_posix.TIOCGSERIAL", TIOCGSERIAL)
-@patch("serialx.platforms.serial_posix.TIOCSSERIAL", TIOCSSERIAL)
+@patch("serialx.platforms.serial_linux.TIOCGSERIAL", TIOCGSERIAL)
+@patch("serialx.platforms.serial_linux.TIOCSSERIAL", TIOCSSERIAL)
 def test_tiocgserial_ioctl_unexpected() -> None:
     """Test that TIOCGSERIAL ioctl not supported is handled gracefully."""
     ioctl_orig = fcntl.ioctl
@@ -59,11 +59,11 @@ def test_tiocgserial_ioctl_unexpected() -> None:
         return ioctl_orig(fd, request, arg, mutate_flag)
 
     with patch(
-        "serialx.platforms.serial_posix.fcntl.ioctl", side_effect=ioctl
+        "serialx.platforms.serial_linux.fcntl.ioctl", side_effect=ioctl
     ) as mock_ioctl:
         with create_socat_pair() as (left, _right):
             with pytest.raises(OSError, match="Invalid argument"):
-                with PosixSerial(left, baudrate=115200):
+                with LinuxSerial(left, baudrate=115200):
                     # The serial port will fail to open
                     pass
 
@@ -75,7 +75,7 @@ async def test_async_linux_race_condition_connect_close() -> None:
     started_configuring = threading.Event()
     resume_configuring = threading.Event()
 
-    class SlowConfigureSerial(PosixSerial):
+    class SlowConfigureSerial(LinuxSerial):
         def _configure_port(self) -> None:
             started_configuring.set()
             if not resume_configuring.wait(timeout=5.0):
@@ -83,7 +83,7 @@ async def test_async_linux_race_condition_connect_close() -> None:
 
             super()._configure_port()
 
-    class TestTransport(PosixSerialTransport):
+    class TestTransport(LinuxSerialTransport):
         _serial_cls = SlowConfigureSerial
 
     class ProbeProtocol(asyncio.Protocol):
@@ -91,7 +91,7 @@ async def test_async_linux_race_condition_connect_close() -> None:
             self.connection_made_calls = 0
 
         def connection_made(self, transport: asyncio.BaseTransport) -> None:
-            assert isinstance(transport, PosixSerialTransport)
+            assert isinstance(transport, LinuxSerialTransport)
             self.connection_made_calls += 1
 
     loop = asyncio.get_running_loop()
@@ -132,7 +132,7 @@ async def test_async_linux_race_condition_connect_close() -> None:
 async def test_async_linux_wait_closed_when_close_task_cancelled() -> None:
     """wait_closed should resolve even if close task is cancelled before start."""
     loop = asyncio.get_running_loop()
-    transport = PosixSerialTransport(loop, asyncio.Protocol())
+    transport = LinuxSerialTransport(loop, asyncio.Protocol())
 
     async with async_create_socat_pair() as (left_path, _right_path):
         await transport.connect(path=left_path, baudrate=115200)
@@ -158,7 +158,7 @@ async def test_async_linux_wait_closed_when_connection_lost_raises() -> None:
             raise RuntimeError("boom")
 
     loop = asyncio.get_running_loop()
-    transport = PosixSerialTransport(loop, RaisingProtocol())
+    transport = LinuxSerialTransport(loop, RaisingProtocol())
 
     async with async_create_socat_pair() as (left_path, _right_path):
         await transport.connect(path=left_path, baudrate=115200)
@@ -171,7 +171,7 @@ async def test_async_linux_wait_closed_when_connection_lost_raises() -> None:
 async def test_async_linux_close_clears_fileno_when_fd_already_closed() -> None:
     """Close should clear fileno even if fd was externally closed."""
     loop = asyncio.get_running_loop()
-    transport = PosixSerialTransport(loop, asyncio.Protocol())
+    transport = LinuxSerialTransport(loop, asyncio.Protocol())
 
     async with async_create_socat_pair() as (left_path, _right_path):
         await transport.connect(path=left_path, baudrate=115200)

--- a/tests/test_sync_transports.py
+++ b/tests/test_sync_transports.py
@@ -129,6 +129,13 @@ def test_sync_random_large(
     serial_pair: SerialPair, baudrate: int, chunk_size: int
 ) -> None:
     """Test random read/write at various speeds."""
+    if (
+        baudrate > 230400
+        and sys.platform == "darwin"
+        and serial_pair.serial_class in ("PosixSerial", "ExtendedPosixSerial")
+    ):
+        pytest.xfail("macOS termios lacks constants above B230400")
+
     with (
         Serial.from_url(serial_pair.left, baudrate=baudrate) as left,
         Serial.from_url(serial_pair.right, baudrate=baudrate) as right,
@@ -172,6 +179,12 @@ def test_sync_buffered_writes_then_read(serial_pair: SerialPair) -> None:
 @pytest.mark.parametrize("payload_size", [1024, 2048])
 def test_sync_large_payload(serial_pair: SerialPair, payload_size: int) -> None:
     """Test large payload transmission."""
+    if sys.platform == "darwin" and serial_pair.serial_class in (
+        "PosixSerial",
+        "ExtendedPosixSerial",
+    ):
+        pytest.xfail("macOS termios lacks constants above B230400")
+
     with (
         Serial.from_url(serial_pair.left, baudrate=921600) as left,
         Serial.from_url(serial_pair.right, baudrate=921600) as right,
@@ -204,6 +217,13 @@ def test_sync_sustained_throughput(
     serial_pair: SerialPair, baudrate: int, iterations: int
 ) -> None:
     """Test sustained data throughput at various baudrates."""
+    if (
+        baudrate > 230400
+        and sys.platform == "darwin"
+        and serial_pair.serial_class in ("PosixSerial", "ExtendedPosixSerial")
+    ):
+        pytest.xfail("macOS termios lacks constants above B230400")
+
     if serial_pair.backend == "esphome" and (baudrate, iterations) == (921600, 512):
         pytest.skip(
             "ESPHome backend is too slow for sustained throughput at 921600/512"
@@ -227,6 +247,13 @@ def test_sync_sustained_throughput(
 )
 def test_sync_valid_baudrates(serial_pair: SerialPair, baudrate: int) -> None:
     """Test that valid baudrates are accepted."""
+    if (
+        baudrate > 230400
+        and sys.platform == "darwin"
+        and serial_pair.serial_class in ("PosixSerial", "ExtendedPosixSerial")
+    ):
+        pytest.xfail("macOS termios lacks constants above B230400")
+
     with Serial.from_url(serial_pair.left, baudrate=baudrate) as serial:
         assert serial.baudrate == baudrate
         serial.write(b"test")
@@ -301,6 +328,9 @@ def test_sync_xonxoff_setting(serial_pair: SerialPair, xonxoff: bool) -> None:
 @pytest.mark.parametrize("rtscts", [True, False])
 def test_sync_rtscts_setting(serial_pair: SerialPair, rtscts: bool) -> None:
     """Test that rtscts setting is accepted."""
+    if rtscts and serial_pair.serial_class == "PosixSerial":
+        pytest.xfail("Strict POSIX backend does not support RTS/CTS flow control")
+
     # Open both sides: on com0com, opening right asserts DTR which raises CTS on left
     with Serial.from_url(serial_pair.right, baudrate=115200):
         with Serial.from_url(serial_pair.left, baudrate=115200, rtscts=rtscts) as left:

--- a/tests/test_sync_transports.py
+++ b/tests/test_sync_transports.py
@@ -239,6 +239,8 @@ def test_sync_valid_parity(serial_pair: SerialPair, parity: Parity) -> None:
     """Test that valid parity settings are accepted."""
     if serial_pair.backend == "esphome" and parity in (Parity.MARK, Parity.SPACE):
         pytest.xfail("ESPHome backend does not support MARK/SPACE parity")
+    if sys.platform == "darwin" and parity in (Parity.MARK, Parity.SPACE):
+        pytest.skip("MARK/SPACE parity not supported on macOS")
 
     with Serial.from_url(serial_pair.left, baudrate=115200, parity=parity) as serial:
         assert serial.parity == parity
@@ -264,6 +266,8 @@ def test_sync_valid_stopbits(
     """Test that valid stopbits settings are accepted."""
     if serial_pair.backend == "esphome" and expected is StopBits.ONE_POINT_FIVE:
         pytest.xfail("ESPHome backend does not support 1.5 stop bits")
+    if sys.platform in ("linux", "darwin") and expected is StopBits.ONE_POINT_FIVE:
+        pytest.skip("1.5 stop bits not supported on POSIX")
 
     with Serial.from_url(
         serial_pair.left, baudrate=115200, stopbits=stopbits

--- a/tests/test_sync_transports.py
+++ b/tests/test_sync_transports.py
@@ -239,8 +239,11 @@ def test_sync_valid_parity(serial_pair: SerialPair, parity: Parity) -> None:
     """Test that valid parity settings are accepted."""
     if serial_pair.backend == "esphome" and parity in (Parity.MARK, Parity.SPACE):
         pytest.xfail("ESPHome backend does not support MARK/SPACE parity")
-    if sys.platform == "darwin" and parity in (Parity.MARK, Parity.SPACE):
-        pytest.skip("MARK/SPACE parity not supported on macOS")
+    if serial_pair.serial_class not in ("LinuxSerial", "Win32Serial") and parity in (
+        Parity.MARK,
+        Parity.SPACE,
+    ):
+        pytest.skip("MARK/SPACE parity requires CMSPAR (Linux) or Win32")
 
     with Serial.from_url(serial_pair.left, baudrate=115200, parity=parity) as serial:
         assert serial.parity == parity
@@ -266,8 +269,11 @@ def test_sync_valid_stopbits(
     """Test that valid stopbits settings are accepted."""
     if serial_pair.backend == "esphome" and expected is StopBits.ONE_POINT_FIVE:
         pytest.xfail("ESPHome backend does not support 1.5 stop bits")
-    if sys.platform in ("linux", "darwin") and expected is StopBits.ONE_POINT_FIVE:
-        pytest.skip("1.5 stop bits not supported on POSIX")
+    if (
+        serial_pair.serial_class not in ("Win32Serial",)
+        and expected is StopBits.ONE_POINT_FIVE
+    ):
+        pytest.skip("1.5 stop bits only supported on Win32")
 
     with Serial.from_url(
         serial_pair.left, baudrate=115200, stopbits=stopbits


### PR DESCRIPTION
This PR modifies the `serial_posix` platform to be entirely POSIX-compliant and moves all Linux-specific functionality into `serial_linux`. If a platform provides a POSIX-compliant API via the `termios` module, `serial_posix` will be used, with platform-specific modules for Darwin and Linux.