### PR TITLE
Initial FreeBSD support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,6 +209,9 @@ split-on-trailing-comma = false
 [tool.ruff.lint.mccabe]
 max-complexity = 25
 
+[tool.codespell]
+skip = "tests/data/*"
+
 [tool.coverage.report]
 show_missing = true
 exclude_also = [

--- a/serialx/platforms/__init__.py
+++ b/serialx/platforms/__init__.py
@@ -27,6 +27,12 @@ elif sys.platform == "darwin":
         DarwinSerialTransport as SerialTransport,
         darwin_list_serial_ports as list_serial_ports,
     )
+elif sys.platform.startswith("freebsd"):
+    from .serial_freebsd import (
+        FreeBSDSerial as Serial,
+        FreeBSDSerialTransport as SerialTransport,
+        freebsd_list_serial_ports as list_serial_ports,
+    )
 elif maybe_posix:
     from .serial_extended_posix import is_extended_posix
 

--- a/serialx/platforms/serial_freebsd.py
+++ b/serialx/platforms/serial_freebsd.py
@@ -28,17 +28,6 @@ class FreeBSDSerialTransport(ExtendedPosixSerialTransport):
     _serial_cls = FreeBSDSerial
 
 
-def _run_sysctl(*args: str) -> str:
-    """Run sysctl and return stdout."""
-    result = subprocess.run(
-        ["sysctl", *args],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    return result.stdout
-
-
 def _parse_pnpinfo(pnpinfo: str) -> dict[str, str]:
     """Parse a sysctl %pnpinfo value into a dict.
 
@@ -65,61 +54,69 @@ def _parse_location(location: str) -> dict[str, str]:
     return result
 
 
-def _get_usb_strings(ugen: str) -> tuple[str | None, str | None]:
-    """Get manufacturer and product strings from usbconfig."""
+def _get_all_usb_strings() -> dict[str, tuple[str | None, str | None]]:
+    """Get manufacturer and product strings for all USB devices via usbconfig."""
     result = subprocess.run(
-        ["usbconfig", "-d", ugen, "dump_device_desc"],
+        ["usbconfig", "dump_device_desc"],
         capture_output=True,
         text=True,
         check=True,
     )
 
-    manufacturer = None
-    product = None
+    devices: dict[str, tuple[str | None, str | None]] = {}
+    current_ugen: str | None = None
+    manufacturer: str | None = None
+    product: str | None = None
 
     for line in result.stdout.splitlines():
+        if line.startswith("ugen"):
+            if current_ugen is not None:
+                devices[current_ugen] = (manufacturer, product)
+            current_ugen = line.split(":")[0]
+            manufacturer = None
+            product = None
+            continue
+
         match = _MANUFACTURER_RE.search(line)
         if match:
             manufacturer = match.group(1)
+            continue
 
         match = _PRODUCT_RE.search(line)
         if match:
             product = match.group(1)
 
-    return manufacturer, product
+    if current_ugen is not None:
+        devices[current_ugen] = (manufacturer, product)
+
+    return devices
 
 
 def freebsd_list_serial_ports() -> list[SerialPortInfo]:
     """List available serial ports on FreeBSD."""
+    sysctl_text = subprocess.run(
+        ["sysctl", "-e", "dev"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    sysctl = dict(line.split("=", 1) for line in sysctl_text.splitlines())
+
+    usb_strings = _get_all_usb_strings()
     results = []
-    ttyname_nodes = [
-        n for n in _run_sysctl("-N", "dev").splitlines() if n.endswith(".ttyname")
-    ]
 
-    for node in ttyname_nodes:
-        parent = node.removesuffix(".ttyname")
+    for key, value in sysctl.items():
+        if not key.endswith(".ttyname"):
+            continue
 
-        output = _run_sysctl(
-            f"{parent}.ttyname",
-            f"{parent}.%pnpinfo",
-            f"{parent}.%location",
-        )
+        parent = key.removesuffix(".ttyname")
+        ttyname = value
+        pnpinfo = _parse_pnpinfo(sysctl[f"{parent}.%pnpinfo"])
+        location = _parse_location(sysctl[f"{parent}.%location"])
 
-        values = {}
-        for line in output.splitlines():
-            key, _, value = line.partition(": ")
-            values[key.strip()] = value.strip()
-
-        ttyname = values[f"{parent}.ttyname"]
-        pnpinfo_raw = values[f"{parent}.%pnpinfo"]
-        location_raw = values[f"{parent}.%location"]
-
-        pnpinfo = _parse_pnpinfo(pnpinfo_raw)
-        location = _parse_location(location_raw)
+        manufacturer, product = usb_strings.get(location["ugen"], (None, None))
 
         device = Path(f"/dev/cua{ttyname}")
-        manufacturer, product = _get_usb_strings(location["ugen"])
-
         vid_str = pnpinfo.get("vendor")
         pid_str = pnpinfo.get("product")
         release_str = pnpinfo.get("release")

--- a/serialx/platforms/serial_freebsd.py
+++ b/serialx/platforms/serial_freebsd.py
@@ -1,0 +1,144 @@
+"""FreeBSD serial port implementation."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+import re
+import subprocess
+
+from ..common import SerialPortInfo
+from .serial_extended_posix import ExtendedPosixSerial, ExtendedPosixSerialTransport
+
+LOGGER = logging.getLogger(__name__)
+
+_PNPINFO_RE = re.compile(r'(\w+)=(?:"([^"]*)"|(\S+))')
+_LOCATION_RE = re.compile(r"(\w+)=(\S+)")
+_MANUFACTURER_RE = re.compile(r"iManufacturer\s*=\s*0x\w+\s+<(.+)>")
+_PRODUCT_RE = re.compile(r"iProduct\s*=\s*0x\w+\s+<(.+)>")
+
+
+class FreeBSDSerial(ExtendedPosixSerial):
+    """FreeBSD serial port implementation."""
+
+
+class FreeBSDSerialTransport(ExtendedPosixSerialTransport):
+    """FreeBSD serial port transport."""
+
+    _serial_cls = FreeBSDSerial
+
+
+def _run_sysctl(*args: str) -> str:
+    """Run sysctl and return stdout."""
+    result = subprocess.run(
+        ["sysctl", *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def _parse_pnpinfo(pnpinfo: str) -> dict[str, str]:
+    """Parse a sysctl %pnpinfo value into a dict.
+
+    Example input:
+        vendor=0x0403 product=0x6001 sernum="A5069RR4" release=0x0600 ...
+    """
+    result = {}
+    for match in _PNPINFO_RE.finditer(pnpinfo):
+        key = match.group(1)
+        value = match.group(2) if match.group(2) is not None else match.group(3)
+        result[key] = value
+    return result
+
+
+def _parse_location(location: str) -> dict[str, str]:
+    """Parse a sysctl %location value into a dict.
+
+    Example input:
+        bus=0 hubaddr=1 port=1 devaddr=2 interface=0 ugen=ugen0.2
+    """
+    result = {}
+    for match in _LOCATION_RE.finditer(location):
+        result[match.group(1)] = match.group(2)
+    return result
+
+
+def _get_usb_strings(ugen: str) -> tuple[str | None, str | None]:
+    """Get manufacturer and product strings from usbconfig."""
+    result = subprocess.run(
+        ["usbconfig", "-d", ugen, "dump_device_desc"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    manufacturer = None
+    product = None
+
+    for line in result.stdout.splitlines():
+        match = _MANUFACTURER_RE.search(line)
+        if match:
+            manufacturer = match.group(1)
+
+        match = _PRODUCT_RE.search(line)
+        if match:
+            product = match.group(1)
+
+    return manufacturer, product
+
+
+def freebsd_list_serial_ports() -> list[SerialPortInfo]:
+    """List available serial ports on FreeBSD."""
+    results = []
+    ttyname_nodes = [
+        n for n in _run_sysctl("-N", "dev").splitlines() if n.endswith(".ttyname")
+    ]
+
+    for node in ttyname_nodes:
+        parent = node.removesuffix(".ttyname")
+
+        output = _run_sysctl(
+            f"{parent}.ttyname",
+            f"{parent}.%pnpinfo",
+            f"{parent}.%location",
+        )
+
+        values = {}
+        for line in output.splitlines():
+            key, _, value = line.partition(": ")
+            values[key.strip()] = value.strip()
+
+        ttyname = values[f"{parent}.ttyname"]
+        pnpinfo_raw = values[f"{parent}.%pnpinfo"]
+        location_raw = values[f"{parent}.%location"]
+
+        pnpinfo = _parse_pnpinfo(pnpinfo_raw)
+        location = _parse_location(location_raw)
+
+        device = Path(f"/dev/cua{ttyname}")
+        manufacturer, product = _get_usb_strings(location["ugen"])
+
+        vid_str = pnpinfo.get("vendor")
+        pid_str = pnpinfo.get("product")
+        release_str = pnpinfo.get("release")
+
+        results.append(
+            SerialPortInfo(
+                device=device,
+                resolved_device=device,
+                vid=int(vid_str, 16) if vid_str else None,
+                pid=int(pid_str, 16) if pid_str else None,
+                serial_number=pnpinfo.get("sernum"),
+                manufacturer=manufacturer,
+                product=product,
+                bcd_device=int(release_str, 16) if release_str else None,
+                interface_description=None,
+                interface_num=(
+                    int(location["interface"]) if "interface" in location else None
+                ),
+            )
+        )
+
+    return results

--- a/tests/data/freebsd/sysctl_dev.txt
+++ b/tests/data/freebsd/sysctl_dev.txt
@@ -1,0 +1,930 @@
+dev.umodem.0.ttyports=1
+dev.umodem.0.ttyname=U0
+dev.umodem.0.%iommu=
+dev.umodem.0.%parent=uhub4
+dev.umodem.0.%pnpinfo=vendor=0x303a product=0x4001 devclass=0xef devsubclass=0x02 devproto=0x01 sernum="80B54EEFAE18" release=0x0101 mode=host intclass=0x02 intsubclass=0x02 intprotocol=0x00 ttyname=U0 ttyports=1
+dev.umodem.0.%location=bus=8 hubaddr=1 port=19 devaddr=4 interface=0 ugen=ugen8.4
+dev.umodem.0.%driver=umodem
+dev.umodem.0.%desc=Nabu Casa ZBT-2, class 239/2, rev 2.00/1.01, addr 3
+dev.umodem.%parent=
+dev.uplcom.%parent=
+dev.uslcom.0.ttyports=1
+dev.uslcom.0.ttyname=U3
+dev.uslcom.0.%iommu=
+dev.uslcom.0.%parent=uhub4
+dev.uslcom.0.%pnpinfo=vendor=0x10c4 product=0xea60 devclass=0x00 devsubclass=0x00 devproto=0x00 sernum="ec4903cb" release=0x0100 mode=host intclass=0xff intsubclass=0x00 intprotocol=0x00 ttyname=U3 ttyports=1
+dev.uslcom.0.%location=bus=8 hubaddr=1 port=20 devaddr=5 interface=0 ugen=ugen8.5
+dev.uslcom.0.%driver=uslcom
+dev.uslcom.0.%desc=Silicon Labs CP2102 USB to UART Bridge Controller, class 0/0, rev 1.10/1.00, addr 4
+dev.uslcom.%parent=
+dev.uftdi.0.ttyports=1
+dev.uftdi.0.ttyname=U4
+dev.uftdi.0.%iommu=
+dev.uftdi.0.%parent=uhub4
+dev.uftdi.0.%pnpinfo=vendor=0x0403 product=0x6001 devclass=0x00 devsubclass=0x00 devproto=0x00 sernum="rutabaga" release=0x0600 mode=host intclass=0xff intsubclass=0xff intprotocol=0xff ttyname=U4 ttyports=1
+dev.uftdi.0.%location=bus=8 hubaddr=1 port=18 devaddr=6 interface=0 ugen=ugen8.6
+dev.uftdi.0.%driver=uftdi
+dev.uftdi.0.%desc=FTDI FT232R USB UART, class 0/0, rev 2.00/6.00, addr 5
+dev.uftdi.2.ttyports=1
+dev.uftdi.2.ttyname=U2
+dev.uftdi.2.%iommu=
+dev.uftdi.2.%parent=uhub4
+dev.uftdi.2.%pnpinfo=vendor=0x0403 product=0x6001 devclass=0x00 devsubclass=0x00 devproto=0x00 sernum="A5069RR4" release=0x0600 mode=host intclass=0xff intsubclass=0xff intprotocol=0xff ttyname=U2 ttyports=1
+dev.uftdi.2.%location=bus=8 hubaddr=1 port=17 devaddr=3 interface=0 ugen=ugen8.3
+dev.uftdi.2.%driver=uftdi
+dev.uftdi.2.%desc=FTDI FT232R USB UART, class 0/0, rev 2.00/6.00, addr 2
+dev.uftdi.1.ttyports=1
+dev.uftdi.1.ttyname=U1
+dev.uftdi.1.%iommu=
+dev.uftdi.1.%parent=uhub4
+dev.uftdi.1.%pnpinfo=vendor=0x0403 product=0x6001 devclass=0x00 devsubclass=0x00 devproto=0x00 sernum="A5069RR4" release=0x0600 mode=host intclass=0xff intsubclass=0xff intprotocol=0xff ttyname=U1 ttyports=1
+dev.uftdi.1.%location=bus=8 hubaddr=1 port=16 devaddr=2 interface=0 ugen=ugen8.2
+dev.uftdi.1.%driver=uftdi
+dev.uftdi.1.%desc=FTDI FT232R USB UART, class 0/0, rev 2.00/6.00, addr 1
+dev.uftdi.%parent=
+dev.uhid.0.%iommu=
+dev.uhid.0.%parent=uhub7
+dev.uhid.0.%pnpinfo=vendor=0x0627 product=0x0001 devclass=0x00 devsubclass=0x00 devproto=0x00 sernum="28754-0000:00:1d.7-1" release=0x0000 mode=host intclass=0x03 intsubclass=0x00 intprotocol=0x00
+dev.uhid.0.%location=bus=7 hubaddr=1 port=1 devaddr=2 interface=0 ugen=ugen7.2
+dev.uhid.0.%driver=uhid
+dev.uhid.0.%desc=QEMU QEMU USB Tablet, class 0/0, rev 2.00/0.00, addr 2
+dev.uhid.%parent=
+dev.vtcon.0.%iommu=
+dev.vtcon.0.%parent=virtio_pci0
+dev.vtcon.0.%pnpinfo=vendor=0x00001af4 device=0x1003 subvendor=0x1af4 device_type=0x00000003
+dev.vtcon.0.%location=
+dev.vtcon.0.%driver=vtcon
+dev.vtcon.0.%desc=VirtIO Console Adapter
+dev.vtcon.%parent=
+dev.smbus.0.%iommu=
+dev.smbus.0.%parent=ichsmb0
+dev.smbus.0.%pnpinfo=
+dev.smbus.0.%location=
+dev.smbus.0.%driver=smbus
+dev.smbus.0.%desc=System Management Bus
+dev.smbus.%parent=
+dev.ichsmb.0.%iommu=rid=0xfb
+dev.ichsmb.0.%parent=pci0
+dev.ichsmb.0.%pnpinfo=vendor=0x8086 device=0x2930 subvendor=0x1af4 subdevice=0x1100 class=0x0c0500
+dev.ichsmb.0.%location=slot=31 function=3 dbsf=pci0:0:31:3 handle=\_SB_.PCI0.SFB_
+dev.ichsmb.0.%driver=ichsmb
+dev.ichsmb.0.%desc=Intel 82801I (ICH9) SMBus controller
+dev.ichsmb.%parent=
+dev.uhub.8.disable_port_power=0
+dev.uhub.8.disable_enumeration=0
+dev.uhub.8.%iommu=
+dev.uhub.8.%parent=usbus3
+dev.uhub.8.%pnpinfo=
+dev.uhub.8.%location=
+dev.uhub.8.%driver=uhub
+dev.uhub.8.%desc=Intel EHCI root HUB, class 9/0, rev 2.00/1.00, addr 1
+dev.uhub.7.disable_port_power=0
+dev.uhub.7.disable_enumeration=0
+dev.uhub.7.%iommu=
+dev.uhub.7.%parent=usbus7
+dev.uhub.7.%pnpinfo=
+dev.uhub.7.%location=
+dev.uhub.7.%driver=uhub
+dev.uhub.7.%desc=Intel EHCI root HUB, class 9/0, rev 2.00/1.00, addr 1
+dev.uhub.6.disable_port_power=0
+dev.uhub.6.disable_enumeration=0
+dev.uhub.6.%iommu=
+dev.uhub.6.%parent=usbus5
+dev.uhub.6.%pnpinfo=
+dev.uhub.6.%location=
+dev.uhub.6.%driver=uhub
+dev.uhub.6.%desc=Intel UHCI root HUB, class 9/0, rev 1.00/1.00, addr 1
+dev.uhub.5.disable_port_power=0
+dev.uhub.5.disable_enumeration=0
+dev.uhub.5.%iommu=
+dev.uhub.5.%parent=usbus0
+dev.uhub.5.%pnpinfo=
+dev.uhub.5.%location=
+dev.uhub.5.%driver=uhub
+dev.uhub.5.%desc=Intel UHCI root HUB, class 9/0, rev 1.00/1.00, addr 1
+dev.uhub.4.disable_port_power=0
+dev.uhub.4.disable_enumeration=0
+dev.uhub.4.%iommu=
+dev.uhub.4.%parent=usbus8
+dev.uhub.4.%pnpinfo=
+dev.uhub.4.%location=
+dev.uhub.4.%driver=uhub
+dev.uhub.4.%desc=(0x1b36) XHCI root HUB, class 9/0, rev 3.00/1.00, addr 1
+dev.uhub.3.disable_port_power=0
+dev.uhub.3.disable_enumeration=0
+dev.uhub.3.%iommu=
+dev.uhub.3.%parent=usbus1
+dev.uhub.3.%pnpinfo=
+dev.uhub.3.%location=
+dev.uhub.3.%driver=uhub
+dev.uhub.3.%desc=Intel UHCI root HUB, class 9/0, rev 1.00/1.00, addr 1
+dev.uhub.2.disable_port_power=0
+dev.uhub.2.disable_enumeration=0
+dev.uhub.2.%iommu=
+dev.uhub.2.%parent=usbus6
+dev.uhub.2.%pnpinfo=
+dev.uhub.2.%location=
+dev.uhub.2.%driver=uhub
+dev.uhub.2.%desc=Intel UHCI root HUB, class 9/0, rev 1.00/1.00, addr 1
+dev.uhub.1.disable_port_power=0
+dev.uhub.1.disable_enumeration=0
+dev.uhub.1.%iommu=
+dev.uhub.1.%parent=usbus4
+dev.uhub.1.%pnpinfo=
+dev.uhub.1.%location=
+dev.uhub.1.%driver=uhub
+dev.uhub.1.%desc=Intel UHCI root HUB, class 9/0, rev 1.00/1.00, addr 1
+dev.uhub.0.disable_port_power=0
+dev.uhub.0.disable_enumeration=0
+dev.uhub.0.%iommu=
+dev.uhub.0.%parent=usbus2
+dev.uhub.0.%pnpinfo=
+dev.uhub.0.%location=
+dev.uhub.0.%driver=uhub
+dev.uhub.0.%desc=Intel UHCI root HUB, class 9/0, rev 1.00/1.00, addr 1
+dev.uhub.%parent=
+dev.attimer.0.%iommu=
+dev.attimer.0.%parent=isa0
+dev.attimer.0.%pnpinfo=
+dev.attimer.0.%location=
+dev.attimer.0.%driver=attimer
+dev.attimer.0.%desc=AT timer
+dev.attimer.%parent=
+dev.apic.0.%iommu=
+dev.apic.0.%parent=nexus0
+dev.apic.0.%pnpinfo=
+dev.apic.0.%location=
+dev.apic.0.%driver=apic
+dev.apic.0.%desc=APIC resources
+dev.apic.%parent=
+dev.psm.0.%iommu=
+dev.psm.0.%parent=atkbdc0
+dev.psm.0.%pnpinfo=
+dev.psm.0.%location=
+dev.psm.0.%driver=psm
+dev.psm.0.%desc=PS/2 Mouse
+dev.psm.%parent=
+dev.psmcpnp.0.%iommu=
+dev.psmcpnp.0.%parent=acpi0
+dev.psmcpnp.0.%pnpinfo=_HID=PNP0F13 _UID=0 _CID=none
+dev.psmcpnp.0.%location=handle=\_SB_.PCI0.SF8_.MOU_
+dev.psmcpnp.0.%driver=psmcpnp
+dev.psmcpnp.0.%desc=PS/2 mouse port
+dev.psmcpnp.%parent=
+dev.atkbd.0.%iommu=
+dev.atkbd.0.%parent=atkbdc0
+dev.atkbd.0.%pnpinfo=
+dev.atkbd.0.%location=
+dev.atkbd.0.%driver=atkbd
+dev.atkbd.0.%desc=AT Keyboard
+dev.atkbd.%parent=
+dev.atkbdc.0.%iommu=
+dev.atkbdc.0.%parent=acpi0
+dev.atkbdc.0.%pnpinfo=_HID=PNP0303 _UID=0 _CID=none
+dev.atkbdc.0.%location=handle=\_SB_.PCI0.SF8_.KBD_
+dev.atkbdc.0.%driver=atkbdc
+dev.atkbdc.0.%desc=Keyboard controller (i8042)
+dev.atkbdc.%parent=
+dev.vmgenc.0.%iommu=
+dev.vmgenc.0.%parent=acpi0
+dev.vmgenc.0.%pnpinfo=_HID=QEMUVGID _UID=0 _CID=VM_GEN_COUNTER
+dev.vmgenc.0.%location=handle=\_SB_.VGEN
+dev.vmgenc.0.%driver=vmgenc
+dev.vmgenc.0.%desc=VM Generation Counter
+dev.vmgenc.%parent=
+dev.acpi_syscontainer.4.%iommu=
+dev.acpi_syscontainer.4.%parent=acpi0
+dev.acpi_syscontainer.4.%pnpinfo=_HID=PNP0A06 _UID=0 _CID=none
+dev.acpi_syscontainer.4.%location=handle=\_SB_.PCI0.PHPR
+dev.acpi_syscontainer.4.%driver=acpi_syscontainer
+dev.acpi_syscontainer.4.%desc=System Container
+dev.acpi_syscontainer.3.%iommu=
+dev.acpi_syscontainer.3.%parent=acpi0
+dev.acpi_syscontainer.3.%pnpinfo=_HID=PNP0A06 _UID=0 _CID=none
+dev.acpi_syscontainer.3.%location=handle=\_SB_.PCI0.GPE0
+dev.acpi_syscontainer.3.%driver=acpi_syscontainer
+dev.acpi_syscontainer.3.%desc=System Container
+dev.acpi_syscontainer.2.%iommu=
+dev.acpi_syscontainer.2.%parent=acpi0
+dev.acpi_syscontainer.2.%pnpinfo=_HID=PNP0A06 _UID=0 _CID=none
+dev.acpi_syscontainer.2.%location=handle=\_SB_.PCI0.PRES
+dev.acpi_syscontainer.2.%driver=acpi_syscontainer
+dev.acpi_syscontainer.2.%desc=System Container
+dev.acpi_syscontainer.1.%iommu=
+dev.acpi_syscontainer.1.%parent=acpi0
+dev.acpi_syscontainer.1.%pnpinfo=_HID=PNP0A06 _UID=0 _CID=none
+dev.acpi_syscontainer.1.%location=handle=\_SB_.PCI0.SMI0
+dev.acpi_syscontainer.1.%driver=acpi_syscontainer
+dev.acpi_syscontainer.1.%desc=System Container
+dev.acpi_syscontainer.0.%iommu=
+dev.acpi_syscontainer.0.%parent=acpi0
+dev.acpi_syscontainer.0.%pnpinfo=_HID=ACPI0010 _UID=0 _CID=PNP0A05
+dev.acpi_syscontainer.0.%location=handle=\_SB_.CPUS
+dev.acpi_syscontainer.0.%driver=acpi_syscontainer
+dev.acpi_syscontainer.0.%desc=System Container
+dev.acpi_syscontainer.%parent=
+dev.ahcich.5.disable_phy=0
+dev.ahcich.5.%iommu=
+dev.ahcich.5.%parent=ahci0
+dev.ahcich.5.%pnpinfo=
+dev.ahcich.5.%location=channel=5
+dev.ahcich.5.%driver=ahcich
+dev.ahcich.5.%desc=AHCI channel
+dev.ahcich.4.disable_phy=0
+dev.ahcich.4.%iommu=
+dev.ahcich.4.%parent=ahci0
+dev.ahcich.4.%pnpinfo=
+dev.ahcich.4.%location=channel=4
+dev.ahcich.4.%driver=ahcich
+dev.ahcich.4.%desc=AHCI channel
+dev.ahcich.3.disable_phy=0
+dev.ahcich.3.%iommu=
+dev.ahcich.3.%parent=ahci0
+dev.ahcich.3.%pnpinfo=
+dev.ahcich.3.%location=channel=3
+dev.ahcich.3.%driver=ahcich
+dev.ahcich.3.%desc=AHCI channel
+dev.ahcich.2.disable_phy=0
+dev.ahcich.2.%iommu=
+dev.ahcich.2.%parent=ahci0
+dev.ahcich.2.%pnpinfo=
+dev.ahcich.2.%location=channel=2
+dev.ahcich.2.%driver=ahcich
+dev.ahcich.2.%desc=AHCI channel
+dev.ahcich.1.disable_phy=0
+dev.ahcich.1.%iommu=
+dev.ahcich.1.%parent=ahci0
+dev.ahcich.1.%pnpinfo=
+dev.ahcich.1.%location=channel=1
+dev.ahcich.1.%driver=ahcich
+dev.ahcich.1.%desc=AHCI channel
+dev.ahcich.0.disable_phy=0
+dev.ahcich.0.%iommu=
+dev.ahcich.0.%parent=ahci0
+dev.ahcich.0.%pnpinfo=
+dev.ahcich.0.%location=channel=0
+dev.ahcich.0.%driver=ahcich
+dev.ahcich.0.%desc=AHCI channel
+dev.ahcich.%parent=
+dev.ahci.0.%iommu=rid=0xfa
+dev.ahci.0.%parent=pci0
+dev.ahci.0.%pnpinfo=vendor=0x8086 device=0x2922 subvendor=0x1af4 subdevice=0x1100 class=0x010601
+dev.ahci.0.%location=slot=31 function=2 dbsf=pci0:0:31:2 handle=\_SB_.PCI0.SFA_
+dev.ahci.0.%driver=ahci
+dev.ahci.0.%desc=Intel ICH9 AHCI SATA controller
+dev.ahci.%parent=
+dev.isa.0.%iommu=
+dev.isa.0.%parent=isab0
+dev.isa.0.%pnpinfo=
+dev.isa.0.%location=
+dev.isa.0.%driver=isa
+dev.isa.0.%desc=ISA bus
+dev.isa.%parent=
+dev.isab.0.%iommu=rid=0xf8
+dev.isab.0.%parent=pci0
+dev.isab.0.%pnpinfo=vendor=0x8086 device=0x2918 subvendor=0x1af4 subdevice=0x1100 class=0x060100
+dev.isab.0.%location=slot=31 function=0 dbsf=pci0:0:31:0 handle=\_SB_.PCI0.SF8_
+dev.isab.0.%driver=isab
+dev.isab.0.%desc=PCI-ISA bridge
+dev.isab.%parent=
+dev.xhci.0.%iommu=rid=0xf0
+dev.xhci.0.%parent=pci7
+dev.xhci.0.%pnpinfo=vendor=0x1b36 device=0x000d subvendor=0x1af4 subdevice=0x1100 class=0x0c0330
+dev.xhci.0.%location=slot=27 function=0 dbsf=pci0:7:27:0 handle=\_SB_.PCI0.SF0_.S10_.SD8_
+dev.xhci.0.%driver=xhci
+dev.xhci.0.%desc=XHCI (generic) USB 3.0 controller
+dev.xhci.%parent=
+dev.vtnet.0.txq0.rescheduled=0
+dev.vtnet.0.txq0.tso=135
+dev.vtnet.0.txq0.csum=41914
+dev.vtnet.0.txq0.omcasts=6
+dev.vtnet.0.txq0.obytes=7208777
+dev.vtnet.0.txq0.opackets=41995
+dev.vtnet.0.rxq0.rescheduled=0
+dev.vtnet.0.rxq0.host_lro=0
+dev.vtnet.0.rxq0.csum_failed=0
+dev.vtnet.0.rxq0.csum=17583
+dev.vtnet.0.rxq0.ierrors=0
+dev.vtnet.0.rxq0.iqdrops=0
+dev.vtnet.0.rxq0.ibytes=37948248
+dev.vtnet.0.rxq0.ipackets=85409
+dev.vtnet.0.tx_task_rescheduled=0
+dev.vtnet.0.tx_tso_offloaded=135
+dev.vtnet.0.tx_csum_offloaded=41917
+dev.vtnet.0.tx_defrag_failed=0
+dev.vtnet.0.tx_defragged=0
+dev.vtnet.0.tx_tso_without_csum=0
+dev.vtnet.0.tx_tso_not_tcp=0
+dev.vtnet.0.tx_csum_proto_mismatch=0
+dev.vtnet.0.tx_csum_unknown_ethtype=0
+dev.vtnet.0.rx_task_rescheduled=0
+dev.vtnet.0.rx_csum_offloaded=17583
+dev.vtnet.0.rx_csum_failed=0
+dev.vtnet.0.rx_csum_inaccessible_ipproto=0
+dev.vtnet.0.rx_csum_bad_offset=0
+dev.vtnet.0.rx_csum_bad_ipproto=0
+dev.vtnet.0.rx_csum_bad_ethtype=0
+dev.vtnet.0.rx_mergeable_failed=0
+dev.vtnet.0.rx_enq_replacement_failed=0
+dev.vtnet.0.rx_frame_too_large=0
+dev.vtnet.0.mbuf_alloc_failed=0
+dev.vtnet.0.flags=4cfe<MAC,CTRL_VQ,CTRL_RX,CTRL_MAC,VLAN_FILTER,TSO_ECN,MRG_RXBUFS,INDIRECT,EVENT_IDX,SW_LRO>
+dev.vtnet.0.features=3087b86f<CSUM,GUEST_CSUM,CTRL_GUEST_OFFLOADS,MTU,MAC,GSO,HOST_TSO4,HOST_TSO6,HOST_ECN,MRG_RXBUF,STATUS,CTRL_VQ,CTRL_RX,CTRL_MAC_ADDR>
+dev.vtnet.0.act_vq_pairs=1
+dev.vtnet.0.req_vq_pairs=1
+dev.vtnet.0.max_vq_pairs=1
+dev.vtnet.0.%iommu=
+dev.vtnet.0.%parent=virtio_pci2
+dev.vtnet.0.%pnpinfo=vendor=0x00001af4 device=0x1000 subvendor=0x1af4 device_type=0x00000001
+dev.vtnet.0.%location=
+dev.vtnet.0.%driver=vtnet
+dev.vtnet.0.%desc=VirtIO Networking Adapter
+dev.vtnet.%parent=
+dev.vtblk.0.writecache_mode=1
+dev.vtblk.0.%iommu=
+dev.vtblk.0.%parent=virtio_pci1
+dev.vtblk.0.%pnpinfo=vendor=0x00001af4 device=0x1001 subvendor=0x1af4 device_type=0x00000002
+dev.vtblk.0.%location=
+dev.vtblk.0.%driver=vtblk
+dev.vtblk.0.%desc=VirtIO Block Adapter
+dev.vtblk.%parent=
+dev.virtio_pci.2.negotiated_features=0x3087b86f <RingEventIdx,RingIndirectDesc,CtrlMacAddr,CtrlRxMode,CtrlVq,Status,MrgRxBuf,TxTSOECN,TxTSOv6,TxTSOv4,TxGSO,MAC,0x8,CtrlRxOffloads,RxChecksum,TxChecksum>
+dev.virtio_pci.2.host_features=0x79bfffef <RingEventIdx,RingIndirectDesc,AnyLayout,NotifyOnEmpty,CtrlMacAddr,GuestAnnounce,CtrlRxModeExtra,CtrlVLANFilter,CtrlRxMode,CtrlVq,Status,MrgRxBuf,TxUFO,TxTSOECN,TxTSOv6,TxTSOv4,RxUFO,RxLROECN,RxLROv6,RxLROv4,TxGSO,MAC,0x8,CtrlRxOffloads,RxChecksum,TxChecksum>
+dev.virtio_pci.2.nvqs=3
+dev.virtio_pci.2.%iommu=rid=0xf0
+dev.virtio_pci.2.%parent=pci6
+dev.virtio_pci.2.%pnpinfo=vendor=0x1af4 device=0x1000 subvendor=0x1af4 subdevice=0x0001 class=0x020000
+dev.virtio_pci.2.%location=slot=18 function=0 dbsf=pci0:6:18:0 handle=\_SB_.PCI0.SF0_.S08_.S90_
+dev.virtio_pci.2.%driver=virtio_pci
+dev.virtio_pci.2.%desc=VirtIO PCI (legacy) Network adapter
+dev.virtio_pci.1.negotiated_features=0x10002e54 <RingIndirectDesc,Discard,ConfigWCE,Topology,FlushCmd,BlockSize,DiskGeometry,MaxNumSegs>
+dev.virtio_pci.1.host_features=0x79007e54 <RingEventIdx,RingIndirectDesc,AnyLayout,NotifyOnEmpty,WriteZeros,Discard,Multiqueue,ConfigWCE,Topology,FlushCmd,BlockSize,DiskGeometry,MaxNumSegs>
+dev.virtio_pci.1.nvqs=1
+dev.virtio_pci.1.%iommu=rid=0xf0
+dev.virtio_pci.1.%parent=pci6
+dev.virtio_pci.1.%pnpinfo=vendor=0x1af4 device=0x1001 subvendor=0x1af4 subdevice=0x0002 class=0x010000
+dev.virtio_pci.1.%location=slot=10 function=0 dbsf=pci0:6:10:0 handle=\_SB_.PCI0.SF0_.S08_.S50_
+dev.virtio_pci.1.%driver=virtio_pci
+dev.virtio_pci.1.%desc=VirtIO PCI (legacy) Block adapter
+dev.virtio_pci.0.negotiated_features=0x2 <MultiplePorts>
+dev.virtio_pci.0.host_features=0x79000006 <RingEventIdx,RingIndirectDesc,AnyLayout,NotifyOnEmpty,EmergencyWrite,MultiplePorts>
+dev.virtio_pci.0.nvqs=64
+dev.virtio_pci.0.%iommu=rid=0xf0
+dev.virtio_pci.0.%parent=pci6
+dev.virtio_pci.0.%pnpinfo=vendor=0x1af4 device=0x1003 subvendor=0x1af4 subdevice=0x0003 class=0x078000
+dev.virtio_pci.0.%location=slot=8 function=0 dbsf=pci0:6:8:0 handle=\_SB_.PCI0.SF0_.S08_.S40_
+dev.virtio_pci.0.%driver=virtio_pci
+dev.virtio_pci.0.%desc=VirtIO PCI (legacy) Console adapter
+dev.virtio_pci.%parent=
+dev.hdac.0.polling=0
+dev.hdac.0.pindump=0
+dev.hdac.0.%iommu=rid=0xd8
+dev.hdac.0.%parent=pci0
+dev.hdac.0.%pnpinfo=vendor=0x8086 device=0x293e subvendor=0x1af4 subdevice=0x1100 class=0x040300
+dev.hdac.0.%location=slot=27 function=0 dbsf=pci0:0:27:0 handle=\_SB_.PCI0.SD8_
+dev.hdac.0.%driver=hdac
+dev.hdac.0.%desc=Intel 82801I HDA Controller
+dev.hdac.%parent=
+dev.ehci.1.%iommu=rid=0xef
+dev.ehci.1.%parent=pci0
+dev.ehci.1.%pnpinfo=vendor=0x8086 device=0x293a subvendor=0x1af4 subdevice=0x1100 class=0x0c0320
+dev.ehci.1.%location=slot=29 function=7 dbsf=pci0:0:29:7 handle=\_SB_.PCI0.SEF_
+dev.ehci.1.%driver=ehci
+dev.ehci.1.%desc=Intel 82801I (ICH9) USB 2.0 controller
+dev.ehci.0.%iommu=rid=0xd7
+dev.ehci.0.%parent=pci0
+dev.ehci.0.%pnpinfo=vendor=0x8086 device=0x293c subvendor=0x1af4 subdevice=0x1100 class=0x0c0320
+dev.ehci.0.%location=slot=26 function=7 dbsf=pci0:0:26:7 handle=\_SB_.PCI0.SD7_
+dev.ehci.0.%driver=ehci
+dev.ehci.0.%desc=Intel 82801I (ICH9) USB 2.0 controller
+dev.ehci.%parent=
+dev.usbus.8.%iommu=
+dev.usbus.8.%parent=xhci0
+dev.usbus.8.%pnpinfo=
+dev.usbus.8.%location=
+dev.usbus.8.%driver=usbus
+dev.usbus.8.%desc=
+dev.usbus.7.%iommu=
+dev.usbus.7.%parent=ehci1
+dev.usbus.7.%pnpinfo=
+dev.usbus.7.%location=
+dev.usbus.7.%driver=usbus
+dev.usbus.7.%desc=
+dev.usbus.6.%iommu=
+dev.usbus.6.%parent=uhci5
+dev.usbus.6.%pnpinfo=
+dev.usbus.6.%location=
+dev.usbus.6.%driver=usbus
+dev.usbus.6.%desc=
+dev.usbus.5.%iommu=
+dev.usbus.5.%parent=uhci4
+dev.usbus.5.%pnpinfo=
+dev.usbus.5.%location=
+dev.usbus.5.%driver=usbus
+dev.usbus.5.%desc=
+dev.usbus.4.%iommu=
+dev.usbus.4.%parent=uhci3
+dev.usbus.4.%pnpinfo=
+dev.usbus.4.%location=
+dev.usbus.4.%driver=usbus
+dev.usbus.4.%desc=
+dev.usbus.3.%iommu=
+dev.usbus.3.%parent=ehci0
+dev.usbus.3.%pnpinfo=
+dev.usbus.3.%location=
+dev.usbus.3.%driver=usbus
+dev.usbus.3.%desc=
+dev.usbus.2.%iommu=
+dev.usbus.2.%parent=uhci2
+dev.usbus.2.%pnpinfo=
+dev.usbus.2.%location=
+dev.usbus.2.%driver=usbus
+dev.usbus.2.%desc=
+dev.usbus.1.%iommu=
+dev.usbus.1.%parent=uhci1
+dev.usbus.1.%pnpinfo=
+dev.usbus.1.%location=
+dev.usbus.1.%driver=usbus
+dev.usbus.1.%desc=
+dev.usbus.0.%iommu=
+dev.usbus.0.%parent=uhci0
+dev.usbus.0.%pnpinfo=
+dev.usbus.0.%location=
+dev.usbus.0.%driver=usbus
+dev.usbus.0.%desc=
+dev.usbus.%parent=
+dev.uhci.5.%iommu=rid=0xea
+dev.uhci.5.%parent=pci0
+dev.uhci.5.%pnpinfo=vendor=0x8086 device=0x2936 subvendor=0x1af4 subdevice=0x1100 class=0x0c0300
+dev.uhci.5.%location=slot=29 function=2 dbsf=pci0:0:29:2 handle=\_SB_.PCI0.SEA_
+dev.uhci.5.%driver=uhci
+dev.uhci.5.%desc=Intel 82801I (ICH9) USB controller
+dev.uhci.4.%iommu=rid=0xe9
+dev.uhci.4.%parent=pci0
+dev.uhci.4.%pnpinfo=vendor=0x8086 device=0x2935 subvendor=0x1af4 subdevice=0x1100 class=0x0c0300
+dev.uhci.4.%location=slot=29 function=1 dbsf=pci0:0:29:1 handle=\_SB_.PCI0.SE9_
+dev.uhci.4.%driver=uhci
+dev.uhci.4.%desc=Intel 82801I (ICH9) USB controller
+dev.uhci.3.%iommu=rid=0xe8
+dev.uhci.3.%parent=pci0
+dev.uhci.3.%pnpinfo=vendor=0x8086 device=0x2934 subvendor=0x1af4 subdevice=0x1100 class=0x0c0300
+dev.uhci.3.%location=slot=29 function=0 dbsf=pci0:0:29:0 handle=\_SB_.PCI0.SE8_
+dev.uhci.3.%driver=uhci
+dev.uhci.3.%desc=Intel 82801I (ICH9) USB controller
+dev.uhci.2.%iommu=rid=0xd2
+dev.uhci.2.%parent=pci0
+dev.uhci.2.%pnpinfo=vendor=0x8086 device=0x2939 subvendor=0x1af4 subdevice=0x1100 class=0x0c0300
+dev.uhci.2.%location=slot=26 function=2 dbsf=pci0:0:26:2 handle=\_SB_.PCI0.SD2_
+dev.uhci.2.%driver=uhci
+dev.uhci.2.%desc=Intel 82801I (ICH9) USB controller
+dev.uhci.1.%iommu=rid=0xd1
+dev.uhci.1.%parent=pci0
+dev.uhci.1.%pnpinfo=vendor=0x8086 device=0x2938 subvendor=0x1af4 subdevice=0x1100 class=0x0c0300
+dev.uhci.1.%location=slot=26 function=1 dbsf=pci0:0:26:1 handle=\_SB_.PCI0.SD1_
+dev.uhci.1.%driver=uhci
+dev.uhci.1.%desc=Intel 82801I (ICH9) USB controller
+dev.uhci.0.%iommu=rid=0xd0
+dev.uhci.0.%parent=pci0
+dev.uhci.0.%pnpinfo=vendor=0x8086 device=0x2937 subvendor=0x1af4 subdevice=0x1100 class=0x0c0300
+dev.uhci.0.%location=slot=26 function=0 dbsf=pci0:0:26:0 handle=\_SB_.PCI0.SD0_
+dev.uhci.0.%driver=uhci
+dev.uhci.0.%desc=Intel 82801I (ICH9) USB controller
+dev.uhci.%parent=
+dev.vgapci.0.%iommu=rid=0x8
+dev.vgapci.0.%parent=pci0
+dev.vgapci.0.%pnpinfo=vendor=0x1234 device=0x1111 subvendor=0x1af4 subdevice=0x1100 class=0x030000
+dev.vgapci.0.%location=slot=1 function=0 dbsf=pci0:0:1:0 handle=\_SB_.PCI0.S08_
+dev.vgapci.0.%driver=vgapci
+dev.vgapci.0.%desc=VGA-compatible display
+dev.vgapci.%parent=
+dev.hostb.0.%iommu=rid=0
+dev.hostb.0.%parent=pci0
+dev.hostb.0.%pnpinfo=vendor=0x8086 device=0x29c0 subvendor=0x1af4 subdevice=0x1100 class=0x060000
+dev.hostb.0.%location=slot=0 function=0 dbsf=pci0:0:0:0 handle=\_SB_.PCI0.S00_
+dev.hostb.0.%driver=hostb
+dev.hostb.0.%desc=Host to PCI bridge
+dev.hostb.%parent=
+dev.pci.9.%iommu=
+dev.pci.9.%parent=pcib9
+dev.pci.9.%pnpinfo=
+dev.pci.9.%location=
+dev.pci.9.%driver=pci
+dev.pci.9.%desc=ACPI PCI bus
+dev.pci.8.%iommu=
+dev.pci.8.%parent=pcib8
+dev.pci.8.%pnpinfo=
+dev.pci.8.%location=
+dev.pci.8.%driver=pci
+dev.pci.8.%desc=ACPI PCI bus
+dev.pci.7.%iommu=
+dev.pci.7.%parent=pcib7
+dev.pci.7.%pnpinfo=
+dev.pci.7.%location=
+dev.pci.7.%driver=pci
+dev.pci.7.%desc=ACPI PCI bus
+dev.pci.6.%iommu=
+dev.pci.6.%parent=pcib6
+dev.pci.6.%pnpinfo=
+dev.pci.6.%location=
+dev.pci.6.%driver=pci
+dev.pci.6.%desc=ACPI PCI bus
+dev.pci.5.%iommu=
+dev.pci.5.%parent=pcib5
+dev.pci.5.%pnpinfo=
+dev.pci.5.%location=
+dev.pci.5.%driver=pci
+dev.pci.5.%desc=ACPI PCI bus
+dev.pci.4.%iommu=
+dev.pci.4.%parent=pcib4
+dev.pci.4.%pnpinfo=
+dev.pci.4.%location=
+dev.pci.4.%driver=pci
+dev.pci.4.%desc=ACPI PCI bus
+dev.pci.3.%iommu=
+dev.pci.3.%parent=pcib3
+dev.pci.3.%pnpinfo=
+dev.pci.3.%location=
+dev.pci.3.%driver=pci
+dev.pci.3.%desc=ACPI PCI bus
+dev.pci.2.%iommu=
+dev.pci.2.%parent=pcib2
+dev.pci.2.%pnpinfo=
+dev.pci.2.%location=
+dev.pci.2.%driver=pci
+dev.pci.2.%desc=ACPI PCI bus
+dev.pci.1.%iommu=
+dev.pci.1.%parent=pcib1
+dev.pci.1.%pnpinfo=
+dev.pci.1.%location=
+dev.pci.1.%driver=pci
+dev.pci.1.%desc=ACPI PCI bus
+dev.pci.0.%iommu=
+dev.pci.0.%parent=pcib0
+dev.pci.0.%pnpinfo=
+dev.pci.0.%location=
+dev.pci.0.%driver=pci
+dev.pci.0.%desc=ACPI PCI bus
+dev.pci.%parent=
+dev.pcib.9.subbus=9
+dev.pcib.9.secbus=9
+dev.pcib.9.pribus=5
+dev.pcib.9.domain=0
+dev.pcib.9.%iommu=rid=0xf0
+dev.pcib.9.%parent=pci5
+dev.pcib.9.%pnpinfo=vendor=0x1b36 device=0x0001 subvendor=0x0000 subdevice=0x0000 class=0x060400
+dev.pcib.9.%location=slot=4 function=0 dbsf=pci0:5:4:0 handle=\_SB_.PCI0.SF0_.S20_
+dev.pcib.9.%driver=pcib
+dev.pcib.9.%desc=ACPI PCI-PCI bridge
+dev.pcib.8.subbus=8
+dev.pcib.8.secbus=8
+dev.pcib.8.pribus=5
+dev.pcib.8.domain=0
+dev.pcib.8.%iommu=rid=0xf0
+dev.pcib.8.%parent=pci5
+dev.pcib.8.%pnpinfo=vendor=0x1b36 device=0x0001 subvendor=0x0000 subdevice=0x0000 class=0x060400
+dev.pcib.8.%location=slot=3 function=0 dbsf=pci0:5:3:0 handle=\_SB_.PCI0.SF0_.S18_
+dev.pcib.8.%driver=pcib
+dev.pcib.8.%desc=ACPI PCI-PCI bridge
+dev.pcib.7.subbus=7
+dev.pcib.7.secbus=7
+dev.pcib.7.pribus=5
+dev.pcib.7.domain=0
+dev.pcib.7.%iommu=rid=0xf0
+dev.pcib.7.%parent=pci5
+dev.pcib.7.%pnpinfo=vendor=0x1b36 device=0x0001 subvendor=0x0000 subdevice=0x0000 class=0x060400
+dev.pcib.7.%location=slot=2 function=0 dbsf=pci0:5:2:0 handle=\_SB_.PCI0.SF0_.S10_
+dev.pcib.7.%driver=pcib
+dev.pcib.7.%desc=ACPI PCI-PCI bridge
+dev.pcib.6.subbus=6
+dev.pcib.6.secbus=6
+dev.pcib.6.pribus=5
+dev.pcib.6.domain=0
+dev.pcib.6.%iommu=rid=0xf0
+dev.pcib.6.%parent=pci5
+dev.pcib.6.%pnpinfo=vendor=0x1b36 device=0x0001 subvendor=0x0000 subdevice=0x0000 class=0x060400
+dev.pcib.6.%location=slot=1 function=0 dbsf=pci0:5:1:0 handle=\_SB_.PCI0.SF0_.S08_
+dev.pcib.6.%driver=pcib
+dev.pcib.6.%desc=ACPI PCI-PCI bridge
+dev.pcib.5.subbus=9
+dev.pcib.5.secbus=5
+dev.pcib.5.pribus=0
+dev.pcib.5.domain=0
+dev.pcib.5.%iommu=rid=0xf0
+dev.pcib.5.%parent=pci0
+dev.pcib.5.%pnpinfo=vendor=0x8086 device=0x244e subvendor=0x0000 subdevice=0x0000 class=0x060401
+dev.pcib.5.%location=slot=30 function=0 dbsf=pci0:0:30:0 handle=\_SB_.PCI0.SF0_
+dev.pcib.5.%driver=pcib
+dev.pcib.5.%desc=ACPI PCI-PCI bridge
+dev.pcib.4.subbus=4
+dev.pcib.4.secbus=4
+dev.pcib.4.pribus=0
+dev.pcib.4.domain=0
+dev.pcib.4.%iommu=rid=0xe3
+dev.pcib.4.%parent=pci0
+dev.pcib.4.%pnpinfo=vendor=0x1b36 device=0x000c subvendor=0x1b36 subdevice=0x0000 class=0x060400
+dev.pcib.4.%location=slot=28 function=3 dbsf=pci0:0:28:3 handle=\_SB_.PCI0.SE3_
+dev.pcib.4.%driver=pcib
+dev.pcib.4.%desc=ACPI PCI-PCI bridge
+dev.pcib.3.subbus=3
+dev.pcib.3.secbus=3
+dev.pcib.3.pribus=0
+dev.pcib.3.domain=0
+dev.pcib.3.%iommu=rid=0xe2
+dev.pcib.3.%parent=pci0
+dev.pcib.3.%pnpinfo=vendor=0x1b36 device=0x000c subvendor=0x1b36 subdevice=0x0000 class=0x060400
+dev.pcib.3.%location=slot=28 function=2 dbsf=pci0:0:28:2 handle=\_SB_.PCI0.SE2_
+dev.pcib.3.%driver=pcib
+dev.pcib.3.%desc=ACPI PCI-PCI bridge
+dev.pcib.2.subbus=2
+dev.pcib.2.secbus=2
+dev.pcib.2.pribus=0
+dev.pcib.2.domain=0
+dev.pcib.2.%iommu=rid=0xe1
+dev.pcib.2.%parent=pci0
+dev.pcib.2.%pnpinfo=vendor=0x1b36 device=0x000c subvendor=0x1b36 subdevice=0x0000 class=0x060400
+dev.pcib.2.%location=slot=28 function=1 dbsf=pci0:0:28:1 handle=\_SB_.PCI0.SE1_
+dev.pcib.2.%driver=pcib
+dev.pcib.2.%desc=ACPI PCI-PCI bridge
+dev.pcib.1.subbus=1
+dev.pcib.1.secbus=1
+dev.pcib.1.pribus=0
+dev.pcib.1.domain=0
+dev.pcib.1.%iommu=rid=0xe0
+dev.pcib.1.%parent=pci0
+dev.pcib.1.%pnpinfo=vendor=0x1b36 device=0x000c subvendor=0x1b36 subdevice=0x0000 class=0x060400
+dev.pcib.1.%location=slot=28 function=0 dbsf=pci0:0:28:0 handle=\_SB_.PCI0.SE0_
+dev.pcib.1.%driver=pcib
+dev.pcib.1.%desc=ACPI PCI-PCI bridge
+dev.pcib.0.%iommu=
+dev.pcib.0.%parent=acpi0
+dev.pcib.0.%pnpinfo=_HID=PNP0A08 _UID=0 _CID=PNP0A03
+dev.pcib.0.%location=handle=\_SB_.PCI0
+dev.pcib.0.%driver=pcib
+dev.pcib.0.%desc=ACPI Host-PCI bridge
+dev.pcib.%parent=
+dev.pci_link.15.%iommu=
+dev.pci_link.15.%parent=acpi0
+dev.pci_link.15.%pnpinfo=_HID=PNP0C0F _UID=23 _CID=none
+dev.pci_link.15.%location=handle=\_SB_.GSIH
+dev.pci_link.15.%driver=pci_link
+dev.pci_link.15.%desc=ACPI PCI Link GSIH
+dev.pci_link.14.%iommu=
+dev.pci_link.14.%parent=acpi0
+dev.pci_link.14.%pnpinfo=_HID=PNP0C0F _UID=22 _CID=none
+dev.pci_link.14.%location=handle=\_SB_.GSIG
+dev.pci_link.14.%driver=pci_link
+dev.pci_link.14.%desc=ACPI PCI Link GSIG
+dev.pci_link.13.%iommu=
+dev.pci_link.13.%parent=acpi0
+dev.pci_link.13.%pnpinfo=_HID=PNP0C0F _UID=21 _CID=none
+dev.pci_link.13.%location=handle=\_SB_.GSIF
+dev.pci_link.13.%driver=pci_link
+dev.pci_link.13.%desc=ACPI PCI Link GSIF
+dev.pci_link.12.%iommu=
+dev.pci_link.12.%parent=acpi0
+dev.pci_link.12.%pnpinfo=_HID=PNP0C0F _UID=20 _CID=none
+dev.pci_link.12.%location=handle=\_SB_.GSIE
+dev.pci_link.12.%driver=pci_link
+dev.pci_link.12.%desc=ACPI PCI Link GSIE
+dev.pci_link.11.%iommu=
+dev.pci_link.11.%parent=acpi0
+dev.pci_link.11.%pnpinfo=_HID=PNP0C0F _UID=19 _CID=none
+dev.pci_link.11.%location=handle=\_SB_.GSID
+dev.pci_link.11.%driver=pci_link
+dev.pci_link.11.%desc=ACPI PCI Link GSID
+dev.pci_link.10.%iommu=
+dev.pci_link.10.%parent=acpi0
+dev.pci_link.10.%pnpinfo=_HID=PNP0C0F _UID=18 _CID=none
+dev.pci_link.10.%location=handle=\_SB_.GSIC
+dev.pci_link.10.%driver=pci_link
+dev.pci_link.10.%desc=ACPI PCI Link GSIC
+dev.pci_link.9.%iommu=
+dev.pci_link.9.%parent=acpi0
+dev.pci_link.9.%pnpinfo=_HID=PNP0C0F _UID=17 _CID=none
+dev.pci_link.9.%location=handle=\_SB_.GSIB
+dev.pci_link.9.%driver=pci_link
+dev.pci_link.9.%desc=ACPI PCI Link GSIB
+dev.pci_link.8.%iommu=
+dev.pci_link.8.%parent=acpi0
+dev.pci_link.8.%pnpinfo=_HID=PNP0C0F _UID=16 _CID=none
+dev.pci_link.8.%location=handle=\_SB_.GSIA
+dev.pci_link.8.%driver=pci_link
+dev.pci_link.8.%desc=ACPI PCI Link GSIA
+dev.pci_link.7.%iommu=
+dev.pci_link.7.%parent=acpi0
+dev.pci_link.7.%pnpinfo=_HID=PNP0C0F _UID=7 _CID=none
+dev.pci_link.7.%location=handle=\_SB_.LNKH
+dev.pci_link.7.%driver=pci_link
+dev.pci_link.7.%desc=ACPI PCI Link LNKH
+dev.pci_link.6.%iommu=
+dev.pci_link.6.%parent=acpi0
+dev.pci_link.6.%pnpinfo=_HID=PNP0C0F _UID=6 _CID=none
+dev.pci_link.6.%location=handle=\_SB_.LNKG
+dev.pci_link.6.%driver=pci_link
+dev.pci_link.6.%desc=ACPI PCI Link LNKG
+dev.pci_link.5.%iommu=
+dev.pci_link.5.%parent=acpi0
+dev.pci_link.5.%pnpinfo=_HID=PNP0C0F _UID=5 _CID=none
+dev.pci_link.5.%location=handle=\_SB_.LNKF
+dev.pci_link.5.%driver=pci_link
+dev.pci_link.5.%desc=ACPI PCI Link LNKF
+dev.pci_link.4.%iommu=
+dev.pci_link.4.%parent=acpi0
+dev.pci_link.4.%pnpinfo=_HID=PNP0C0F _UID=4 _CID=none
+dev.pci_link.4.%location=handle=\_SB_.LNKE
+dev.pci_link.4.%driver=pci_link
+dev.pci_link.4.%desc=ACPI PCI Link LNKE
+dev.pci_link.3.%iommu=
+dev.pci_link.3.%parent=acpi0
+dev.pci_link.3.%pnpinfo=_HID=PNP0C0F _UID=3 _CID=none
+dev.pci_link.3.%location=handle=\_SB_.LNKD
+dev.pci_link.3.%driver=pci_link
+dev.pci_link.3.%desc=ACPI PCI Link LNKD
+dev.pci_link.2.%iommu=
+dev.pci_link.2.%parent=acpi0
+dev.pci_link.2.%pnpinfo=_HID=PNP0C0F _UID=2 _CID=none
+dev.pci_link.2.%location=handle=\_SB_.LNKC
+dev.pci_link.2.%driver=pci_link
+dev.pci_link.2.%desc=ACPI PCI Link LNKC
+dev.pci_link.1.%iommu=
+dev.pci_link.1.%parent=acpi0
+dev.pci_link.1.%pnpinfo=_HID=PNP0C0F _UID=1 _CID=none
+dev.pci_link.1.%location=handle=\_SB_.LNKB
+dev.pci_link.1.%driver=pci_link
+dev.pci_link.1.%desc=ACPI PCI Link LNKB
+dev.pci_link.0.%iommu=
+dev.pci_link.0.%parent=acpi0
+dev.pci_link.0.%pnpinfo=_HID=PNP0C0F _UID=0 _CID=none
+dev.pci_link.0.%location=handle=\_SB_.LNKA
+dev.pci_link.0.%driver=pci_link
+dev.pci_link.0.%desc=ACPI PCI Link LNKA
+dev.pci_link.%parent=
+dev.acpi_timer.0.%iommu=
+dev.acpi_timer.0.%parent=acpi0
+dev.acpi_timer.0.%pnpinfo=unknown
+dev.acpi_timer.0.%location=
+dev.acpi_timer.0.%driver=acpi_timer
+dev.acpi_timer.0.%desc=24-bit timer at 3.579545MHz
+dev.acpi_timer.%parent=
+dev.atrtc.0.%iommu=
+dev.atrtc.0.%parent=acpi0
+dev.atrtc.0.%pnpinfo=_HID=PNP0B00 _UID=0 _CID=none
+dev.atrtc.0.%location=handle=\_SB_.PCI0.SF8_.RTC_
+dev.atrtc.0.%driver=atrtc
+dev.atrtc.0.%desc=AT realtime clock
+dev.atrtc.%parent=
+dev.cpu.3.cx_method=C1/hlt
+dev.cpu.3.cx_usage_counters=503522
+dev.cpu.3.cx_usage=100.00% last 27us
+dev.cpu.3.cx_lowest=C1
+dev.cpu.3.cx_supported=C1/1/0
+dev.cpu.3.%iommu=
+dev.cpu.3.%parent=acpi0
+dev.cpu.3.%pnpinfo=_HID=none _UID=0 _CID=none
+dev.cpu.3.%location=handle=\_SB_.CPUS.C003
+dev.cpu.3.%driver=cpu
+dev.cpu.3.%desc=ACPI CPU
+dev.cpu.2.cx_method=C1/hlt
+dev.cpu.2.cx_usage_counters=527877
+dev.cpu.2.cx_usage=100.00% last 4092us
+dev.cpu.2.cx_lowest=C1
+dev.cpu.2.cx_supported=C1/1/0
+dev.cpu.2.%iommu=
+dev.cpu.2.%parent=acpi0
+dev.cpu.2.%pnpinfo=_HID=none _UID=0 _CID=none
+dev.cpu.2.%location=handle=\_SB_.CPUS.C002
+dev.cpu.2.%driver=cpu
+dev.cpu.2.%desc=ACPI CPU
+dev.cpu.1.cx_method=C1/hlt
+dev.cpu.1.cx_usage_counters=501138
+dev.cpu.1.cx_usage=100.00% last 25991us
+dev.cpu.1.cx_lowest=C1
+dev.cpu.1.cx_supported=C1/1/0
+dev.cpu.1.%iommu=
+dev.cpu.1.%parent=acpi0
+dev.cpu.1.%pnpinfo=_HID=none _UID=0 _CID=none
+dev.cpu.1.%location=handle=\_SB_.CPUS.C001
+dev.cpu.1.%driver=cpu
+dev.cpu.1.%desc=ACPI CPU
+dev.cpu.0.cx_method=C1/hlt
+dev.cpu.0.cx_usage_counters=1260378
+dev.cpu.0.cx_usage=100.00% last 20062us
+dev.cpu.0.cx_lowest=C1
+dev.cpu.0.cx_supported=C1/1/0
+dev.cpu.0.%iommu=
+dev.cpu.0.%parent=acpi0
+dev.cpu.0.%pnpinfo=_HID=none _UID=0 _CID=none
+dev.cpu.0.%location=handle=\_SB_.CPUS.C000
+dev.cpu.0.%driver=cpu
+dev.cpu.0.%desc=ACPI CPU
+dev.cpu.%parent=
+dev.acpi_sysresource.0.%iommu=
+dev.acpi_sysresource.0.%parent=acpi0
+dev.acpi_sysresource.0.%pnpinfo=_HID=PNP0C01 _UID=0 _CID=none
+dev.acpi_sysresource.0.%location=handle=\_SB_.DRAC
+dev.acpi_sysresource.0.%driver=acpi_sysresource
+dev.acpi_sysresource.0.%desc=System Resource
+dev.acpi_sysresource.%parent=
+dev.acpi.0.%iommu=
+dev.acpi.0.%parent=nexus0
+dev.acpi.0.%pnpinfo=
+dev.acpi.0.%location=
+dev.acpi.0.%driver=acpi
+dev.acpi.0.%desc=BOCHS BXPC
+dev.acpi.%parent=
+dev.aesni.0.%iommu=
+dev.aesni.0.%parent=nexus0
+dev.aesni.0.%pnpinfo=
+dev.aesni.0.%location=
+dev.aesni.0.%driver=aesni
+dev.aesni.0.%desc=AES-CBC,AES-CCM,AES-GCM,AES-ICM,AES-XTS,SHA1,SHA256
+dev.aesni.%parent=
+dev.cryptosoft.0.%iommu=
+dev.cryptosoft.0.%parent=nexus0
+dev.cryptosoft.0.%pnpinfo=
+dev.cryptosoft.0.%location=
+dev.cryptosoft.0.%driver=cryptosoft
+dev.cryptosoft.0.%desc=software crypto
+dev.cryptosoft.%parent=
+dev.smbios.0.%iommu=
+dev.smbios.0.%parent=nexus0
+dev.smbios.0.%pnpinfo=
+dev.smbios.0.%location=
+dev.smbios.0.%driver=smbios
+dev.smbios.0.%desc=System Management BIOS
+dev.smbios.%parent=
+dev.ram.0.%iommu=
+dev.ram.0.%parent=nexus0
+dev.ram.0.%pnpinfo=
+dev.ram.0.%location=
+dev.ram.0.%driver=ram
+dev.ram.0.%desc=System RAM
+dev.ram.%parent=
+dev.kvmclock.0.tsc_freq=806400000
+dev.kvmclock.0.vdso_enable_without_rdtscp=0
+dev.kvmclock.0.vdso_force_unstable=0
+dev.kvmclock.0.%iommu=
+dev.kvmclock.0.%parent=nexus0
+dev.kvmclock.0.%pnpinfo=
+dev.kvmclock.0.%location=
+dev.kvmclock.0.%driver=kvmclock
+dev.kvmclock.0.%desc=KVM paravirtual clock
+dev.kvmclock.%parent=
+dev.efirtc.0.%iommu=
+dev.efirtc.0.%parent=nexus0
+dev.efirtc.0.%pnpinfo=
+dev.efirtc.0.%location=
+dev.efirtc.0.%driver=efirtc
+dev.efirtc.0.%desc=EFI Realtime Clock
+dev.efirtc.%parent=
+dev.nexus.0.%iommu=
+dev.nexus.0.%parent=root0
+dev.nexus.0.%pnpinfo=
+dev.nexus.0.%location=
+dev.nexus.0.%driver=nexus
+dev.nexus.0.%desc=
+dev.nexus.%parent=
+dev.xen.xsd_kva=0
+dev.xen.xsd_port=0
+dev.xen.balloon.high_mem=0
+dev.xen.balloon.low_mem=0
+dev.xen.balloon.hard_limit=0
+dev.xen.balloon.driver_pages=0
+dev.xen.balloon.target=0
+dev.xen.balloon.current=0
+dev.netmap.iflib_rx_miss_bufs=0
+dev.netmap.iflib_rx_miss=0
+dev.netmap.iflib_crcstrip=1
+dev.netmap.max_bridges=8
+dev.netmap.bridge_batch=1024
+dev.netmap.default_pipes=0
+dev.netmap.port_numa_affinity=0
+dev.netmap.priv_buf_num=4098
+dev.netmap.priv_buf_size=2048
+dev.netmap.buf_curr_num=0
+dev.netmap.buf_num=163840
+dev.netmap.buf_curr_size=0
+dev.netmap.buf_size=2048
+dev.netmap.priv_ring_num=4
+dev.netmap.priv_ring_size=20480
+dev.netmap.ring_curr_num=0
+dev.netmap.ring_num=200
+dev.netmap.ring_curr_size=0
+dev.netmap.ring_size=36864
+dev.netmap.priv_if_num=2
+dev.netmap.priv_if_size=1024
+dev.netmap.if_curr_num=0
+dev.netmap.if_num=100
+dev.netmap.if_curr_size=0
+dev.netmap.if_size=1024
+dev.netmap.ptnet_vnet_hdr=1
+dev.netmap.generic_rings=1
+dev.netmap.generic_ringsize=1024
+dev.netmap.generic_mit=100000
+dev.netmap.generic_hwcsum=0
+dev.netmap.admode=0
+dev.netmap.fwd=0
+dev.netmap.txsync_retry=2
+dev.netmap.no_pendintr=1
+dev.netmap.no_timestamp=0
+dev.netmap.verbose=0

--- a/tests/data/freebsd/usbconfig_dump_device_desc.txt
+++ b/tests/data/freebsd/usbconfig_dump_device_desc.txt
@@ -1,0 +1,255 @@
+ugen2.1: <UHCI root HUB Intel> at usbus2, cfg=0 md=HOST spd=FULL (12Mbps) pwr=SAVE (0mA)
+
+  bLength = 0x0012 
+  bDescriptorType = 0x0001 
+  bcdUSB = 0x0100 
+  bDeviceClass = 0x0009  <HUB>
+  bDeviceSubClass = 0x0000 
+  bDeviceProtocol = 0x0000 
+  bMaxPacketSize0 = 0x0040 
+  idVendor = 0x0000 
+  idProduct = 0x0000 
+  bcdDevice = 0x0100 
+  iManufacturer = 0x0001  <Intel>
+  iProduct = 0x0002  <UHCI root HUB>
+  iSerialNumber = 0x0000  <no string>
+  bNumConfigurations = 0x0001 
+
+ugen4.1: <UHCI root HUB Intel> at usbus4, cfg=0 md=HOST spd=FULL (12Mbps) pwr=SAVE (0mA)
+
+  bLength = 0x0012 
+  bDescriptorType = 0x0001 
+  bcdUSB = 0x0100 
+  bDeviceClass = 0x0009  <HUB>
+  bDeviceSubClass = 0x0000 
+  bDeviceProtocol = 0x0000 
+  bMaxPacketSize0 = 0x0040 
+  idVendor = 0x0000 
+  idProduct = 0x0000 
+  bcdDevice = 0x0100 
+  iManufacturer = 0x0001  <Intel>
+  iProduct = 0x0002  <UHCI root HUB>
+  iSerialNumber = 0x0000  <no string>
+  bNumConfigurations = 0x0001 
+
+ugen6.1: <UHCI root HUB Intel> at usbus6, cfg=0 md=HOST spd=FULL (12Mbps) pwr=SAVE (0mA)
+
+  bLength = 0x0012 
+  bDescriptorType = 0x0001 
+  bcdUSB = 0x0100 
+  bDeviceClass = 0x0009  <HUB>
+  bDeviceSubClass = 0x0000 
+  bDeviceProtocol = 0x0000 
+  bMaxPacketSize0 = 0x0040 
+  idVendor = 0x0000 
+  idProduct = 0x0000 
+  bcdDevice = 0x0100 
+  iManufacturer = 0x0001  <Intel>
+  iProduct = 0x0002  <UHCI root HUB>
+  iSerialNumber = 0x0000  <no string>
+  bNumConfigurations = 0x0001 
+
+ugen1.1: <UHCI root HUB Intel> at usbus1, cfg=0 md=HOST spd=FULL (12Mbps) pwr=SAVE (0mA)
+
+  bLength = 0x0012 
+  bDescriptorType = 0x0001 
+  bcdUSB = 0x0100 
+  bDeviceClass = 0x0009  <HUB>
+  bDeviceSubClass = 0x0000 
+  bDeviceProtocol = 0x0000 
+  bMaxPacketSize0 = 0x0040 
+  idVendor = 0x0000 
+  idProduct = 0x0000 
+  bcdDevice = 0x0100 
+  iManufacturer = 0x0001  <Intel>
+  iProduct = 0x0002  <UHCI root HUB>
+  iSerialNumber = 0x0000  <no string>
+  bNumConfigurations = 0x0001 
+
+ugen8.1: <XHCI root HUB (0x1b36)> at usbus8, cfg=0 md=HOST spd=SUPER (5.0Gbps) pwr=SAVE (0mA)
+
+  bLength = 0x0012 
+  bDescriptorType = 0x0001 
+  bcdUSB = 0x0300 
+  bDeviceClass = 0x0009  <HUB>
+  bDeviceSubClass = 0x0000 
+  bDeviceProtocol = 0x0003 
+  bMaxPacketSize0 = 0x0009 
+  idVendor = 0x0000 
+  idProduct = 0x0000 
+  bcdDevice = 0x0100 
+  iManufacturer = 0x0001  <(0x1b36)>
+  iProduct = 0x0002  <XHCI root HUB>
+  iSerialNumber = 0x0000  <no string>
+  bNumConfigurations = 0x0001 
+
+ugen0.1: <UHCI root HUB Intel> at usbus0, cfg=0 md=HOST spd=FULL (12Mbps) pwr=SAVE (0mA)
+
+  bLength = 0x0012 
+  bDescriptorType = 0x0001 
+  bcdUSB = 0x0100 
+  bDeviceClass = 0x0009  <HUB>
+  bDeviceSubClass = 0x0000 
+  bDeviceProtocol = 0x0000 
+  bMaxPacketSize0 = 0x0040 
+  idVendor = 0x0000 
+  idProduct = 0x0000 
+  bcdDevice = 0x0100 
+  iManufacturer = 0x0001  <Intel>
+  iProduct = 0x0002  <UHCI root HUB>
+  iSerialNumber = 0x0000  <no string>
+  bNumConfigurations = 0x0001 
+
+ugen5.1: <UHCI root HUB Intel> at usbus5, cfg=0 md=HOST spd=FULL (12Mbps) pwr=SAVE (0mA)
+
+  bLength = 0x0012 
+  bDescriptorType = 0x0001 
+  bcdUSB = 0x0100 
+  bDeviceClass = 0x0009  <HUB>
+  bDeviceSubClass = 0x0000 
+  bDeviceProtocol = 0x0000 
+  bMaxPacketSize0 = 0x0040 
+  idVendor = 0x0000 
+  idProduct = 0x0000 
+  bcdDevice = 0x0100 
+  iManufacturer = 0x0001  <Intel>
+  iProduct = 0x0002  <UHCI root HUB>
+  iSerialNumber = 0x0000  <no string>
+  bNumConfigurations = 0x0001 
+
+ugen7.1: <EHCI root HUB Intel> at usbus7, cfg=0 md=HOST spd=HIGH (480Mbps) pwr=SAVE (0mA)
+
+  bLength = 0x0012 
+  bDescriptorType = 0x0001 
+  bcdUSB = 0x0200 
+  bDeviceClass = 0x0009  <HUB>
+  bDeviceSubClass = 0x0000 
+  bDeviceProtocol = 0x0001 
+  bMaxPacketSize0 = 0x0040 
+  idVendor = 0x0000 
+  idProduct = 0x0000 
+  bcdDevice = 0x0100 
+  iManufacturer = 0x0001  <Intel>
+  iProduct = 0x0002  <EHCI root HUB>
+  iSerialNumber = 0x0000  <no string>
+  bNumConfigurations = 0x0001 
+
+ugen3.1: <EHCI root HUB Intel> at usbus3, cfg=0 md=HOST spd=HIGH (480Mbps) pwr=SAVE (0mA)
+
+  bLength = 0x0012 
+  bDescriptorType = 0x0001 
+  bcdUSB = 0x0200 
+  bDeviceClass = 0x0009  <HUB>
+  bDeviceSubClass = 0x0000 
+  bDeviceProtocol = 0x0001 
+  bMaxPacketSize0 = 0x0040 
+  idVendor = 0x0000 
+  idProduct = 0x0000 
+  bcdDevice = 0x0100 
+  iManufacturer = 0x0001  <Intel>
+  iProduct = 0x0002  <EHCI root HUB>
+  iSerialNumber = 0x0000  <no string>
+  bNumConfigurations = 0x0001 
+
+ugen8.2: <FT232 Serial (UART) IC Future Technology Devices International, Ltd> at usbus8, cfg=0 md=HOST spd=FULL (12Mbps) pwr=ON (90mA)
+
+  bLength = 0x0012 
+  bDescriptorType = 0x0001 
+  bcdUSB = 0x0200 
+  bDeviceClass = 0x0000  <Probed by interface class>
+  bDeviceSubClass = 0x0000 
+  bDeviceProtocol = 0x0000 
+  bMaxPacketSize0 = 0x0008 
+  idVendor = 0x0403 
+  idProduct = 0x6001 
+  bcdDevice = 0x0600 
+  iManufacturer = 0x0001  <FTDI>
+  iProduct = 0x0002  <FT232R USB UART>
+  iSerialNumber = 0x0003  <A5069RR4>
+  bNumConfigurations = 0x0001 
+
+ugen8.3: <FT232 Serial (UART) IC Future Technology Devices International, Ltd> at usbus8, cfg=0 md=HOST spd=FULL (12Mbps) pwr=ON (90mA)
+
+  bLength = 0x0012 
+  bDescriptorType = 0x0001 
+  bcdUSB = 0x0200 
+  bDeviceClass = 0x0000  <Probed by interface class>
+  bDeviceSubClass = 0x0000 
+  bDeviceProtocol = 0x0000 
+  bMaxPacketSize0 = 0x0008 
+  idVendor = 0x0403 
+  idProduct = 0x6001 
+  bcdDevice = 0x0600 
+  iManufacturer = 0x0001  <FTDI>
+  iProduct = 0x0002  <FT232R USB UART>
+  iSerialNumber = 0x0003  <A5069RR4>
+  bNumConfigurations = 0x0001 
+
+ugen7.2: <QEMU Tablet Adomax Technology Co., Ltd> at usbus7, cfg=0 md=HOST spd=HIGH (480Mbps) pwr=ON (100mA)
+
+  bLength = 0x0012 
+  bDescriptorType = 0x0001 
+  bcdUSB = 0x0200 
+  bDeviceClass = 0x0000  <Probed by interface class>
+  bDeviceSubClass = 0x0000 
+  bDeviceProtocol = 0x0000 
+  bMaxPacketSize0 = 0x0040 
+  idVendor = 0x0627 
+  idProduct = 0x0001 
+  bcdDevice = 0x0000 
+  iManufacturer = 0x0001  <QEMU>
+  iProduct = 0x0003  <QEMU USB Tablet>
+  iSerialNumber = 0x000a  <28754-0000:00:1d.7-1>
+  bNumConfigurations = 0x0001 
+
+ugen8.4: <ZBT-2 Nabu Casa> at usbus8, cfg=0 md=HOST spd=FULL (12Mbps) pwr=ON (100mA)
+
+  bLength = 0x0012 
+  bDescriptorType = 0x0001 
+  bcdUSB = 0x0200 
+  bDeviceClass = 0x00ef  <Miscellaneous device>
+  bDeviceSubClass = 0x0002 
+  bDeviceProtocol = 0x0001 
+  bMaxPacketSize0 = 0x0040 
+  idVendor = 0x303a 
+  idProduct = 0x4001 
+  bcdDevice = 0x0101 
+  iManufacturer = 0x0001  <Nabu Casa>
+  iProduct = 0x0002  <ZBT-2>
+  iSerialNumber = 0x0003  <80B54EEFAE18>
+  bNumConfigurations = 0x0001 
+
+ugen8.5: <CP210x UART Bridge Silicon Labs> at usbus8, cfg=0 md=HOST spd=FULL (12Mbps) pwr=ON (100mA)
+
+  bLength = 0x0012 
+  bDescriptorType = 0x0001 
+  bcdUSB = 0x0110 
+  bDeviceClass = 0x0000  <Probed by interface class>
+  bDeviceSubClass = 0x0000 
+  bDeviceProtocol = 0x0000 
+  bMaxPacketSize0 = 0x0040 
+  idVendor = 0x10c4 
+  idProduct = 0xea60 
+  bcdDevice = 0x0100 
+  iManufacturer = 0x0001  <Silicon Labs>
+  iProduct = 0x0002  <CP2102 USB to UART Bridge Controller>
+  iSerialNumber = 0x0003  <ec4903cb>
+  bNumConfigurations = 0x0001 
+
+ugen8.6: <FT232 Serial (UART) IC Future Technology Devices International, Ltd> at usbus8, cfg=0 md=HOST spd=FULL (12Mbps) pwr=ON (90mA)
+
+  bLength = 0x0012 
+  bDescriptorType = 0x0001 
+  bcdUSB = 0x0200 
+  bDeviceClass = 0x0000  <Probed by interface class>
+  bDeviceSubClass = 0x0000 
+  bDeviceProtocol = 0x0000 
+  bMaxPacketSize0 = 0x0008 
+  idVendor = 0x0403 
+  idProduct = 0x6001 
+  bcdDevice = 0x0600 
+  iManufacturer = 0x0001  <FTDI>
+  iProduct = 0x0002  <FT232R USB UART>
+  iSerialNumber = 0x0003  <rutabaga>
+  bNumConfigurations = 0x0001 
+

--- a/tests/test_async_transports.py
+++ b/tests/test_async_transports.py
@@ -564,6 +564,10 @@ async def test_async_resume_reading_when_not_paused(serial_pair: SerialPair) -> 
 
 
 @pytest.mark.skipif(not SOCAT_BINARY, reason="socat binary is missing")
+@pytest.mark.xfail(
+    sys.platform.startswith("freebsd"),
+    reason="FreeBSD PTYs do not signal peer close",
+)
 async def test_async_peer_close_triggers_connection_lost() -> None:
     """Test that killing one socat process triggers connection_lost on the other."""
     async with async_create_bridged_socat_pair() as pair:
@@ -625,6 +629,8 @@ async def test_async_get_modem_pins(serial_pair: SerialPair) -> None:
 
 async def test_async_set_modem_pins_api(serial_pair: SerialPair) -> None:
     """Test modem pin writes are accepted on all backends."""
+    if sys.platform.startswith("freebsd") and serial_pair.backend == "socat":
+        pytest.xfail("FreeBSD PTYs do not track modem pin state")
 
     async with async_create_reader_writer(serial_pair.left, baudrate=115200) as (
         _,

--- a/tests/test_async_transports.py
+++ b/tests/test_async_transports.py
@@ -630,7 +630,7 @@ async def test_async_get_modem_pins(serial_pair: SerialPair) -> None:
 async def test_async_set_modem_pins_api(serial_pair: SerialPair) -> None:
     """Test modem pin writes are accepted on all backends."""
     if serial_pair.backend == "socat" and sys.platform.startswith("freebsd"):
-        pytest.skip("FreeBSD PTYs do not track modem pin state")
+        pytest.xfail("FreeBSD socat sets all pins to LOW")
 
     async with async_create_reader_writer(serial_pair.left, baudrate=115200) as (
         _,

--- a/tests/test_async_transports.py
+++ b/tests/test_async_transports.py
@@ -629,8 +629,8 @@ async def test_async_get_modem_pins(serial_pair: SerialPair) -> None:
 
 async def test_async_set_modem_pins_api(serial_pair: SerialPair) -> None:
     """Test modem pin writes are accepted on all backends."""
-    if sys.platform.startswith("freebsd") and serial_pair.backend == "socat":
-        pytest.xfail("FreeBSD PTYs do not track modem pin state")
+    if serial_pair.backend == "socat" and sys.platform.startswith("freebsd"):
+        pytest.skip("FreeBSD PTYs do not track modem pin state")
 
     async with async_create_reader_writer(serial_pair.left, baudrate=115200) as (
         _,

--- a/tests/test_list_serial_ports_freebsd.py
+++ b/tests/test_list_serial_ports_freebsd.py
@@ -1,0 +1,131 @@
+"""Tests for FreeBSD serial port listing with mocked command output."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from serialx.common import SerialPortInfo
+from serialx.platforms.serial_freebsd import freebsd_list_serial_ports
+
+DATA_DIR = Path(__file__).parent / "data" / "freebsd"
+SYSCTL_OUTPUT = (DATA_DIR / "sysctl_dev.txt").read_text()
+USBCONFIG_OUTPUT = (DATA_DIR / "usbconfig_dump_device_desc.txt").read_text()
+
+
+def test_freebsd_list_serial_ports() -> None:
+    """Test listing all serial ports with captured FreeBSD command output."""
+
+    def _mock_subprocess_run(args, **kwargs):
+        class Result:
+            def __init__(self, stdout):
+                self.stdout = stdout
+                self.returncode = 0
+
+        if args[:3] == ["sysctl", "-e", "dev"]:
+            return Result(SYSCTL_OUTPUT)
+
+        if args[:2] == ["usbconfig", "dump_device_desc"]:
+            return Result(USBCONFIG_OUTPUT)
+
+        raise ValueError(f"Unexpected command: {args}")
+
+    with patch("subprocess.run", side_effect=_mock_subprocess_run):
+        ports = freebsd_list_serial_ports()
+
+    assert len(ports) == 5
+
+    ports_by_device = {str(p.device): p for p in ports}
+
+    # /dev/cuaU0: Nabu Casa ZBT-2 (CDC ACM via umodem)
+    assert ports_by_device["/dev/cuaU0"] == SerialPortInfo(
+        device=Path("/dev/cuaU0"),
+        resolved_device=Path("/dev/cuaU0"),
+        vid=0x303A,
+        pid=0x4001,
+        serial_number="80B54EEFAE18",
+        manufacturer="Nabu Casa",
+        product="ZBT-2",
+        bcd_device=0x0101,
+        interface_description=None,
+        interface_num=0,
+    )
+
+    # /dev/cuaU1: FTDI FT232R (ugen8.2)
+    assert ports_by_device["/dev/cuaU1"] == SerialPortInfo(
+        device=Path("/dev/cuaU1"),
+        resolved_device=Path("/dev/cuaU1"),
+        vid=0x0403,
+        pid=0x6001,
+        serial_number="A5069RR4",
+        manufacturer="FTDI",
+        product="FT232R USB UART",
+        bcd_device=0x0600,
+        interface_description=None,
+        interface_num=0,
+    )
+
+    # /dev/cuaU2: FTDI FT232R (ugen8.3)
+    assert ports_by_device["/dev/cuaU2"] == SerialPortInfo(
+        device=Path("/dev/cuaU2"),
+        resolved_device=Path("/dev/cuaU2"),
+        vid=0x0403,
+        pid=0x6001,
+        serial_number="A5069RR4",
+        manufacturer="FTDI",
+        product="FT232R USB UART",
+        bcd_device=0x0600,
+        interface_description=None,
+        interface_num=0,
+    )
+
+    # /dev/cuaU3: Silicon Labs CP2102 (ugen8.5)
+    assert ports_by_device["/dev/cuaU3"] == SerialPortInfo(
+        device=Path("/dev/cuaU3"),
+        resolved_device=Path("/dev/cuaU3"),
+        vid=0x10C4,
+        pid=0xEA60,
+        serial_number="ec4903cb",
+        manufacturer="Silicon Labs",
+        product="CP2102 USB to UART Bridge Controller",
+        bcd_device=0x0100,
+        interface_description=None,
+        interface_num=0,
+    )
+
+    # /dev/cuaU4: FTDI FT232R with custom serial (ugen8.6)
+    assert ports_by_device["/dev/cuaU4"] == SerialPortInfo(
+        device=Path("/dev/cuaU4"),
+        resolved_device=Path("/dev/cuaU4"),
+        vid=0x0403,
+        pid=0x6001,
+        serial_number="rutabaga",
+        manufacturer="FTDI",
+        product="FT232R USB UART",
+        bcd_device=0x0600,
+        interface_description=None,
+        interface_num=0,
+    )
+
+
+def test_freebsd_list_serial_ports_no_devices() -> None:
+    """Test listing when no serial devices are present."""
+
+    def mock_run(args, **kwargs):
+        class Result:
+            def __init__(self, stdout):
+                self.stdout = stdout
+                self.returncode = 0
+
+        if args[:3] == ["sysctl", "-e", "dev"]:
+            return Result("dev.uhub.0.%parent=xhci0\n")
+
+        if args[:2] == ["usbconfig", "dump_device_desc"]:
+            return Result("")
+
+        raise ValueError(f"Unexpected command: {args}")
+
+    with patch("subprocess.run", side_effect=mock_run):
+        ports = freebsd_list_serial_ports()
+
+    assert ports == []

--- a/tests/test_list_serial_ports_freebsd.py
+++ b/tests/test_list_serial_ports_freebsd.py
@@ -2,6 +2,14 @@
 
 from __future__ import annotations
 
+import pytest
+
+try:
+    import termios  # noqa: F401
+except ImportError:
+    pytest.skip("FreeBSD-only tests", allow_module_level=True)
+
+
 from pathlib import Path
 from unittest.mock import patch
 

--- a/tests/test_sync_transports.py
+++ b/tests/test_sync_transports.py
@@ -451,6 +451,9 @@ def test_sync_get_modem_pins(serial_pair: SerialPair) -> None:
 
 def test_sync_set_modem_pins_api(serial_pair: SerialPair) -> None:
     """Test modem pin writes are accepted on all backends."""
+    if sys.platform.startswith("freebsd") and serial_pair.backend == "socat":
+        pytest.xfail("FreeBSD PTYs do not track modem pin state")
+
     with Serial.from_url(serial_pair.left, baudrate=115200) as serial:
         serial.set_modem_pins(dtr=True, rts=True)
         pins_high = serial.get_modem_pins()
@@ -580,6 +583,10 @@ def test_sync_readexactly_partial_timeout(serial_pair: SerialPair) -> None:
 
 
 @pytest.mark.skip_backends("socket", "esphome")
+@pytest.mark.xfail(
+    sys.platform.startswith("freebsd"),
+    reason="FreeBSD ucom driver does not enforce write buffer limits",
+)
 def test_sync_write_timeout(serial_pair: SerialPair) -> None:
     """Test that write timeout works when buffer is full."""
 

--- a/tests/test_sync_transports.py
+++ b/tests/test_sync_transports.py
@@ -452,7 +452,7 @@ def test_sync_get_modem_pins(serial_pair: SerialPair) -> None:
 def test_sync_set_modem_pins_api(serial_pair: SerialPair) -> None:
     """Test modem pin writes are accepted on all backends."""
     if serial_pair.backend == "socat" and sys.platform.startswith("freebsd"):
-        pytest.skip("FreeBSD PTYs do not track modem pin state")
+        pytest.xfail("FreeBSD socat sets all pins to LOW")
 
     with Serial.from_url(serial_pair.left, baudrate=115200) as serial:
         serial.set_modem_pins(dtr=True, rts=True)

--- a/tests/test_sync_transports.py
+++ b/tests/test_sync_transports.py
@@ -451,8 +451,8 @@ def test_sync_get_modem_pins(serial_pair: SerialPair) -> None:
 
 def test_sync_set_modem_pins_api(serial_pair: SerialPair) -> None:
     """Test modem pin writes are accepted on all backends."""
-    if sys.platform.startswith("freebsd") and serial_pair.backend == "socat":
-        pytest.xfail("FreeBSD PTYs do not track modem pin state")
+    if serial_pair.backend == "socat" and sys.platform.startswith("freebsd"):
+        pytest.skip("FreeBSD PTYs do not track modem pin state")
 
     with Serial.from_url(serial_pair.left, baudrate=115200) as serial:
         serial.set_modem_pins(dtr=True, rts=True)


### PR DESCRIPTION
With https://github.com/puddly/serialx/pull/31, Linux support now is built on top of new POSIX and "extended" POSIX platforms, both of which are feature-detected. The new FreeBSD platform doesn't add any extra code to extended POSIX, it just adds a bit to list serial ports.

---

Unfortunately, adding FreeBSD to the CI test suite will be a bit difficult with GitHub Actions but I'm able to confirm functionality with zigpy-cli and manually running the test suite in a VM. Almost all adapter-based tests pass, with only a few failing due to `socat` differences on the platform.

Synchronous write timeouts fail, however. `write` always succeeds even with hardware flow control and `select` never times out as we expect. Polling `TIOCOUTQ` may be a way around this, since it grows without bound and we can maybe detect this condition.

---

CC @amigan, since you mentioned running Home Assistant on FreeBSD