### PR TITLE
Build `tty0tty0` loopback driver for Linux CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,14 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y socat libudev-dev
+          sudo apt-get install -y socat libudev-dev linux-headers-$(uname -r)
+      - name: Build and load tty0tty kernel module
+        run: |
+          git clone https://github.com/lcgamboa/tty0tty /tmp/tty0tty
+          git -C /tmp/tty0tty checkout dac0a105bee6997ebb3a06441c7befe3164c9fd1
+          make -C /tmp/tty0tty/module
+          sudo insmod /tmp/tty0tty/module/tty0tty.ko
+          sudo chmod 666 /dev/tnt0 /dev/tnt1
       - name: Set up uv
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -192,6 +199,7 @@ jobs:
             --cov=serialx \
             -o console_output_style=count \
             -p no:sugar \
+            --adapter-pair /dev/tnt0:/dev/tnt1 \
             tests
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@ except ImportError:
     aioesphomeapi = None
 
 COM0COM_RE = re.compile(r"^CNC[A-Z]\d+$", re.IGNORECASE)
+TTY0TTY_RE = re.compile(r"^/dev/tnt\d+$")
 
 
 def _get_posix_serial_classes() -> list[str]:
@@ -61,10 +62,6 @@ def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line(
         "markers",
         "skip_backends(*backends): skip test for the listed serial_pair backends",
-    )
-    config.addinivalue_line(
-        "markers",
-        "require_backends(*backends): only run test for the listed serial_pair backends",
     )
 
 
@@ -125,6 +122,8 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
         for left, right in _get_adapter_pairs(metafunc.config):
             if COM0COM_RE.match(left) or COM0COM_RE.match(right):
                 backend = "com0com"
+            elif TTY0TTY_RE.match(left) or TTY0TTY_RE.match(right):
+                backend = "tty0tty"
             else:
                 backend = "adapter"
 
@@ -168,10 +167,6 @@ def serial_pair(request: pytest.FixtureRequest) -> Generator[SerialPair]:
         if backend in marker.args:
             pytest.skip(f"Skipped for backend {backend!r}")
 
-    for marker in request.node.iter_markers("require_backends"):
-        if backend not in marker.args:
-            pytest.skip(f"Requires backend in {marker.args!r}, got {backend!r}")
-
     # Check if a serial class override is requested (e.g. "PosixSerial")
     serial_class_override = (
         backend_info[1]
@@ -210,7 +205,7 @@ def serial_pair(request: pytest.FixtureRequest) -> Generator[SerialPair]:
     elif backend == "socket":
         with create_socket_pair() as (left, right):
             yield SerialPair(left, right, "socket")
-    elif backend in ("adapter", "com0com"):
+    elif backend in ("adapter", "com0com", "tty0tty"):
         yield SerialPair(backend_info[1], backend_info[2], backend)
 
 

--- a/tests/test_async_transports.py
+++ b/tests/test_async_transports.py
@@ -695,7 +695,7 @@ async def test_async_set_modem_pins(serial_pair: SerialPair) -> None:
 # trigger backpressure conditions.
 
 
-@pytest.mark.skip_backends("socket", "com0com", "socat", "esphome")
+@pytest.mark.skip_backends("socket", "com0com", "socat", "esphome", "tty0tty")
 async def test_async_backpressure_callbacks(serial_pair: SerialPair) -> None:
     """Test backpressure pause/resume callbacks through public async APIs."""
 
@@ -874,7 +874,7 @@ async def test_async_fast_open_close(serial_pair: SerialPair) -> None:
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="CloseHandle resets modem signals")
-@pytest.mark.require_backends("adapter")
+@pytest.mark.skip_backends("socket", "socat", "esphome", "com0com", "tty0tty")
 async def test_async_deassert_on_open(serial_pair: SerialPair) -> None:
     """Test DTR/CTS deassertion on open."""
 
@@ -910,7 +910,7 @@ async def test_async_deassert_on_open(serial_pair: SerialPair) -> None:
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="CloseHandle resets modem signals")
-@pytest.mark.require_backends("adapter")
+@pytest.mark.skip_backends("socket", "socat", "esphome", "com0com", "tty0tty")
 async def test_async_hang_up_on_close(serial_pair: SerialPair) -> None:
     """Test DTR/CTS hang up on close."""
 
@@ -957,7 +957,7 @@ async def test_async_hang_up_on_close(serial_pair: SerialPair) -> None:
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="CloseHandle resets modem signals")
-@pytest.mark.require_backends("adapter")
+@pytest.mark.skip_backends("socket", "socat", "esphome", "com0com", "tty0tty")
 @pytest.mark.parametrize(
     ("rtscts", "rtsdtr_on_open", "expected_state"),
     [

--- a/tests/test_sync_transports.py
+++ b/tests/test_sync_transports.py
@@ -612,7 +612,7 @@ def test_sync_read_until_total_timeout(serial_pair: SerialPair) -> None:
         assert elapsed() == pytest.approx(0.5, abs=0.15)
 
 
-@pytest.mark.skip_backends("socket", "esphome")
+@pytest.mark.skip_backends("socket", "esphome", "tty0tty")
 @pytest.mark.xfail(
     sys.platform.startswith("freebsd"),
     reason="FreeBSD ucom driver does not enforce write buffer limits",
@@ -678,7 +678,7 @@ def test_sync_reset_read_buffer(serial_pair: SerialPair) -> None:
         assert right.read(1024) == b""
 
 
-@pytest.mark.skip_backends("socket", "esphome", "socat")
+@pytest.mark.skip_backends("socket", "esphome", "socat", "tty0tty")
 def test_sync_reset_write_buffer(serial_pair: SerialPair) -> None:
     """Test that reset_write_buffer discards pending output."""
     with Serial.from_url(serial_pair.left, baudrate=9600, write_timeout=0) as left:
@@ -707,7 +707,7 @@ def test_sync_buffer_methods(serial_pair: SerialPair) -> None:
 # and verify cross-port behavior that virtual backends can't emulate.
 
 
-@pytest.mark.require_backends("adapter")
+@pytest.mark.skip_backends("socket", "socat", "esphome", "com0com", "tty0tty")
 def test_dtr_cts(serial_pair: SerialPair) -> None:
     """Test that DTR on one side controls CTS on the other."""
 
@@ -735,7 +735,7 @@ def test_dtr_cts(serial_pair: SerialPair) -> None:
         assert left.get_modem_pins().cts is PinState.LOW
 
 
-@pytest.mark.require_backends("adapter")
+@pytest.mark.skip_backends("socket", "socat", "esphome", "com0com", "tty0tty")
 def test_deprecated_dtr_cts(serial_pair: SerialPair) -> None:
     """Test DTR/CTS cross-port behavior via deprecated property aliases."""
 
@@ -776,7 +776,7 @@ def test_fast_open_close(serial_pair: SerialPair) -> None:
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="CloseHandle resets modem signals")
-@pytest.mark.require_backends("adapter")
+@pytest.mark.skip_backends("socket", "socat", "esphome", "com0com", "tty0tty")
 def test_deassert_on_open(serial_pair: SerialPair) -> None:
     """Test DTR/CTS deassertion on open."""
 
@@ -812,7 +812,7 @@ def test_deassert_on_open(serial_pair: SerialPair) -> None:
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="CloseHandle resets modem signals")
-@pytest.mark.require_backends("adapter")
+@pytest.mark.skip_backends("socket", "socat", "esphome", "com0com", "tty0tty")
 def test_hang_up_on_close(serial_pair: SerialPair) -> None:
     """Test DTR/CTS hang up on close."""
 
@@ -856,7 +856,7 @@ def test_hang_up_on_close(serial_pair: SerialPair) -> None:
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="CloseHandle resets modem signals")
-@pytest.mark.require_backends("adapter")
+@pytest.mark.skip_backends("socket", "socat", "esphome", "com0com", "tty0tty")
 @pytest.mark.parametrize(
     ("rtscts", "rtsdtr_on_open", "expected_state"),
     [
@@ -899,7 +899,7 @@ def test_deassert_on_open_with_rtscts(
             assert left.get_modem_pins().cts is expected_state
 
 
-@pytest.mark.require_backends("adapter")
+@pytest.mark.skip_backends("socket", "socat", "esphome", "com0com", "tty0tty")
 def test_write_timeout_cts_held(serial_pair: SerialPair) -> None:
     """Test that write timeout fires when CTS is deasserted (flow control hold)."""
 


### PR DESCRIPTION
This is like `com0com` but for Linux. It doesn't do baudrate emulation and flow control pins are hooked up a bit differently but it's still good to have for automated tests.