### PR TITLE
Fix file descriptor leak in `DescriptorTransport` during close*

### DIFF
--- a/serialx/descriptor_transport.py
+++ b/serialx/descriptor_transport.py
@@ -73,6 +73,9 @@ class DescriptorTransport(BaseSerialTransport):
             None, os.open, path, os.O_RDWR | os.O_NOCTTY | os.O_NONBLOCK
         )
 
+        if self._closing:
+            self._maybe_background_close(None)
+
     async def _connect(self, **_kwargs) -> None:
         assert self._fileno is not None
         self._loop.add_reader(self._fileno, self._read_ready)
@@ -307,10 +310,9 @@ class DescriptorTransport(BaseSerialTransport):
         if self._fileno is not None:
             self.write_eof()
         else:
-            # If we haven't opened yet, but close is requested, ensure we notify protocol
-            # or ensure we don't open.
+            # The fd hasn't been opened yet. Just set the flag; _open() will
+            # trigger the close sequence once the executor finishes.
             self._closing = True
-            self._maybe_background_close(None)
 
     def __del__(self) -> None:
         """Clean up transport on deletion."""
@@ -318,7 +320,7 @@ class DescriptorTransport(BaseSerialTransport):
             assert self._fileno is not None
 
             warnings.warn(f"unclosed transport {self!r}", ResourceWarning, source=self)
-            if self._loop is not None:
+            if not self._closing:
                 self._loop.remove_reader(self._fileno)
 
             _safe_close(self._fileno)
@@ -377,7 +379,7 @@ class DescriptorTransport(BaseSerialTransport):
 
         task_exc = task.exception()
         if task_exc is not None:
-            if self._loop is not None:
+            if not self._closed_waiter.done():
                 self._loop.call_exception_handler(
                     {
                         "message": "Unhandled exception in background close task",
@@ -391,37 +393,32 @@ class DescriptorTransport(BaseSerialTransport):
     async def _call_connection_lost(self, exc: Exception | None) -> None:
         LOGGER.debug("Closing connection: %r", exc)
 
-        loop = self._loop
         fileno = self._fileno
 
         try:
             if fileno is not None:
-                loop.remove_reader(fileno)
+                self._loop.remove_reader(fileno)
                 self._fileno = None
 
                 # For serial ports it would make sense to flush here BUT no modern serial
                 # driver requires this: once the data is enqueued, even `os.close` blocks
                 # for the entire transmit duration.
                 LOGGER.debug("Closing file descriptor %s", fileno)
-                await loop.run_in_executor(None, _safe_close, fileno)
+                await self._loop.run_in_executor(None, _safe_close, fileno)
         finally:
-            protocol = self._protocol
-            self._loop = None  # type: ignore[assignment]
-            self._protocol = None  # type: ignore[assignment]
-
             if self._connection_made:
                 LOGGER.debug("Calling protocol `connection_lost` with exc=%r", exc)
                 try:
-                    protocol.connection_lost(exc)
+                    self._protocol.connection_lost(exc)
                 except (SystemExit, KeyboardInterrupt):
                     raise
                 except BaseException as protocol_exc:
-                    loop.call_exception_handler(
+                    self._loop.call_exception_handler(
                         {
                             "message": "protocol.connection_lost() failed",
                             "exception": protocol_exc,
                             "transport": self,
-                            "protocol": protocol,
+                            "protocol": self._protocol,
                         }
                     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
+from collections.abc import AsyncGenerator, Generator
 import contextlib
 import dataclasses
 import importlib
@@ -333,16 +333,19 @@ def _snapshot_fds() -> dict[int, str]:
 
 
 @pytest.fixture(autouse=True)
-def check_fd_leaks(request: pytest.FixtureRequest) -> Generator[None]:
+async def check_fd_leaks(request: pytest.FixtureRequest) -> AsyncGenerator[None]:
     """Detect leaked file descriptors between tests."""
     if sys.platform != "linux":
         yield
         return
 
     before = _snapshot_fds()
-    yield
-    after = _snapshot_fds()
 
-    leaked = {fd: path for fd, path in after.items() if fd not in before}
-    if leaked:
-        pytest.fail(f"Leaked file descriptors: {leaked}")
+    try:
+        yield
+    finally:
+        after = _snapshot_fds()
+
+        leaked = {fd: path for fd, path in after.items() if fd not in before}
+        if leaked:
+            pytest.fail(f"Leaked file descriptors: {leaked}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from collections.abc import Generator
 import contextlib
 import dataclasses
 import importlib
+import os
 import sys
 import time
 from unittest.mock import patch
@@ -314,3 +315,34 @@ def _purge_com0com(request: pytest.FixtureRequest) -> None:
         time.sleep(0.05)
         PurgeComm(serial_left._handle, flags)  # type: ignore[attr-defined]
         PurgeComm(serial_right._handle, flags)  # type: ignore[attr-defined]
+
+
+def _snapshot_fds() -> dict[int, str]:
+    """Return a mapping of open fd -> target path for this process."""
+    pid = os.getpid()
+    result = {}
+
+    try:
+        for entry in os.listdir(f"/proc/{pid}/fd"):
+            with contextlib.suppress(OSError):
+                result[int(entry)] = os.readlink(f"/proc/{pid}/fd/{entry}")
+    except FileNotFoundError:
+        pass
+
+    return result
+
+
+@pytest.fixture(autouse=True)
+def check_fd_leaks(request: pytest.FixtureRequest) -> Generator[None]:
+    """Detect leaked file descriptors between tests."""
+    if sys.platform != "linux":
+        yield
+        return
+
+    before = _snapshot_fds()
+    yield
+    after = _snapshot_fds()
+
+    leaked = {fd: path for fd, path in after.items() if fd not in before}
+    if leaked:
+        pytest.fail(f"Leaked file descriptors: {leaked}")


### PR DESCRIPTION
This failure was caught during https://github.com/puddly/serialx/pull/40 testing.

The setup is a bit synthetic:
1. Create the asyncio transport directly.
2. Background the connection opening.
3. Schedule a close in the same event loop iteration.

A single failing test isn't bad but this file descriptor leaked _across_ tests, which wreaked all sorts of havoc.