### PR TITLE
In-tree PySerial compatibility module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -470,6 +470,34 @@ jobs:
           include-hidden-files: true
           path: .coverage
 
+  pytest-serialx-compat:
+    runs-on: ubuntu-latest
+    needs: prepare-base
+    name: Run serialx-compat tests (Python 3.10)
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v6
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v6
+        id: python
+        with:
+          python-version: "3.10"
+      - name: Restore base Python virtual environment
+        id: cache-venv
+        uses: actions/cache/restore@v4
+        with:
+          fail-on-cache-miss: true
+          path: venv
+          key: >-
+            1-${{ runner.os }}-base-venv-${{
+            steps.python.outputs.python-version }}-${{
+            hashFiles('pyproject.toml', 'Cargo.toml', 'src/lib.rs') }}
+      - name: Install serialx-compat and run tests
+        run: |
+          . venv/bin/activate
+          pip install -e serialx_compat[dev]
+          pytest -q serialx_compat/tests
+
   coverage:
     name: Process test coverage
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -47,7 +47,6 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "abi3audit {wheel} && cp {wheel} {dest_dir}"
 
       - name: Upload wheels
-        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
           name: wheels-${{ matrix.os }}
@@ -82,25 +81,22 @@ jobs:
           rm dist/*-cp*-*.whl
 
       - name: Upload sdist
-        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
           name: sdist
           path: dist/*.tar.gz
 
       - name: Upload wheel
-        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
           name: wheels-ubuntu
           path: dist/*.whl
 
-  publish:
-    name: Publish to PyPI
+  publish-pypi:
+    name: Publish serialx to PyPI
     needs: [build-wheels, build-sdist]
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
-
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -108,5 +104,136 @@ jobs:
           path: dist
           merge-multiple: true
 
-      - name: Publish to PyPI
+      - name: Publish serialx to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  build-serialx-compat:
+    name: Build serialx-compat
+    needs: [build-wheels, build-sdist, publish-pypi]
+    runs-on: ubuntu-latest
+    if: ${{ always() && (github.event_name != 'release' || needs['publish-pypi'].result == 'success') }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
+      - name: Install build tools
+        run: pip install build pkginfo
+
+      - name: Resolve version context for release
+        if: github.event_name == 'release'
+        run: |
+          echo "RELEASE_VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+          echo "SERIALX_PIN_VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+
+      - name: Resolve latest serialx version (non-release)
+        if: github.event_name != 'release'
+        run: |
+          set -euo pipefail
+          latest="$(curl -fsSL https://pypi.org/pypi/serialx/json | jq -r '.info.version')"
+          if [ -z "${latest}" ] || [ "${latest}" = "null" ]; then
+            echo "Could not resolve latest serialx version from PyPI" >&2
+            exit 1
+          fi
+          echo "Using serialx==${latest} for dependency pinning in non-release build."
+          echo "SERIALX_PIN_VERSION=${latest}" >> "$GITHUB_ENV"
+
+      - name: Wait for serialx release on PyPI
+        if: github.event_name == 'release'
+        run: |
+          for attempt in $(seq 1 40); do
+            if pip install --disable-pip-version-check --no-cache-dir "serialx==${SERIALX_PIN_VERSION}"; then
+              echo "serialx==${SERIALX_PIN_VERSION} is available on PyPI."
+              exit 0
+            fi
+            echo "serialx==${SERIALX_PIN_VERSION} not available yet (attempt ${attempt}/40), retrying..."
+            sleep 15
+          done
+
+          echo "Timed out waiting for serialx==${SERIALX_PIN_VERSION} on PyPI." >&2
+          exit 1
+
+      - name: Verify serialx pin version resolves on PyPI
+        if: github.event_name != 'release'
+        run: pip install --disable-pip-version-check --no-cache-dir "serialx==${SERIALX_PIN_VERSION}"
+
+      - name: Pin serialx dependency for build artifact
+        shell: python
+        run: |
+          import os
+          import re
+          from pathlib import Path
+
+          version = os.environ["SERIALX_PIN_VERSION"]
+          path = Path("serialx_compat/pyproject.toml")
+          text = path.read_text()
+          updated = re.sub(
+              r'^dependencies\s*=\s*\["serialx"(?:==[^"]+)?\]\s*(?:#.*)?$',
+              f'dependencies = ["serialx=={version}"]',
+              text,
+              count=1,
+              flags=re.MULTILINE,
+          )
+          if updated == text:
+              raise SystemExit(
+                  "Failed to pin serialx dependency in serialx_compat/pyproject.toml"
+              )
+          path.write_text(updated)
+
+      - name: Build serialx-compat
+        run: python -m build --sdist --wheel --outdir dist-serialx-compat serialx_compat
+
+      - name: Verify built serialx-compat wheel metadata
+        shell: python
+        run: |
+          import glob
+          import os
+          import pkginfo
+
+          release_event = os.environ.get("GITHUB_EVENT_NAME") == "release"
+          expected_release = os.environ.get("RELEASE_VERSION")
+          if release_event and not expected_release:
+              raise SystemExit("RELEASE_VERSION is not set for release build")
+
+          wheels = sorted(glob.glob("dist-serialx-compat/*.whl"))
+          if not wheels:
+              raise SystemExit("No wheel produced in dist-serialx-compat/")
+
+          for wheel in wheels:
+              metadata = pkginfo.Wheel(wheel)
+              version = metadata.version
+              if not version:
+                  raise SystemExit(f"{wheel}: missing version metadata")
+              if release_event and version != expected_release:
+                  raise SystemExit(
+                      f"{wheel}: version mismatch, expected {expected_release}, got {version}"
+                  )
+              print(f"{wheel}: {metadata.name} version {version}")
+
+      - name: Upload serialx-compat artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: serialx-compat-dist
+          path: dist-serialx-compat/*
+
+  publish-serialx-compat-pypi:
+    name: Publish serialx-compat to PyPI
+    needs: [build-serialx-compat]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    steps:
+      - name: Download serialx-compat artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: serialx-compat-dist
+          path: dist-serialx-compat
+
+      - name: Publish serialx-compat to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist-serialx-compat/

--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ native asynchronous APIs for all platforms.
 pip install serialx
 ```
 
+For drop-in import compatibility (`serial`, `serial_asyncio`,
+`serial_asyncio_fast`) without runtime patching, install:
+
+```console
+pip install serialx-compat
+```
+
 # Usage
 
 Serialx features a pyserial and pyserial-asyncio compatibility layer for easy testing.

--- a/serialx_compat/README.md
+++ b/serialx_compat/README.md
@@ -1,5 +1,4 @@
 # serialx-compat
-
 `serialx-compat` provides import-path compatibility for projects that expect:
 
 - `serial`
@@ -8,29 +7,7 @@
 
 All functionality is delegated to [`serialx`](https://pypi.org/project/serialx/).
 
-## Installation
-
-```bash
-pip install serialx-compat
-```
-
-From this monorepo via Git:
-
-```bash
-uv pip install "git+https://github.com/puddly/serialx.git@<ref>#subdirectory=serialx_compat"
-```
-
-## Usage
-
-```python
-import serial
-import serial_asyncio
-import serial_asyncio_fast
-```
-
-These modules are backed by `serialx` implementations.
-
-## Notes
-
-This package intentionally overlaps Python import paths with `pyserial`,
-`pyserial-asyncio`, and `pyserial-asyncio-fast`. Do not install them together.
+> [!IMPORTANT] 
+> WARNING: This package intentionally overlaps Python import paths with
+> `pyserial`, `pyserial-asyncio`, and `pyserial-asyncio-fast`. Uninstall those packages
+> first.

--- a/serialx_compat/README.md
+++ b/serialx_compat/README.md
@@ -1,0 +1,36 @@
+# serialx-compat
+
+`serialx-compat` provides import-path compatibility for projects that expect:
+
+- `serial`
+- `serial_asyncio`
+- `serial_asyncio_fast`
+
+All functionality is delegated to [`serialx`](https://pypi.org/project/serialx/).
+
+## Installation
+
+```bash
+pip install serialx-compat
+```
+
+From this monorepo via Git:
+
+```bash
+uv pip install "git+https://github.com/puddly/serialx.git@<ref>#subdirectory=serialx_compat"
+```
+
+## Usage
+
+```python
+import serial
+import serial_asyncio
+import serial_asyncio_fast
+```
+
+These modules are backed by `serialx` implementations.
+
+## Notes
+
+This package intentionally overlaps Python import paths with `pyserial`,
+`pyserial-asyncio`, and `pyserial-asyncio-fast`. Do not install them together.

--- a/serialx_compat/pyproject.toml
+++ b/serialx_compat/pyproject.toml
@@ -39,4 +39,4 @@ show_error_codes = true
 show_error_context = true
 
 [tool.setuptools_scm]
-fallback_version = "0.0.0"
+root = ".."

--- a/serialx_compat/pyproject.toml
+++ b/serialx_compat/pyproject.toml
@@ -1,0 +1,42 @@
+[build-system]
+requires = ["setuptools>=80", "setuptools-scm[simple]>=8"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "serialx-compat"
+dynamic = ["version"]
+description = "Compatibility package exposing pyserial-style imports backed by serialx"
+readme = "README.md"
+requires-python = ">=3.10"
+license = "Apache-2.0"
+authors = [{ name = "puddly", email = "puddly3@gmail.com" }]
+dependencies = ["serialx"]  # Rewritten to serialx==<release version> by release CI
+
+[project.optional-dependencies]
+esphome = [
+    "serialx[esphome]",
+]
+
+dev = [
+    "serialx[dev]",
+]
+
+[project.urls]
+Repository = "https://github.com/puddly/serialx"
+
+[tool.setuptools]
+py-modules = ["serial_asyncio", "serial_asyncio_fast"]
+
+[tool.setuptools.packages.find]
+include = ["serial", "serial.*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.mypy]
+check_untyped_defs = true
+show_error_codes = true
+show_error_context = true
+
+[tool.setuptools_scm]
+fallback_version = "0.0.0"

--- a/serialx_compat/serial/__init__.py
+++ b/serialx_compat/serial/__init__.py
@@ -2,6 +2,15 @@
 
 from __future__ import annotations
 
+import importlib.util
+
+if importlib.util.find_spec("serial.serialcli"):
+    raise RuntimeError(
+        "serialx-compat detected a mixed installation with pyserial files. Uninstall"
+        " pyserial, pyserial-asyncio, and pyserial-asyncio-fast before installing"
+        " serialx-compat."
+    )
+
 from importlib.metadata import version
 
 from serialx import (

--- a/serialx_compat/serial/__init__.py
+++ b/serialx_compat/serial/__init__.py
@@ -1,0 +1,70 @@
+"""Compatibility shim for pyserial's ``serial`` package backed by serialx."""
+
+from __future__ import annotations
+
+from importlib.metadata import version
+
+from serialx import (
+    CR,
+    EIGHTBITS,
+    LF,
+    PARITY_EVEN,
+    PARITY_NONE,
+    PARITY_ODD,
+    SEVENBITS,
+    STOPBITS_ONE,
+    STOPBITS_TWO,
+    BaseSerial,
+    BaseSerialTransport,
+    ModemPins,
+    Parity,
+    PinState,
+    Serial,
+    SerialException,
+    SerialPortInfo,
+    SerialStreamWriter,
+    SerialTimeoutException,
+    SerialTransport,
+    StopBits,
+    UnsupportedSetting,
+    create_serial_connection,
+    get_serial_classes,
+    list_serial_ports,
+    open_serial_connection,
+    serial_for_url,
+)
+
+VERSION = version("serialx-compat")
+__version__ = VERSION
+
+__all__ = [
+    "create_serial_connection",
+    "get_serial_classes",
+    "list_serial_ports",
+    "open_serial_connection",
+    "serial_for_url",
+    "ModemPins",
+    "Parity",
+    "PinState",
+    "BaseSerial",
+    "BaseSerialTransport",
+    "Serial",
+    "SerialException",
+    "UnsupportedSetting",
+    "SerialPortInfo",
+    "SerialStreamWriter",
+    "SerialTransport",
+    "StopBits",
+    "SerialTimeoutException",
+    "EIGHTBITS",
+    "SEVENBITS",
+    "PARITY_NONE",
+    "PARITY_EVEN",
+    "PARITY_ODD",
+    "STOPBITS_ONE",
+    "STOPBITS_TWO",
+    "CR",
+    "LF",
+    "VERSION",
+    "__version__",
+]

--- a/serialx_compat/serial/serialutil.py
+++ b/serialx_compat/serial/serialutil.py
@@ -1,0 +1,8 @@
+"""Compatibility shim for pyserial's ``serial.serialutil`` module."""
+
+from __future__ import annotations
+
+from serialx.serialutil import *  # noqa: F401,F403
+from serialx.serialutil import __all__ as _serialutil_all
+
+__all__ = _serialutil_all

--- a/serialx_compat/serial/tools/__init__.py
+++ b/serialx_compat/serial/tools/__init__.py
@@ -1,0 +1,5 @@
+"""Compatibility shim for pyserial's ``serial.tools`` package."""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/serialx_compat/serial/tools/list_ports.py
+++ b/serialx_compat/serial/tools/list_ports.py
@@ -1,0 +1,8 @@
+"""Compatibility shim for pyserial's ``serial.tools.list_ports`` module."""
+
+from __future__ import annotations
+
+from serialx.tools.list_ports import *  # noqa: F401,F403
+from serialx.tools.list_ports import __all__ as _list_ports_all
+
+__all__ = _list_ports_all

--- a/serialx_compat/serial/tools/list_ports_common.py
+++ b/serialx_compat/serial/tools/list_ports_common.py
@@ -1,0 +1,8 @@
+"""Compatibility shim for ``serial.tools.list_ports_common`` module."""
+
+from __future__ import annotations
+
+from serialx.tools.list_ports_common import *  # noqa: F401,F403
+from serialx.tools.list_ports_common import __all__ as _list_ports_common_all
+
+__all__ = _list_ports_common_all

--- a/serialx_compat/serial_asyncio.py
+++ b/serialx_compat/serial_asyncio.py
@@ -1,0 +1,24 @@
+"""Compatibility shim for ``serial_asyncio`` backed by serialx."""
+
+from __future__ import annotations
+
+from importlib.metadata import version
+
+from serialx import (
+    SerialStreamWriter,
+    SerialTransport,
+    create_serial_connection,
+    open_serial_connection,
+)
+
+VERSION = version("serialx-compat")
+__version__ = VERSION
+
+__all__ = [
+    "SerialStreamWriter",
+    "SerialTransport",
+    "create_serial_connection",
+    "open_serial_connection",
+    "VERSION",
+    "__version__",
+]

--- a/serialx_compat/serial_asyncio_fast.py
+++ b/serialx_compat/serial_asyncio_fast.py
@@ -1,0 +1,24 @@
+"""Compatibility shim for ``serial_asyncio_fast`` backed by serialx."""
+
+from __future__ import annotations
+
+from importlib.metadata import version
+
+from serialx import (
+    SerialStreamWriter,
+    SerialTransport,
+    create_serial_connection,
+    open_serial_connection,
+)
+
+VERSION = version("serialx-compat")
+__version__ = VERSION
+
+__all__ = [
+    "SerialStreamWriter",
+    "SerialTransport",
+    "create_serial_connection",
+    "open_serial_connection",
+    "VERSION",
+    "__version__",
+]

--- a/serialx_compat/tests/test_compat_imports.py
+++ b/serialx_compat/tests/test_compat_imports.py
@@ -1,0 +1,42 @@
+"""Smoke tests for import compatibility shims."""
+
+from __future__ import annotations
+
+import serial
+import serial.serialutil
+import serial.tools
+import serial.tools.list_ports
+import serial.tools.list_ports_common
+import serial_asyncio
+import serial_asyncio_fast
+
+
+def test_serial_exports_versions_and_core_symbols() -> None:
+    """Serial module exposes expected symbols and version attributes."""
+    assert serial.__version__ == serial.VERSION
+    assert isinstance(serial.VERSION, str)
+    assert hasattr(serial, "Serial")
+    assert hasattr(serial, "serial_for_url")
+
+
+def test_serial_submodules_are_importable() -> None:
+    """Serial package submodules expected by pyserial users import correctly."""
+    assert hasattr(serial.tools.list_ports, "comports")
+
+
+def test_serial_asyncio_exports_versions_and_core_symbols() -> None:
+    """serial_asyncio module exposes expected symbols and version attributes."""
+    assert serial_asyncio.__version__ == serial_asyncio.VERSION
+    assert isinstance(serial_asyncio.VERSION, str)
+    assert hasattr(serial_asyncio, "create_serial_connection")
+    assert hasattr(serial_asyncio, "open_serial_connection")
+    assert hasattr(serial_asyncio, "SerialTransport")
+
+
+def test_serial_asyncio_fast_exports_versions_and_core_symbols() -> None:
+    """serial_asyncio_fast module exposes expected symbols and version attributes."""
+    assert serial_asyncio_fast.__version__ == serial_asyncio_fast.VERSION
+    assert isinstance(serial_asyncio_fast.VERSION, str)
+    assert hasattr(serial_asyncio_fast, "create_serial_connection")
+    assert hasattr(serial_asyncio_fast, "open_serial_connection")
+    assert hasattr(serial_asyncio_fast, "SerialTransport")


### PR DESCRIPTION
This PR adds `serialx-compat`, a package that provides the `serial`, `serial_asyncio`, and `serial_asyncio_fast` modules. It will be published in lockstep with serialx and will share the same package versions.