### PR TITLE
Switch serialx-compat to not use dynamic versioning

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -178,24 +178,19 @@ jobs:
         shell: python
         run: |
           import os
-          import re
           from pathlib import Path
 
           version = os.environ["SERIALX_PIN_VERSION"]
           path = Path("serialx_compat/pyproject.toml")
           text = path.read_text()
-          updated = re.sub(
-              r'^dependencies\s*=\s*\["serialx"(?:==[^"]+)?\]\s*(?:#.*)?$',
-              f'dependencies = ["serialx=={version}"]',
-              text,
-              count=1,
-              flags=re.MULTILINE,
+
+          assert 'version = "0.0.0"' in text
+          assert 'dependencies = ["serialx"]' in text
+
+          path.write_text(
+              text.replace('version = "0.0.0"', f'version = "{version}"')
+                  .replace('dependencies = ["serialx"]', f'dependencies = ["serialx=={version}"]')
           )
-          if updated == text:
-              raise SystemExit(
-                  "Failed to pin serialx dependency in serialx_compat/pyproject.toml"
-              )
-          path.write_text(updated)
 
       - name: Build serialx-compat
         run: python -m build --sdist --wheel --outdir dist-serialx-compat serialx_compat

--- a/serialx_compat/pyproject.toml
+++ b/serialx_compat/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=80", "setuptools-scm[simple]>=8"]
+requires = ["setuptools>=80"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "serialx-compat"
-dynamic = ["version"]
+version = "0.0.0"  # Rewritten by CI to match the serialx version
 description = "Compatibility package exposing pyserial-style imports backed by serialx"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -37,6 +37,3 @@ testpaths = ["tests"]
 check_untyped_defs = true
 show_error_codes = true
 show_error_context = true
-
-[tool.setuptools_scm]
-root = ".."


### PR DESCRIPTION
The v1.1.0 release failed because the `pyproject.toml` patching was "caught" by setuptools-scm and triggered a version bump. We should unconditionally patch the versions.