### PR TITLE
Move `_socket_timeout` into the base socket transport

### DIFF
--- a/serialx/platforms/serial_rfc2217/__init__.py
+++ b/serialx/platforms/serial_rfc2217/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Generator
-from contextlib import contextmanager, suppress
+from contextlib import suppress
 from enum import IntEnum
 import logging
 import sys
@@ -404,21 +404,6 @@ class RFC2217Serial(SocketSerial):
 
         self._engine = Rfc2217()
         self._data_buffer = bytearray()
-
-    @contextmanager
-    def _socket_timeout(
-        self, timeout: float | None
-    ) -> Generator[float | None, None, None]:
-        """Context manager to set socket timeout temporarily."""
-        assert self._socket is not None
-
-        original_timeout = self._socket.gettimeout()
-        self._socket.settimeout(timeout)
-
-        try:
-            yield original_timeout
-        finally:
-            self._socket.settimeout(original_timeout)
 
     def _open(self) -> None:
         """Open the TCP connection and negotiate COM-PORT-OPTION."""

--- a/serialx/platforms/serial_socket.py
+++ b/serialx/platforms/serial_socket.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Generator
+from contextlib import contextmanager
 import logging
 import socket
 import urllib.parse
@@ -58,6 +60,21 @@ class SocketSerial(BaseSerial):
         """Get the connection timeout in seconds."""
         return self._connect_timeout
 
+    @contextmanager
+    def _socket_timeout(
+        self, timeout: float | None
+    ) -> Generator[float | None, None, None]:
+        """Context manager to set socket timeout temporarily."""
+        assert self._socket is not None
+
+        original_timeout = self._socket.gettimeout()
+        self._socket.settimeout(timeout)
+
+        try:
+            yield original_timeout
+        finally:
+            self._socket.settimeout(original_timeout)
+
     def _get_effective_socket_timeout(self) -> float | None:
         """Calculate effective socket timeout as min of read and write timeouts."""
         if self._read_timeout is None:
@@ -99,6 +116,20 @@ class SocketSerial(BaseSerial):
     def reset_read_buffer(self) -> None:
         """Reset the read buffer."""
 
+        # Drain all of the pending data in nonblocking mode
+        with self._socket_timeout(0):
+            while True:
+                if self._socket is None:
+                    break
+
+                try:
+                    data = self._socket.recv(1024)
+                except BlockingIOError:
+                    break
+
+                if not data:
+                    break
+
     def reset_write_buffer(self) -> None:
         """Reset the write buffer."""
 
@@ -109,21 +140,21 @@ class SocketSerial(BaseSerial):
         """Write bytes to socket."""
         assert self._socket is not None
 
-        self._socket.settimeout(timeout)
-
         data = bytes(b)
-        self._socket.sendall(data)
+
+        with self._socket_timeout(timeout):
+            self._socket.sendall(data)
+
         return len(data)
 
     def _readinto(self, b: Buffer, *, timeout: float | None) -> int:
         """Read bytes from socket into buffer."""
         assert self._socket is not None
 
-        self._socket.settimeout(timeout)
-
         m = memoryview(b).cast("B")
         try:
-            return self._socket.recv_into(m)
+            with self._socket_timeout(timeout):
+                return self._socket.recv_into(m)
         except TimeoutError:
             return 0
 
@@ -289,3 +320,25 @@ class SocketSerialTransport(BaseSerialTransport):
         if self._tcp_transport is not None:
             return self._tcp_transport.get_write_buffer_size()
         return 0
+
+    def get_write_buffer_limits(self) -> tuple[int, int]:
+        """Get the write buffer low and high water marks."""
+        if self._tcp_transport is None:
+            return (0, 0)
+
+        return self._tcp_transport.get_write_buffer_limits()
+
+    def set_write_buffer_limits(self, high=None, low=None) -> None:
+        """Set the write buffer low and high water marks."""
+        if self._tcp_transport is None:
+            raise RuntimeError("Transport not connected")
+
+        self._tcp_transport.set_write_buffer_limits(high=high, low=low)
+
+    def can_write_eof(self) -> bool:
+        """Return whether the underlying TCP transport supports EOF."""
+        return (
+            self._tcp_transport.can_write_eof()
+            if self._tcp_transport is not None
+            else False
+        )

--- a/tests/common.py
+++ b/tests/common.py
@@ -88,11 +88,10 @@ SERIAL_PAIR_DEFAULT_QUIRKS: dict[SerialBackend, frozenset[SerialQuirk]] = {
         {
             SerialQuirk.NO_RTS_CTS,
             SerialQuirk.NO_DTR_DSR,
-            SerialQuirk.NO_RESET_READ_BUFFER,
             SerialQuirk.NO_RESET_WRITE_BUFFER,
-            SerialQuirk.NO_BUFFER_CONTROL,
             SerialQuirk.NO_WRITE_TIMEOUT,
             SerialQuirk.NO_NUM_UNREAD_BYTES,
+            SerialQuirk.NO_PAUSE_WRITING_CALLBACKS,
             SerialQuirk.NO_EXCLUSIVITY,
             SerialQuirk.NO_UNPLUG,
         }


### PR DESCRIPTION
This PR moves `_socket_timeout` into the base `socket://` handler, allowing more granular timeouts for some operations. This unlocks `reset_read_buffer` and implements passthrough for `can_write_eof`, `set_write_buffer_limits`, and `get_write_buffer_limits`.

---

<sup>We need a quick change for a v1.1.1 release, since v1.1.0 uploaded serialx to PyPI but serialx-compat had a build error.</sup>