### PR TITLE
Allow passing ESPHome ports by name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
         with:
           path: tests/esphome/.esphome/build/serialx-host-daemon/.pioenvs/serialx-host-daemon/program
           key: >-
-            1-esphome-daemon-${{
+            2-esphome-daemon-${{
             hashFiles('tests/esphome/host_daemon.yaml', 'tests/esphome/external_components/**') }}
       - name: Set up Python 3.13
         if: steps.cache-esphome.outputs.cache-hit != 'true'
@@ -190,7 +190,7 @@ jobs:
           curl -LsSf https://astral.sh/uv/install.sh | sh
           uv venv esphome-venv
           . esphome-venv/bin/activate
-          uv pip install 'git+https://github.com/esphome/esphome@3f143d9f19ae29a408f1024e202aa869e86a7787'
+          uv pip install 'esphome>=2026.3.2'
           esphome compile tests/esphome/host_daemon.yaml
       - name: Cache ESPHome binary
         if: steps.cache-esphome.outputs.cache-hit != 'true'
@@ -262,7 +262,7 @@ jobs:
         with:
           path: tests/esphome/.esphome/build/serialx-host-daemon/.pioenvs/serialx-host-daemon/program
           key: >-
-            1-esphome-daemon-${{
+            2-esphome-daemon-${{
             hashFiles('tests/esphome/host_daemon.yaml', 'tests/esphome/external_components/**') }}
       - name: Restore cached ser2net binary
         uses: actions/cache/restore@v4

--- a/README.md
+++ b/README.md
@@ -83,6 +83,39 @@ async def main():
 	await transport.set_modem_pins(rts=True, dtr=True)
 ```
 
+## ESPHome serial proxy
+Serialx can communicate with serial devices exposed by [ESPHome](https://esphome.io/).
+
+It can either create the API instance directly, for simplicity:
+
+```python
+from serialx import open_serial_connection
+
+reader, writer = await open_serial_connection(
+    url="esphome://192.168.1.42:6053/?port_name=Zigbee&noise_psk=...",
+    baudrate=115200,
+)
+```
+
+Or reuse an existing API instance, for efficiency:
+```python
+from aioesphomeapi import APIClient
+from serialx import open_serial_connection
+from serialx.platforms.serial_esphome import ESPHomeSerialTransport
+
+# An external API instance
+api = APIClient(address="192.168.1.42", port=6053, noise_psk="...", password=None)
+await api.connect(login=True)
+
+reader, writer = await open_serial_connection(
+    url=None,
+    transport_cls=ESPHomeSerialTransport,
+    api=api,
+    port_name="Zigbee",
+    baudrate=115200,
+)
+```
+
 # Development
 All development dependencies are listed in `pyproject.toml`. To install them, use:
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dev = [
     "pytest-timeout",
     "pytest-xdist",
     "psutil",
-    "aioesphomeapi>=44.5.1 ; python_version >= '3.11'",
+    "aioesphomeapi>=44.6.0 ; python_version >= '3.11'",
 ]
 
 [tool.setuptools.packages.find]

--- a/serialx/async_serial.py
+++ b/serialx/async_serial.py
@@ -26,23 +26,30 @@ class SerialStreamWriter(asyncio.StreamWriter, Generic[_T]):
 async def create_serial_connection(
     loop,
     protocol_factory: Callable[[], asyncio.Protocol],
-    url,
-    baudrate,
+    url: str | None,
+    baudrate: int,
     parity=Parity.NONE,
     stopbits=StopBits.ONE,
     xonxoff=False,
     rtscts=False,
     exclusive=True,
+    *,
+    transport_cls: type[BaseSerialTransport] | None = None,
     **kwargs,
 ) -> tuple[BaseSerialTransport, asyncio.Protocol]:
     """Create a serial port connection with asyncio."""
     if not exclusive:
         raise ValueError("Only exclusive=True is supported")
 
-    _, transport_cls = await asyncio.get_running_loop().run_in_executor(
-        None, get_serial_classes, url
-    )
+    if transport_cls is None:
+        if url is None:
+            raise ValueError("One of `url` or `transport_cls` must be provided.")
 
+        _, transport_cls = await asyncio.get_running_loop().run_in_executor(
+            None, get_serial_classes, url
+        )
+
+    assert transport_cls is not None
     protocol = protocol_factory()
     transport = transport_cls(loop=loop, protocol=protocol)
 

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -638,7 +638,7 @@ class BaseSerialTransport(asyncio.Transport):
     async def connect(
         self,
         *,
-        path: str,
+        path: str | None,
         baudrate: int,
         parity: Parity = Parity.NONE,
         stopbits: StopBits = StopBits.ONE,

--- a/serialx/platforms/serial_esphome.py
+++ b/serialx/platforms/serial_esphome.py
@@ -106,11 +106,12 @@ class ESPHomeSerial(BaseSerial):
 
     def _open(self) -> None:
         """Open the serial port."""
-        self._loop = asyncio.new_event_loop()
-        self._read_event = asyncio.Event()
-        self._loop_thread = threading.Thread(target=self._loop.run_forever)
-        self._loop_thread.start()
+        if self._loop is None:
+            self._loop = asyncio.new_event_loop()
+            self._loop_thread = threading.Thread(target=self._loop.run_forever)
+            self._loop_thread.start()
 
+        self._read_event = asyncio.Event()
         self._call_on_loop(self._async_open())
         self._call_on_loop(self._async_subscribe())
 
@@ -318,6 +319,7 @@ class ESPHomeSerial(BaseSerial):
             self._loop.call_soon_threadsafe(self._loop.stop)
             self._loop_thread.join()
             self._loop.close()
+            self._loop = None
             self._loop_thread = None
 
 
@@ -369,8 +371,13 @@ class ESPHomeSerialTransport(BaseSerialTransport):
             self._unsub()
             self._unsub = None
 
-        if self._serial is not None and self._serial._api is not None:
-            self._serial._unsubscribe_instance()
+        if self._serial is None or self._serial._api is None:
+            self._call_protocol_connection_lost(None)
+            return
+
+        self._serial._unsubscribe_instance()
+
+        if self._serial._disconnect_api:
             api = self._serial._api
             self._serial._api = None
             self._loop.create_task(self._async_close(api))

--- a/serialx/platforms/serial_esphome.py
+++ b/serialx/platforms/serial_esphome.py
@@ -246,7 +246,7 @@ class ESPHomeSerial(BaseSerial):
             line_states=self._last_line_state,
         )
 
-        await self._ping(timeout=2.0)
+        await self._async_get_modem_pins()
 
     def _get_modem_pins(self) -> ModemPins:
         return self._call_on_loop(self._async_get_modem_pins())

--- a/serialx/platforms/serial_esphome.py
+++ b/serialx/platforms/serial_esphome.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable, Coroutine
+from contextlib import suppress
 from enum import IntFlag
 import logging
 import threading
@@ -12,7 +13,7 @@ import urllib.parse
 
 import aioesphomeapi
 from aioesphomeapi import APIClient, SerialProxyDataReceived, SerialProxyParity
-from aioesphomeapi.core import PingRequest, PingResponse
+from aioesphomeapi.core import APIConnectionError, PingRequest, PingResponse
 from typing_extensions import Buffer
 
 from serialx import UnsupportedSetting
@@ -199,7 +200,10 @@ class ESPHomeSerial(BaseSerial):
         """Unsubscribe serial proxy streaming for this instance if supported."""
         if self._api is None or not self._instance_subscribed:
             return
-        self._api.serial_proxy_unsubscribe(self._instance_id)
+
+        with suppress(APIConnectionError):
+            self._api.serial_proxy_unsubscribe(self._instance_id)
+
         self._instance_subscribed = False
 
     def _configure_port(self) -> None:

--- a/serialx/platforms/serial_esphome.py
+++ b/serialx/platforms/serial_esphome.py
@@ -128,8 +128,8 @@ class ESPHomeSerial(BaseSerial):
             parsed = urllib.parse.urlparse(str(self._path))
             params = urllib.parse.parse_qs(parsed.query)
 
-            if "port" in params:
-                port_value = params["port"][0]
+            if "port_name" in params:
+                port_value = params["port_name"][0]
             else:
                 # Backwards compat: esphome://host:port/{instance_id}
                 port_value = urllib.parse.unquote(parsed.path.strip("/"))

--- a/serialx/platforms/serial_esphome.py
+++ b/serialx/platforms/serial_esphome.py
@@ -126,14 +126,19 @@ class ESPHomeSerial(BaseSerial):
         if self._api is None:
             assert self._path is not None
             parsed = urllib.parse.urlparse(str(self._path))
-            path_str = parsed.path.strip("/")
-
-            if path_str.isdigit():
-                self._instance_id = int(path_str)
-            else:
-                self._port_name = path_str
-
             params = urllib.parse.parse_qs(parsed.query)
+
+            if "port" in params:
+                port_value = params["port"][0]
+            else:
+                # Backwards compat: esphome://host:port/{instance_id}
+                port_value = urllib.parse.unquote(parsed.path.strip("/"))
+
+            if port_value.isdigit():
+                self._instance_id = int(port_value)
+            else:
+                self._port_name = port_value
+
             self._api = aioesphomeapi.APIClient(
                 address=parsed.hostname,
                 port=parsed.port or ESPHOME_DEFAULT_PORT,
@@ -374,10 +379,6 @@ class ESPHomeSerialTransport(BaseSerialTransport):
         if self._unsub is not None:
             self._unsub()
             self._unsub = None
-
-        if self._serial is None or self._serial._api is None:
-            self._call_protocol_connection_lost(None)
-            return
 
         self._serial._unsubscribe_instance()
 

--- a/serialx/platforms/serial_esphome.py
+++ b/serialx/platforms/serial_esphome.py
@@ -62,6 +62,9 @@ class ESPHomeSerial(BaseSerial):
         *args,
         connect_timeout: float = 10.0,
         loop: asyncio.AbstractEventLoop | None = None,
+        api: APIClient | None = None,
+        port_name: str | None = None,
+        port_instance: int | None = None,
         **kwargs,
     ) -> None:
         """Initialize ESPHome serial port."""
@@ -77,22 +80,41 @@ class ESPHomeSerial(BaseSerial):
         # a temporary event loop while the async one passes through its own.
         self._loop = loop
         self._loop_thread: threading.Thread | None = None
-
         self._connect_timeout = connect_timeout
 
-        parsed = urllib.parse.urlparse(str(self._path))
-        params = urllib.parse.parse_qs(parsed.query)
-
-        self._host = parsed.hostname
-        self._port = parsed.port or ESPHOME_DEFAULT_PORT
-
-        path_str = parsed.path.strip("/")
-        self.instance = int(path_str) if path_str else 0
-
-        self._password = params["password"][0] if "password" in params else None
-        self._noise_psk = params["noise_psk"][0] if "noise_psk" in params else None
-
         self._api: APIClient | None = None
+        self._port_name: str | None = None
+        self._instance_id: int | None = None
+
+        if api is None:
+            if self._path is None:
+                raise ValueError("Either `path` or `api` must be provided")
+
+            parsed = urllib.parse.urlparse(str(self._path))
+
+            path_str = parsed.path.strip("/")
+            if not path_str:
+                raise ValueError(f"URI does not contain a port name: {self._path!r}")
+
+            if path_str.isdigit():
+                self._instance_id = int(path_str)
+            else:
+                self._port_name = path_str
+
+            params = urllib.parse.parse_qs(parsed.query)
+            self._api = aioesphomeapi.APIClient(
+                address=parsed.hostname,
+                port=parsed.port or ESPHOME_DEFAULT_PORT,
+                password=params["password"][0] if "password" in params else None,
+                noise_psk=params["noise_psk"][0] if "noise_psk" in params else None,
+            )
+            self._api_connect = True
+        else:
+            self._api = api
+            self._api_connect = False
+            self._port_name = port_name
+            self._instance_id = port_instance
+
         self._read_buffer = bytearray()
         self._read_event = asyncio.Event()
         self._unsub: Callable[[], None] | None = None
@@ -106,7 +128,7 @@ class ESPHomeSerial(BaseSerial):
         return asyncio.run_coroutine_threadsafe(coro, self._loop).result()
 
     def _on_data(self, msg: SerialProxyDataReceived) -> None:
-        if msg.instance == self.instance:
+        if msg.instance == self._instance_id:
             self._read_buffer.extend(msg.data)
             self._read_event.set()
 
@@ -126,13 +148,11 @@ class ESPHomeSerial(BaseSerial):
         return self._api is not None
 
     async def _async_open(self) -> None:
-        self._api = aioesphomeapi.APIClient(
-            self._host,
-            self._port,
-            password=self._password,
-            noise_psk=self._noise_psk,
-        )
-        await self._api.connect(login=True)
+        # Only connect if the API was not passed in externally
+        assert self._api is not None
+
+        if self._api_connect:
+            await self._api.connect(login=True)
 
     async def _async_subscribe(self) -> None:
         assert self._api is not None
@@ -156,7 +176,27 @@ class ESPHomeSerial(BaseSerial):
         """Subscribe serial proxy streaming for this instance if supported."""
         if self._api is None or self._instance_subscribed:
             return
-        self._api.serial_proxy_subscribe(self.instance)
+
+        info = await self._api.device_info()
+
+        if self._instance_id is None:
+            assert self._port_name is not None
+
+            name_to_info_mapping = {
+                proxy_info.name: (index, proxy_info)
+                for index, proxy_info in enumerate(info.serial_proxies)
+            }
+
+            if self._port_name not in name_to_info_mapping:
+                raise ValueError(
+                    f"Serial proxy with name {self._port_name!r}"
+                    f" does not exist in {name_to_info_mapping!r}"
+                )
+
+            instance_id, _proxy_info = name_to_info_mapping[self._port_name]
+            self._instance_id = instance_id
+
+        self._api.serial_proxy_subscribe(self._instance_id)
 
         # Ping to ensure the daemon has processed the subscribe
         await self._ping(timeout=self._connect_timeout)
@@ -167,14 +207,14 @@ class ESPHomeSerial(BaseSerial):
         """Unsubscribe serial proxy streaming for this instance if supported."""
         if self._api is None or not self._instance_subscribed:
             return
-        self._api.serial_proxy_unsubscribe(self.instance)
+        self._api.serial_proxy_unsubscribe(self._instance_id)
         self._instance_subscribed = False
 
     def _configure_port(self) -> None:
         """Configure the serial port settings."""
         assert self._api is not None
         self._api.serial_proxy_configure(
-            instance=self.instance,
+            instance=self._instance_id,
             baudrate=self._baudrate,
             flow_control=self._rtscts,
             parity=PARITY_MAP[self._parity],
@@ -202,7 +242,7 @@ class ESPHomeSerial(BaseSerial):
 
         self._last_line_state = line_states
         self._api.serial_proxy_set_modem_pins(
-            instance=self.instance,
+            instance=self._instance_id,
             line_states=self._last_line_state,
         )
 
@@ -213,7 +253,7 @@ class ESPHomeSerial(BaseSerial):
 
     async def _async_get_modem_pins(self) -> ModemPins:
         assert self._api is not None
-        rsp = await self._api.serial_proxy_get_modem_pins(instance=self.instance)
+        rsp = await self._api.serial_proxy_get_modem_pins(instance=self._instance_id)
         self._last_line_state = rsp.line_states
 
         return ModemPins(
@@ -239,7 +279,7 @@ class ESPHomeSerial(BaseSerial):
     async def _async_flush(self) -> None:
         """Flush write buffers."""
         assert self._api is not None
-        await self._api.serial_proxy_flush(instance=self.instance)
+        await self._api.serial_proxy_flush(instance=self._instance_id)
 
     def flush(self) -> None:
         """Flush write buffers."""
@@ -249,7 +289,7 @@ class ESPHomeSerial(BaseSerial):
         """Write bytes to serial port."""
         assert self._api is not None
         data = bytes(b)
-        self._api.serial_proxy_write(instance=self.instance, data=data)
+        self._api.serial_proxy_write(instance=self._instance_id, data=data)
         return len(data)
 
     def _readinto(self, b: Buffer, *, timeout: float | None) -> int:
@@ -317,7 +357,7 @@ class ESPHomeSerialTransport(BaseSerialTransport):
         self._protocol.connection_made(self)
 
     def _on_data(self, msg: SerialProxyDataReceived) -> None:
-        if msg.instance == self._serial.instance:
+        if msg.instance == self._serial._instance_id:
             self._protocol.data_received(msg.data)
 
     def write(self, data: bytes | bytearray | memoryview) -> None:

--- a/serialx/platforms/serial_esphome.py
+++ b/serialx/platforms/serial_esphome.py
@@ -82,38 +82,10 @@ class ESPHomeSerial(BaseSerial):
         self._loop_thread: threading.Thread | None = None
         self._connect_timeout = connect_timeout
 
-        self._api: APIClient | None = None
-        self._port_name: str | None = None
-        self._instance_id: int | None = None
-
-        if api is None:
-            if self._path is None:
-                raise ValueError("Either `path` or `api` must be provided")
-
-            parsed = urllib.parse.urlparse(str(self._path))
-
-            path_str = parsed.path.strip("/")
-            if not path_str:
-                raise ValueError(f"URI does not contain a port name: {self._path!r}")
-
-            if path_str.isdigit():
-                self._instance_id = int(path_str)
-            else:
-                self._port_name = path_str
-
-            params = urllib.parse.parse_qs(parsed.query)
-            self._api = aioesphomeapi.APIClient(
-                address=parsed.hostname,
-                port=parsed.port or ESPHOME_DEFAULT_PORT,
-                password=params["password"][0] if "password" in params else None,
-                noise_psk=params["noise_psk"][0] if "noise_psk" in params else None,
-            )
-            self._api_connect = True
-        else:
-            self._api = api
-            self._api_connect = False
-            self._port_name = port_name
-            self._instance_id = port_instance
+        self._api: APIClient | None = api
+        self._port_name: str | None = port_name
+        self._instance_id: int | None = port_instance
+        self._disconnect_api: bool = False
 
         self._read_buffer = bytearray()
         self._read_event = asyncio.Event()
@@ -149,10 +121,29 @@ class ESPHomeSerial(BaseSerial):
 
     async def _async_open(self) -> None:
         # Only connect if the API was not passed in externally
-        assert self._api is not None
+        if self._api is None:
+            assert self._path is not None
+            parsed = urllib.parse.urlparse(str(self._path))
+            path_str = parsed.path.strip("/")
 
-        if self._api_connect:
+            if path_str.isdigit():
+                self._instance_id = int(path_str)
+            else:
+                self._port_name = path_str
+
+            params = urllib.parse.parse_qs(parsed.query)
+            self._api = aioesphomeapi.APIClient(
+                address=parsed.hostname,
+                port=parsed.port or ESPHOME_DEFAULT_PORT,
+                password=params["password"][0] if "password" in params else None,
+                noise_psk=params["noise_psk"][0] if "noise_psk" in params else None,
+            )
+
+            self._disconnect_api = True
             await self._api.connect(login=True)
+        else:
+            # Don't disconnect an externally-passed API
+            self._disconnect_api = False
 
     async def _async_subscribe(self) -> None:
         assert self._api is not None
@@ -317,7 +308,7 @@ class ESPHomeSerial(BaseSerial):
             self._unsub()
             self._unsub = None
 
-        if self._api is not None:
+        if self._disconnect_api and self._api is not None:
             self._unsubscribe_instance()
             self._call_on_loop(self._api.disconnect())
             self._api = None

--- a/tests/common.py
+++ b/tests/common.py
@@ -313,8 +313,8 @@ def create_esphome_pair(left_tty: str, right_tty: str) -> Iterator[tuple[str, st
         api_port = _get_listening_ports(process.pid)[0]
 
         yield (
-            f"esphome://127.0.0.1:{api_port}/0",
-            f"esphome://127.0.0.1:{api_port}/1",
+            f"esphome://127.0.0.1:{api_port}?port=Serial+Proxy+Left",
+            f"esphome://127.0.0.1:{api_port}?port=Serial+Proxy+Right",
         )
     finally:
         if process.poll() is None:

--- a/tests/common.py
+++ b/tests/common.py
@@ -313,8 +313,8 @@ def create_esphome_pair(left_tty: str, right_tty: str) -> Iterator[tuple[str, st
         api_port = _get_listening_ports(process.pid)[0]
 
         yield (
-            f"esphome://127.0.0.1:{api_port}?port=Serial+Proxy+Left",
-            f"esphome://127.0.0.1:{api_port}?port=Serial+Proxy+Right",
+            f"esphome://127.0.0.1:{api_port}?port_name=Serial+Proxy+Left",
+            f"esphome://127.0.0.1:{api_port}?port_name=Serial+Proxy+Right",
         )
     finally:
         if process.poll() is None:

--- a/tests/test_async_transports.py
+++ b/tests/test_async_transports.py
@@ -598,6 +598,19 @@ async def test_async_invalid_uri() -> None:
         )
 
 
+async def test_create_serial_connection_no_url_no_transport() -> None:
+    """Test that create_serial_connection requires url or transport_cls."""
+    loop = asyncio.get_running_loop()
+
+    with pytest.raises(ValueError, match="url.*transport_cls"):
+        await create_serial_connection(
+            loop,
+            asyncio.Protocol,
+            url=None,
+            baudrate=115200,
+        )
+
+
 async def test_async_get_modem_pins(serial_pair: SerialPair) -> None:
     """Test reading modem control bits."""
     async with async_create_reader_writer(serial_pair.left, baudrate=115200) as (

--- a/tests/test_serial_esphome.py
+++ b/tests/test_serial_esphome.py
@@ -5,7 +5,10 @@ import pytest
 try:
     from aioesphomeapi import APIClient
 except ImportError:
-    pytest.skip("aioesphomeapi is required to run esphome transport tests")
+    pytest.skip(
+        "aioesphomeapi is required to run esphome transport tests",
+        allow_module_level=True,
+    )
 
 import urllib.parse
 

--- a/tests/test_serial_esphome.py
+++ b/tests/test_serial_esphome.py
@@ -46,3 +46,31 @@ async def test_externally_passed_api() -> None:
 
             # The API is still connected
             await api.device_info()
+
+
+@pytest.mark.skipif(not ESPHOME_HOST_BINARY, reason="esphome host binary not available")
+async def test_externally_passed_api_close_after_disconnect() -> None:
+    """Test closing the transport after the API has been disconnected."""
+    with create_socat_pair() as (socat_left, socat_right):
+        with create_esphome_pair(socat_left, socat_right) as (left, _right):
+            parsed = urllib.parse.urlparse(left)
+            api = APIClient(
+                address=parsed.hostname,
+                port=parsed.port or ESPHOME_DEFAULT_PORT,
+                password=None,
+            )
+            await api.connect(login=True)
+
+            reader, writer = await open_serial_connection(
+                url=None,
+                transport_cls=ESPHomeSerialTransport,
+                api=api,
+                port_name="Serial Proxy Left",
+                baudrate=115200,
+            )
+
+            # Disconnect the API before closing the transport
+            await api.disconnect()
+
+            writer.close()
+            await writer.wait_closed()

--- a/tests/test_serial_esphome.py
+++ b/tests/test_serial_esphome.py
@@ -96,3 +96,18 @@ async def test_connect_by_instance_id() -> None:
 
             writer.close()
             await writer.wait_closed()
+
+
+@pytest.mark.skipif(not ESPHOME_HOST_BINARY, reason="esphome host binary not available")
+async def test_connect_by_invalid_name() -> None:
+    """Test that connecting with an invalid port name raises ValueError."""
+    with create_socat_pair() as (socat_left, socat_right):
+        with create_esphome_pair(socat_left, socat_right) as (left, _right):
+            parsed = urllib.parse.urlparse(left)
+            url = f"esphome://{parsed.hostname}:{parsed.port}?port=Nonexistent"
+
+            with pytest.raises(ValueError, match="does not exist"):
+                await open_serial_connection(
+                    url=url,
+                    baudrate=115200,
+                )

--- a/tests/test_serial_esphome.py
+++ b/tests/test_serial_esphome.py
@@ -1,9 +1,13 @@
 """ESPHome serial port tests."""
 
-import urllib.parse
-
-from aioesphomeapi import APIClient
 import pytest
+
+try:
+    from aioesphomeapi import APIClient
+except ImportError:
+    pytest.skip("aioesphomeapi is required to run esphome transport tests")
+
+import urllib.parse
 
 from serialx import open_serial_connection
 from serialx.platforms.serial_esphome import (

--- a/tests/test_serial_esphome.py
+++ b/tests/test_serial_esphome.py
@@ -74,3 +74,25 @@ async def test_externally_passed_api_close_after_disconnect() -> None:
 
             writer.close()
             await writer.wait_closed()
+
+
+@pytest.mark.skipif(not ESPHOME_HOST_BINARY, reason="esphome host binary not available")
+async def test_connect_by_instance_id() -> None:
+    """Test connecting to an ESPHome serial proxy by instance ID."""
+    with create_socat_pair() as (socat_left, socat_right):
+        with create_esphome_pair(socat_left, socat_right) as (left, _right):
+            parsed = urllib.parse.urlparse(left)
+
+            # Connect by instance ID instead of name
+            url = f"esphome://{parsed.hostname}:{parsed.port}/0"
+
+            reader, writer = await open_serial_connection(
+                url=url,
+                baudrate=115200,
+            )
+
+            writer.write(b"test")
+            await writer.drain()
+
+            writer.close()
+            await writer.wait_closed()

--- a/tests/test_serial_esphome.py
+++ b/tests/test_serial_esphome.py
@@ -104,7 +104,7 @@ async def test_connect_by_invalid_name() -> None:
     with create_socat_pair() as (socat_left, socat_right):
         with create_esphome_pair(socat_left, socat_right) as (left, _right):
             parsed = urllib.parse.urlparse(left)
-            url = f"esphome://{parsed.hostname}:{parsed.port}?port=Nonexistent"
+            url = f"esphome://{parsed.hostname}:{parsed.port}?port_name=Nonexistent"
 
             with pytest.raises(ValueError, match="does not exist"):
                 await open_serial_connection(

--- a/tests/test_serial_esphome.py
+++ b/tests/test_serial_esphome.py
@@ -1,0 +1,48 @@
+"""ESPHome serial port tests."""
+
+import urllib.parse
+
+from aioesphomeapi import APIClient
+import pytest
+
+from serialx import open_serial_connection
+from serialx.platforms.serial_esphome import (
+    ESPHOME_DEFAULT_PORT,
+    ESPHomeSerialTransport,
+)
+
+from .common import ESPHOME_HOST_BINARY, create_esphome_pair, create_socat_pair
+
+
+@pytest.mark.skipif(not ESPHOME_HOST_BINARY, reason="esphome host binary not available")
+async def test_externally_passed_api() -> None:
+    """Test passing an ESPHome API instance externally."""
+    with create_socat_pair() as (socat_left, socat_right):
+        with create_esphome_pair(socat_left, socat_right) as (left, _right):
+            # Connect to the ESPHome API externally
+            parsed = urllib.parse.urlparse(left)
+            api = APIClient(
+                address=parsed.hostname,
+                port=parsed.port or ESPHOME_DEFAULT_PORT,
+                password=None,
+            )
+            await api.connect(login=True)
+
+            # Create a serial reader/writer pair
+            for _attempt in range(10):
+                reader, writer = await open_serial_connection(
+                    url=None,
+                    transport_cls=ESPHomeSerialTransport,
+                    api=api,
+                    port_name="Serial Proxy Left",
+                    baudrate=115200,
+                )
+
+                writer.write(b"test")
+                await writer.drain()
+
+                writer.close()
+                await writer.wait_closed()
+
+            # The API is still connected
+            await api.device_info()


### PR DESCRIPTION
Instead of using ESPHome serial proxy port instance IDs to refer to ports, we should use the user-friendly `name`. I've taken this opportunity to clean up the URI format.

Before:
```
esphome://my-device.local/0
```

After:
```
esphome://my-device.local?port_name=Some+Name
```

Python code that knows it's directly communicating with an ESPHome device should instead pass these as kwargs to either `Serial.from_url` (sync) or `open_serial_connection` (async) to avoid dealing with URI encoding.

The old format is still supported for convenience. In addition, we now support passing an external aioesphomeapi instance, which allows for creating and tearing down serial connections without opening a new API connection to a device.