### PR TITLE
Fix serial port listing race conditions (Linux)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,7 +288,7 @@ jobs:
           sudo apt-get install -y socat libudev-dev
       - name: Load tty0tty kernel module
         run: |
-          sudo insmod --force tty0tty.ko
+          sudo insmod -f tty0tty.ko
           sudo chmod 666 /dev/tnt0 /dev/tnt1
       - name: Set up uv
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,40 +199,11 @@ jobs:
           path: tests/esphome/.esphome/build/serialx-host-daemon/.pioenvs/serialx-host-daemon/program
           key: ${{ steps.cache-esphome.outputs.cache-primary-key }}
 
-  build-tty0tty:
-    name: Build tty0tty
-    runs-on: ubuntu-latest
-    env:
-      TTY0TTY_COMMIT: "dac0a105bee6997ebb3a06441c7befe3164c9fd1"
-    steps:
-      - name: Get kernel version
-        id: kernel
-        run: echo "version=$(uname -r)" >> "$GITHUB_OUTPUT"
-      - name: Restore cached tty0tty module
-        id: cache-tty0tty
-        uses: actions/cache/restore@v4
-        with:
-          path: tty0tty.ko
-          key: tty0tty-${{ env.TTY0TTY_COMMIT }}-${{ steps.kernel.outputs.version }}
-      - name: Build tty0tty
-        if: steps.cache-tty0tty.outputs.cache-hit != 'true'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y linux-headers-$(uname -r)
-          git clone https://github.com/lcgamboa/tty0tty /tmp/tty0tty
-          git -C /tmp/tty0tty checkout $TTY0TTY_COMMIT
-          make -C /tmp/tty0tty/module
-          cp /tmp/tty0tty/module/tty0tty.ko tty0tty.ko
-      - name: Cache tty0tty module
-        if: steps.cache-tty0tty.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: tty0tty.ko
-          key: ${{ steps.cache-tty0tty.outputs.cache-primary-key }}
-
   pytest:
     runs-on: ubuntu-latest
-    needs: [prepare-base, compile-esphome, build-ser2net, build-tty0tty]
+    needs: [prepare-base, compile-esphome, build-ser2net]
+    env:
+      TTY0TTY_COMMIT: "dac0a105bee6997ebb3a06441c7befe3164c9fd1"
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
@@ -277,18 +248,26 @@ jobs:
         id: kernel
         run: echo "version=$(uname -r)" >> "$GITHUB_OUTPUT"
       - name: Restore cached tty0tty module
-        uses: actions/cache/restore@v4
+        id: cache-tty0tty
+        uses: actions/cache@v4
         with:
           path: tty0tty.ko
-          key: tty0tty-dac0a105bee6997ebb3a06441c7befe3164c9fd1-${{ steps.kernel.outputs.version }}
-          restore-keys: tty0tty-dac0a105bee6997ebb3a06441c7befe3164c9fd1-
+          key: tty0tty-${{ env.TTY0TTY_COMMIT }}-${{ steps.kernel.outputs.version }}
+      - name: Build tty0tty
+        if: steps.cache-tty0tty.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get install -y linux-headers-$(uname -r)
+          git clone https://github.com/lcgamboa/tty0tty /tmp/tty0tty
+          git -C /tmp/tty0tty checkout $TTY0TTY_COMMIT
+          make -C /tmp/tty0tty/module
+          cp /tmp/tty0tty/module/tty0tty.ko tty0tty.ko
       - name: Install system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y socat libudev-dev
       - name: Load tty0tty kernel module
         run: |
-          sudo insmod -f tty0tty.ko
+          sudo insmod tty0tty.ko
           sudo chmod 666 /dev/tnt0 /dev/tnt1
       - name: Set up uv
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,13 +281,14 @@ jobs:
         with:
           path: tty0tty.ko
           key: tty0tty-dac0a105bee6997ebb3a06441c7befe3164c9fd1-${{ steps.kernel.outputs.version }}
+          restore-keys: tty0tty-dac0a105bee6997ebb3a06441c7befe3164c9fd1-
       - name: Install system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y socat libudev-dev
       - name: Load tty0tty kernel module
         run: |
-          sudo insmod tty0tty.ko
+          sudo insmod --force tty0tty.ko
           sudo chmod 666 /dev/tnt0 /dev/tnt1
       - name: Set up uv
         run: |

--- a/serialx/platforms/serial_linux.py
+++ b/serialx/platforms/serial_linux.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import array
+from collections.abc import Generator
+from contextlib import suppress
 import ctypes
 import errno
 import fcntl
@@ -185,18 +187,25 @@ class LinuxSerialTransport(ExtendedPosixSerialTransport):
     _serial_cls = LinuxSerial
 
 
+def iterdir_safe(path: Path) -> Generator[Path]:
+    """Safely iterate over a dir, yielding nothing on error."""
+
+    with suppress(OSError):
+        yield from path.iterdir()
+
+
 def linux_list_serial_ports() -> list[SerialPortInfo]:
     """List serial ports on Linux."""
     by_id_symlinks = {}
     by_id_path = DEV_ROOT / "serial/by-id"
 
-    if by_id_path.exists():
-        for symlink in by_id_path.iterdir():
-            by_id_symlinks[symlink.resolve()] = symlink
+    # `/dev/serial/by-id/` can disappear if nothing is plugged in
+    for symlink in iterdir_safe(by_id_path):
+        by_id_symlinks[symlink.resolve()] = symlink
 
     results = []
 
-    for path in (SYS_ROOT / "class/tty").iterdir():
+    for path in iterdir_safe(SYS_ROOT / "class/tty"):
         if not path.name.startswith("tty"):
             continue
 
@@ -214,39 +223,59 @@ def linux_list_serial_ports() -> list[SerialPortInfo]:
             usb_interface = resolved.parent
             usb_device = usb_interface.parent
             interface_file = usb_interface / "interface"
-            info = SerialPortInfo(
-                device=unique_device,
-                resolved_device=device,
-                vid=int((usb_device / "idVendor").read_text(), 16),
-                pid=int((usb_device / "idProduct").read_text(), 16),
-                serial_number=(usb_device / "serial").read_text()[:-1],
-                manufacturer=(usb_device / "manufacturer").read_text()[:-1],
-                product=(usb_device / "product").read_text()[:-1],
-                bcd_device=int((usb_device / "bcdDevice").read_text(), 16),
-                interface_description=(
-                    interface_file.read_text()[:-1] if interface_file.exists() else None
-                ),
-                interface_num=int((usb_interface / "bInterfaceNumber").read_text(), 16),
-            )
+
+            try:
+                info = SerialPortInfo(
+                    device=unique_device,
+                    resolved_device=device,
+                    vid=int((usb_device / "idVendor").read_text(), 16),
+                    pid=int((usb_device / "idProduct").read_text(), 16),
+                    serial_number=(usb_device / "serial").read_text()[:-1],
+                    manufacturer=(usb_device / "manufacturer").read_text()[:-1],
+                    product=(usb_device / "product").read_text()[:-1],
+                    bcd_device=int((usb_device / "bcdDevice").read_text(), 16),
+                    interface_description=(
+                        interface_file.read_text()[:-1]
+                        if interface_file.exists()
+                        else None
+                    ),
+                    interface_num=int(
+                        (usb_interface / "bInterfaceNumber").read_text(), 16
+                    ),
+                )
+            except OSError:
+                LOGGER.debug(
+                    "Serial device %r disappeared during iteration", usb_device
+                )
+                continue
         elif subsystem == "usb":
             # CDC ACM devices
             usb_interface = resolved
             usb_device = usb_interface.parent
             interface_file = usb_interface / "interface"
-            info = SerialPortInfo(
-                device=unique_device,
-                resolved_device=device,
-                vid=int((usb_device / "idVendor").read_text(), 16),
-                pid=int((usb_device / "idProduct").read_text(), 16),
-                serial_number=(usb_device / "serial").read_text()[:-1],
-                manufacturer=(usb_device / "manufacturer").read_text()[:-1],
-                product=(usb_device / "product").read_text()[:-1],
-                bcd_device=int((usb_device / "bcdDevice").read_text(), 16),
-                interface_description=(
-                    interface_file.read_text()[:-1] if interface_file.exists() else None
-                ),
-                interface_num=int((usb_interface / "bInterfaceNumber").read_text(), 16),
-            )
+
+            try:
+                info = SerialPortInfo(
+                    device=unique_device,
+                    resolved_device=device,
+                    vid=int((usb_device / "idVendor").read_text(), 16),
+                    pid=int((usb_device / "idProduct").read_text(), 16),
+                    serial_number=(usb_device / "serial").read_text()[:-1],
+                    manufacturer=(usb_device / "manufacturer").read_text()[:-1],
+                    product=(usb_device / "product").read_text()[:-1],
+                    bcd_device=int((usb_device / "bcdDevice").read_text(), 16),
+                    interface_description=(
+                        interface_file.read_text()[:-1]
+                        if interface_file.exists()
+                        else None
+                    ),
+                    interface_num=int(
+                        (usb_interface / "bInterfaceNumber").read_text(), 16
+                    ),
+                )
+            except OSError:
+                LOGGER.debug("USB device %r disappeared during iteration", usb_device)
+                continue
         elif subsystem == "serial-base":
             # Native serial ports
             info = SerialPortInfo(

--- a/serialx/platforms/serial_linux.py
+++ b/serialx/platforms/serial_linux.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import array
-from collections.abc import Generator
+from collections.abc import Iterator
 from contextlib import suppress
 import ctypes
 import errno
@@ -187,7 +187,7 @@ class LinuxSerialTransport(ExtendedPosixSerialTransport):
     _serial_cls = LinuxSerial
 
 
-def iterdir_safe(path: Path) -> Generator[Path]:
+def iterdir_safe(path: Path) -> Iterator[Path]:
     """Safely iterate over a dir, yielding nothing on error."""
 
     with suppress(OSError):

--- a/tests/test_list_serial_ports_linux.py
+++ b/tests/test_list_serial_ports_linux.py
@@ -436,3 +436,132 @@ def test_list_serial_ports_linux(fake_sysfs) -> None:
         interface_description=None,
         interface_num=None,
     )
+
+
+def test_list_serial_ports_no_sysfs(tmp_path: Path) -> None:
+    """Test listing serial ports when /sys/class/tty doesn't exist."""
+    sys_root = tmp_path / "sys"
+    dev_root = tmp_path / "dev"
+    sys_root.mkdir()
+    dev_root.mkdir()
+
+    # Don't create /sys/class/tty at all
+    with (
+        patch.object(serial_linux, "SYS_ROOT", sys_root),
+        patch.object(serial_linux, "DEV_ROOT", dev_root),
+    ):
+        ports = linux_list_serial_ports()
+
+    assert ports == []
+
+
+def test_list_serial_ports_no_by_id_dir(tmp_path: Path) -> None:
+    """Test listing serial ports when /dev/serial/by-id doesn't exist."""
+    sys_root = tmp_path / "sys"
+    dev_root = tmp_path / "dev"
+    sys_root.mkdir()
+    dev_root.mkdir()
+
+    create_usb_serial_device(
+        sys_root,
+        dev_root,
+        tty_name="ttyUSB0",
+        device_path="devices/platform/soc/fe980000.usb/usb1/1-1/1-1.1/1-1.1.1/1-1.1.1.1/1-1.1.1.1:1.0/ttyUSB0/tty/ttyUSB0",
+        vid="10c4",
+        pid="ea60",
+        serial="ec4903cb",
+        manufacturer="Silicon Labs",
+        product="CP2102 USB to UART Bridge Controller",
+        bcd_device="0100",
+        # No by_id_name: /dev/serial/by-id directory won't be created
+    )
+
+    with (
+        patch.object(serial_linux, "SYS_ROOT", sys_root),
+        patch.object(serial_linux, "DEV_ROOT", dev_root),
+    ):
+        ports = linux_list_serial_ports()
+
+    assert len(ports) == 1
+    assert ports[0].device == dev_root / "ttyUSB0"
+    assert ports[0].resolved_device == dev_root / "ttyUSB0"
+    assert ports[0].vid == 0x10C4
+
+
+def test_list_serial_ports_device_disappears_during_scan(tmp_path: Path) -> None:
+    """Test that a USB device disappearing mid-scan is handled gracefully."""
+    sys_root = tmp_path / "sys"
+    dev_root = tmp_path / "dev"
+    sys_root.mkdir()
+    dev_root.mkdir()
+
+    # Create a device that will "disappear"
+    create_usb_serial_device(
+        sys_root,
+        dev_root,
+        tty_name="ttyUSB0",
+        device_path="devices/platform/soc/fe980000.usb/usb1/1-1/1-1.1/1-1.1.1/1-1.1.1.1/1-1.1.1.1:1.0/ttyUSB0/tty/ttyUSB0",
+        vid="10c4",
+        pid="ea60",
+        serial="ec4903cb",
+        manufacturer="Silicon Labs",
+        product="CP2102 USB to UART Bridge Controller",
+        bcd_device="0100",
+    )
+
+    # Create a device that stays
+    create_native_serial_device(
+        sys_root,
+        dev_root,
+        tty_name="ttyAMA0",
+        device_path="devices/platform/soc/fe201000.serial/fe201000.serial:0/fe201000.serial:0.0/tty/ttyAMA0",
+    )
+
+    # Delete a sysfs file to simulate the device being unplugged mid-scan
+    usb_device = (
+        sys_root / "devices/platform/soc/fe980000.usb/usb1/1-1/1-1.1/1-1.1.1/1-1.1.1.1"
+    )
+    (usb_device / "idVendor").unlink()
+
+    with (
+        patch.object(serial_linux, "SYS_ROOT", sys_root),
+        patch.object(serial_linux, "DEV_ROOT", dev_root),
+    ):
+        ports = linux_list_serial_ports()
+
+    # The disappeared USB device should be skipped, native UART remains
+    assert len(ports) == 1
+    assert ports[0].device == dev_root / "ttyAMA0"
+
+
+def test_list_serial_ports_cdc_acm_device_disappears(tmp_path: Path) -> None:
+    """Test that a CDC ACM device disappearing mid-scan is handled gracefully."""
+    sys_root = tmp_path / "sys"
+    dev_root = tmp_path / "dev"
+    sys_root.mkdir()
+    dev_root.mkdir()
+
+    create_cdc_acm_device(
+        sys_root,
+        dev_root,
+        tty_name="ttyACM0",
+        device_path="devices/platform/soc/fe980000.usb/usb1/1-1/1-1.2/1-1.2:1.0/tty/ttyACM0",
+        vid="303a",
+        pid="4005",
+        serial="80B54EEFAE18",
+        manufacturer="Nabu Casa",
+        product="ZBT-2",
+        bcd_device="0100",
+    )
+
+    # Delete a sysfs file to simulate the device being unplugged mid-scan
+    usb_device = sys_root / "devices/platform/soc/fe980000.usb/usb1/1-1/1-1.2"
+    (usb_device / "idVendor").unlink()
+
+    with (
+        patch.object(serial_linux, "SYS_ROOT", sys_root),
+        patch.object(serial_linux, "DEV_ROOT", dev_root),
+    ):
+        ports = linux_list_serial_ports()
+
+    assert ports == []


### PR DESCRIPTION
`/dev/serial/by-id/` can sometimes disappear (https://github.com/home-assistant/core/actions/runs/24097226356/job/70300140523?pr=167615) so we need to harden listing serial ports and recover gracefully when `/dev/` or `/sys/` paths disappear mid iteration.