### PR TITLE
Make `device` and `resolved_device` strings, not paths

### DIFF
--- a/serialx/common.py
+++ b/serialx/common.py
@@ -10,7 +10,6 @@ from contextlib import contextmanager
 import dataclasses
 from enum import Enum
 import io
-import os
 from pathlib import Path
 import time
 from typing import Any
@@ -757,8 +756,8 @@ def get_serial_classes(
 class SerialPortInfo:
     """A serial port."""
 
-    device: os.PathLike
-    resolved_device: os.PathLike
+    device: str
+    resolved_device: str
 
     vid: int | None
     pid: int | None

--- a/serialx/platforms/serial_freebsd.py
+++ b/serialx/platforms/serial_freebsd.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 import re
 import subprocess
 
@@ -116,15 +115,15 @@ def freebsd_list_serial_ports() -> list[SerialPortInfo]:
 
         manufacturer, product = usb_strings.get(location["ugen"], (None, None))
 
-        device = Path(f"/dev/cua{ttyname}")
+        device = f"/dev/cua{ttyname}"
         vid_str = pnpinfo.get("vendor")
         pid_str = pnpinfo.get("product")
         release_str = pnpinfo.get("release")
 
         results.append(
             SerialPortInfo(
-                device=str(device),
-                resolved_device=str(device),
+                device=device,
+                resolved_device=device,
                 vid=int(vid_str, 16) if vid_str else None,
                 pid=int(pid_str, 16) if pid_str else None,
                 serial_number=pnpinfo.get("sernum"),

--- a/serialx/platforms/serial_freebsd.py
+++ b/serialx/platforms/serial_freebsd.py
@@ -123,8 +123,8 @@ def freebsd_list_serial_ports() -> list[SerialPortInfo]:
 
         results.append(
             SerialPortInfo(
-                device=device,
-                resolved_device=device,
+                device=str(device),
+                resolved_device=str(device),
                 vid=int(vid_str, 16) if vid_str else None,
                 pid=int(pid_str, 16) if pid_str else None,
                 serial_number=pnpinfo.get("sernum"),

--- a/serialx/platforms/serial_linux.py
+++ b/serialx/platforms/serial_linux.py
@@ -226,8 +226,8 @@ def linux_list_serial_ports() -> list[SerialPortInfo]:
 
             try:
                 info = SerialPortInfo(
-                    device=unique_device,
-                    resolved_device=device,
+                    device=str(unique_device),
+                    resolved_device=str(device),
                     vid=int((usb_device / "idVendor").read_text(), 16),
                     pid=int((usb_device / "idProduct").read_text(), 16),
                     serial_number=(usb_device / "serial").read_text()[:-1],
@@ -256,8 +256,8 @@ def linux_list_serial_ports() -> list[SerialPortInfo]:
 
             try:
                 info = SerialPortInfo(
-                    device=unique_device,
-                    resolved_device=device,
+                    device=str(unique_device),
+                    resolved_device=str(device),
                     vid=int((usb_device / "idVendor").read_text(), 16),
                     pid=int((usb_device / "idProduct").read_text(), 16),
                     serial_number=(usb_device / "serial").read_text()[:-1],
@@ -279,8 +279,8 @@ def linux_list_serial_ports() -> list[SerialPortInfo]:
         elif subsystem == "serial-base":
             # Native serial ports
             info = SerialPortInfo(
-                device=unique_device,
-                resolved_device=device,
+                device=str(unique_device),
+                resolved_device=str(device),
                 vid=None,
                 pid=None,
                 serial_number=None,

--- a/tests/test_list_serial_ports_freebsd.py
+++ b/tests/test_list_serial_ports_freebsd.py
@@ -47,8 +47,8 @@ def test_freebsd_list_serial_ports() -> None:
 
     # /dev/cuaU0: Nabu Casa ZBT-2 (CDC ACM via umodem)
     assert ports_by_device["/dev/cuaU0"] == SerialPortInfo(
-        device=Path("/dev/cuaU0"),
-        resolved_device=Path("/dev/cuaU0"),
+        device="/dev/cuaU0",
+        resolved_device="/dev/cuaU0",
         vid=0x303A,
         pid=0x4001,
         serial_number="80B54EEFAE18",
@@ -61,8 +61,8 @@ def test_freebsd_list_serial_ports() -> None:
 
     # /dev/cuaU1: FTDI FT232R (ugen8.2)
     assert ports_by_device["/dev/cuaU1"] == SerialPortInfo(
-        device=Path("/dev/cuaU1"),
-        resolved_device=Path("/dev/cuaU1"),
+        device="/dev/cuaU1",
+        resolved_device="/dev/cuaU1",
         vid=0x0403,
         pid=0x6001,
         serial_number="A5069RR4",
@@ -75,8 +75,8 @@ def test_freebsd_list_serial_ports() -> None:
 
     # /dev/cuaU2: FTDI FT232R (ugen8.3)
     assert ports_by_device["/dev/cuaU2"] == SerialPortInfo(
-        device=Path("/dev/cuaU2"),
-        resolved_device=Path("/dev/cuaU2"),
+        device="/dev/cuaU2",
+        resolved_device="/dev/cuaU2",
         vid=0x0403,
         pid=0x6001,
         serial_number="A5069RR4",
@@ -89,8 +89,8 @@ def test_freebsd_list_serial_ports() -> None:
 
     # /dev/cuaU3: Silicon Labs CP2102 (ugen8.5)
     assert ports_by_device["/dev/cuaU3"] == SerialPortInfo(
-        device=Path("/dev/cuaU3"),
-        resolved_device=Path("/dev/cuaU3"),
+        device="/dev/cuaU3",
+        resolved_device="/dev/cuaU3",
         vid=0x10C4,
         pid=0xEA60,
         serial_number="ec4903cb",
@@ -103,8 +103,8 @@ def test_freebsd_list_serial_ports() -> None:
 
     # /dev/cuaU4: FTDI FT232R with custom serial (ugen8.6)
     assert ports_by_device["/dev/cuaU4"] == SerialPortInfo(
-        device=Path("/dev/cuaU4"),
-        resolved_device=Path("/dev/cuaU4"),
+        device="/dev/cuaU4",
+        resolved_device="/dev/cuaU4",
         vid=0x0403,
         pid=0x6001,
         serial_number="rutabaga",

--- a/tests/test_list_serial_ports_linux.py
+++ b/tests/test_list_serial_ports_linux.py
@@ -310,9 +310,11 @@ def test_list_serial_ports_linux(fake_sysfs) -> None:
 
     # /dev/ttyUSB0: CP2102
     assert ports_by_name["ttyUSB0"] == SerialPortInfo(
-        device=dev_root
-        / "serial/by-id/usb-Silicon_Labs_CP2102_USB_to_UART_Bridge_Controller_ec4903cb-if00-port0",
-        resolved_device=dev_root / "ttyUSB0",
+        device=str(
+            dev_root
+            / "serial/by-id/usb-Silicon_Labs_CP2102_USB_to_UART_Bridge_Controller_ec4903cb-if00-port0"
+        ),
+        resolved_device=str(dev_root / "ttyUSB0"),
         vid=0x10C4,
         pid=0xEA60,
         serial_number="ec4903cb",
@@ -325,9 +327,11 @@ def test_list_serial_ports_linux(fake_sysfs) -> None:
 
     # /dev/ttyUSB1: Another CP2102
     assert ports_by_name["ttyUSB1"] == SerialPortInfo(
-        device=dev_root
-        / "serial/by-id/usb-Silicon_Labs_CP2102_USB_to_UART_Bridge_Controller_41b06ea8-if00-port0",
-        resolved_device=dev_root / "ttyUSB1",
+        device=str(
+            dev_root
+            / "serial/by-id/usb-Silicon_Labs_CP2102_USB_to_UART_Bridge_Controller_41b06ea8-if00-port0"
+        ),
+        resolved_device=str(dev_root / "ttyUSB1"),
         vid=0x10C4,
         pid=0xEA60,
         serial_number="41b06ea8",
@@ -340,8 +344,10 @@ def test_list_serial_ports_linux(fake_sysfs) -> None:
 
     # /dev/ttyUSB2: FTDI
     assert ports_by_name["ttyUSB2"] == SerialPortInfo(
-        device=dev_root / "serial/by-id/usb-FTDI_FT232R_USB_UART_A5069RR4-if00-port0",
-        resolved_device=dev_root / "ttyUSB2",
+        device=str(
+            dev_root / "serial/by-id/usb-FTDI_FT232R_USB_UART_A5069RR4-if00-port0"
+        ),
+        resolved_device=str(dev_root / "ttyUSB2"),
         vid=0x0403,
         pid=0x6001,
         serial_number="A5069RR4",
@@ -354,9 +360,11 @@ def test_list_serial_ports_linux(fake_sysfs) -> None:
 
     # /dev/ttyUSB3: Prolific
     assert ports_by_name["ttyUSB3"] == SerialPortInfo(
-        device=dev_root
-        / "serial/by-id/usb-Prolific_Technology_Inc._USB-Serial_Controller_DSDCb147613-if00-port0",
-        resolved_device=dev_root / "ttyUSB3",
+        device=str(
+            dev_root
+            / "serial/by-id/usb-Prolific_Technology_Inc._USB-Serial_Controller_DSDCb147613-if00-port0"
+        ),
+        resolved_device=str(dev_root / "ttyUSB3"),
         vid=0x067B,
         pid=0x23A3,
         serial_number="DSDCb147613",
@@ -369,8 +377,10 @@ def test_list_serial_ports_linux(fake_sysfs) -> None:
 
     # /dev/ttyUSB4: FTDI with custom serial
     assert ports_by_name["ttyUSB4"] == SerialPortInfo(
-        device=dev_root / "serial/by-id/usb-FTDI_FT232R_USB_UART_rutabaga-if00-port0",
-        resolved_device=dev_root / "ttyUSB4",
+        device=str(
+            dev_root / "serial/by-id/usb-FTDI_FT232R_USB_UART_rutabaga-if00-port0"
+        ),
+        resolved_device=str(dev_root / "ttyUSB4"),
         vid=0x0403,
         pid=0x6001,
         serial_number="rutabaga",
@@ -383,8 +393,8 @@ def test_list_serial_ports_linux(fake_sysfs) -> None:
 
     # /dev/ttyACM0: ZBT-2 CDC ACM
     assert ports_by_name["ttyACM0"] == SerialPortInfo(
-        device=dev_root / "serial/by-id/usb-Nabu_Casa_ZBT-2_80B54EEFAE18-if00",
-        resolved_device=dev_root / "ttyACM0",
+        device=str(dev_root / "serial/by-id/usb-Nabu_Casa_ZBT-2_80B54EEFAE18-if00"),
+        resolved_device=str(dev_root / "ttyACM0"),
         vid=0x303A,
         pid=0x4005,
         serial_number="80B54EEFAE18",
@@ -397,8 +407,8 @@ def test_list_serial_ports_linux(fake_sysfs) -> None:
 
     # /dev/ttyAMA0: Native UART
     assert ports_by_name["ttyAMA0"] == SerialPortInfo(
-        device=dev_root / "ttyAMA0",
-        resolved_device=dev_root / "ttyAMA0",
+        device=str(dev_root / "ttyAMA0"),
+        resolved_device=str(dev_root / "ttyAMA0"),
         vid=None,
         pid=None,
         serial_number=None,
@@ -411,8 +421,8 @@ def test_list_serial_ports_linux(fake_sysfs) -> None:
 
     # /dev/ttyAMA1: Native UART
     assert ports_by_name["ttyAMA1"] == SerialPortInfo(
-        device=dev_root / "ttyAMA1",
-        resolved_device=dev_root / "ttyAMA1",
+        device=str(dev_root / "ttyAMA1"),
+        resolved_device=str(dev_root / "ttyAMA1"),
         vid=None,
         pid=None,
         serial_number=None,
@@ -425,8 +435,8 @@ def test_list_serial_ports_linux(fake_sysfs) -> None:
 
     # /dev/ttyAMA2: Native UART
     assert ports_by_name["ttyAMA2"] == SerialPortInfo(
-        device=dev_root / "ttyAMA2",
-        resolved_device=dev_root / "ttyAMA2",
+        device=str(dev_root / "ttyAMA2"),
+        resolved_device=str(dev_root / "ttyAMA2"),
         vid=None,
         pid=None,
         serial_number=None,
@@ -483,8 +493,8 @@ def test_list_serial_ports_no_by_id_dir(tmp_path: Path) -> None:
         ports = linux_list_serial_ports()
 
     assert len(ports) == 1
-    assert ports[0].device == dev_root / "ttyUSB0"
-    assert ports[0].resolved_device == dev_root / "ttyUSB0"
+    assert ports[0].device == str(dev_root / "ttyUSB0")
+    assert ports[0].resolved_device == str(dev_root / "ttyUSB0")
     assert ports[0].vid == 0x10C4
 
 
@@ -531,7 +541,7 @@ def test_list_serial_ports_device_disappears_during_scan(tmp_path: Path) -> None
 
     # The disappeared USB device should be skipped, native UART remains
     assert len(ports) == 1
-    assert ports[0].device == dev_root / "ttyAMA0"
+    assert ports[0].device == str(dev_root / "ttyAMA0")
 
 
 def test_list_serial_ports_cdc_acm_device_disappears(tmp_path: Path) -> None:


### PR DESCRIPTION
Home Assistant (and I assume other projects) directly interact with `.device` and expect it to be a string, not a `Path`.