### PR TITLE
Fix serial port listing with unknown serial subsystems (Linux)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,6 +361,7 @@ jobs:
       - name: Run tests
         run: |
           . venv/bin/activate
+          python -m serialx.tools.list_ports
           pytest --timeout=20 --cov=serialx tests
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
+          check-latest: true
       - name: Restore base Python virtual environment
         id: cache-venv
         uses: actions/cache/restore@v4
@@ -62,6 +63,7 @@ jobs:
         id: python
         with:
           python-version: "3.10"
+          check-latest: true
       - name: Restore base Python virtual environment
         id: cache-venv
         uses: actions/cache/restore@v4
@@ -462,6 +464,7 @@ jobs:
         id: python
         with:
           python-version: "3.10"
+          check-latest: true
       - name: Restore base Python virtual environment
         id: cache-venv
         uses: actions/cache/restore@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,6 +285,7 @@ jobs:
         run: |
           . venv/bin/activate
           uv pip install pytest-xdist pytest-cov
+          python -m serialx.tools.list_ports
           pytest \
             -n auto \
             -qq \

--- a/serialx/platforms/serial_linux.py
+++ b/serialx/platforms/serial_linux.py
@@ -308,6 +308,7 @@ def linux_list_serial_ports() -> list[SerialPortInfo]:
                 subsystem,
                 device,
             )
+            continue
 
         results.append(info)
 

--- a/serialx/platforms/serial_linux.py
+++ b/serialx/platforms/serial_linux.py
@@ -220,10 +220,6 @@ def linux_list_serial_ports() -> list[SerialPortInfo]:
 
         try:
             resolved = tty_device.resolve(strict=True)
-        except OSError:
-            continue
-
-        try:
             # Some devices have no subsystem (GitHub Actions runner VM)
             subsystem = (resolved / "subsystem").resolve(strict=True).name
         except OSError:

--- a/serialx/platforms/serial_linux.py
+++ b/serialx/platforms/serial_linux.py
@@ -217,8 +217,18 @@ def linux_list_serial_ports() -> list[SerialPortInfo]:
             continue
 
         device = DEV_ROOT / path.name
-        resolved = tty_device.resolve()
-        subsystem = (resolved / "subsystem").resolve().name
+
+        try:
+            resolved = tty_device.resolve(strict=True)
+        except OSError:
+            continue
+
+        try:
+            # Some devices have no subsystem (GitHub Actions runner VM)
+            subsystem = (resolved / "subsystem").resolve(strict=True).name
+        except OSError:
+            continue
+
         unique_device = by_id_symlinks.get(device, device)
 
         if subsystem == "usb-serial":

--- a/tests/test_list_serial_ports_linux.py
+++ b/tests/test_list_serial_ports_linux.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import sys
 
 import pytest
@@ -165,6 +166,35 @@ def create_native_serial_device(
 
     subsystem_dir = sys_root / "bus/serial-base"
     (serial_base_path / "subsystem").symlink_to(subsystem_dir)
+
+
+def create_unknown_subsystem_device(
+    sys_root: Path,
+    dev_root: Path,
+    *,
+    tty_name: str,
+    device_path: str,
+    subsystem_name: str,
+) -> None:
+    """Create a fake device with an unknown/unsupported subsystem."""
+    full_device_path = sys_root / device_path.lstrip("/")
+    device_dir = full_device_path.parent.parent
+
+    tty_class = sys_root / "class/tty" / tty_name
+    tty_class.parent.mkdir(parents=True, exist_ok=True)
+    tty_class.symlink_to(Path("../..") / device_path.lstrip("/"))
+
+    full_device_path.mkdir(parents=True, exist_ok=True)
+    (full_device_path / "device").symlink_to(device_dir)
+
+    device_dir.mkdir(parents=True, exist_ok=True)
+
+    driver_dir = sys_root / f"bus/{subsystem_name}/drivers/some_driver"
+    driver_dir.mkdir(parents=True, exist_ok=True)
+    (device_dir / "driver").symlink_to(driver_dir)
+
+    subsystem_dir = sys_root / f"bus/{subsystem_name}"
+    (device_dir / "subsystem").symlink_to(subsystem_dir)
 
 
 @pytest.fixture
@@ -623,6 +653,34 @@ def test_list_serial_ports_native_device_disappears(tmp_path: Path) -> None:
         ports = linux_list_serial_ports()
 
     assert ports == []
+
+
+def test_list_serial_ports_unknown_subsystem(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that devices with unknown subsystems are skipped without error."""
+    sys_root = tmp_path / "sys"
+    dev_root = tmp_path / "dev"
+    sys_root.mkdir()
+    dev_root.mkdir()
+
+    create_unknown_subsystem_device(
+        sys_root,
+        dev_root,
+        tty_name="ttyXR0",
+        device_path="devices/platform/soc/fe123000.serial/fe123000.serial:0/fe123000.serial:0.0/tty/ttyXR0",
+        subsystem_name="some-unknown-bus",
+    )
+
+    with (
+        caplog.at_level(logging.WARNING),
+        patch.object(serial_linux, "SYS_ROOT", sys_root),
+        patch.object(serial_linux, "DEV_ROOT", dev_root),
+    ):
+        ports = linux_list_serial_ports()
+
+    assert ports == []
+    assert "Unknown serial device subsystem 'some-unknown-bus'" in caplog.text
 
 
 def test_list_serial_ports_empty(tmp_path: Path) -> None:

--- a/tests/test_list_serial_ports_linux.py
+++ b/tests/test_list_serial_ports_linux.py
@@ -623,3 +623,19 @@ def test_list_serial_ports_native_device_disappears(tmp_path: Path) -> None:
         ports = linux_list_serial_ports()
 
     assert ports == []
+
+
+def test_list_serial_ports_empty(tmp_path: Path) -> None:
+    """Test that listing serial ports still works when there are no ports."""
+    sys_root = tmp_path / "sys"
+    dev_root = tmp_path / "dev"
+    sys_root.mkdir()
+    dev_root.mkdir()
+
+    with (
+        patch.object(serial_linux, "SYS_ROOT", sys_root),
+        patch.object(serial_linux, "DEV_ROOT", dev_root),
+    ):
+        ports = linux_list_serial_ports()
+
+    assert ports == []

--- a/tests/test_list_serial_ports_linux.py
+++ b/tests/test_list_serial_ports_linux.py
@@ -168,6 +168,36 @@ def create_native_serial_device(
     (serial_base_path / "subsystem").symlink_to(subsystem_dir)
 
 
+def create_unknown_subsystem_device(
+    sys_root: Path,
+    dev_root: Path,
+    *,
+    tty_name: str,
+    device_path: str,
+    subsystem_name: str | None,
+) -> None:
+    """Create a fake device with an unknown/unsupported subsystem."""
+    full_device_path = sys_root / device_path.lstrip("/")
+    device_dir = full_device_path.parent.parent
+
+    tty_class = sys_root / "class/tty" / tty_name
+    tty_class.parent.mkdir(parents=True, exist_ok=True)
+    tty_class.symlink_to(Path("../..") / device_path.lstrip("/"))
+
+    full_device_path.mkdir(parents=True, exist_ok=True)
+    (full_device_path / "device").symlink_to(device_dir)
+
+    device_dir.mkdir(parents=True, exist_ok=True)
+
+    if subsystem_name is not None:
+        driver_dir = sys_root / f"bus/{subsystem_name}/drivers/some_driver"
+        driver_dir.mkdir(parents=True, exist_ok=True)
+        (device_dir / "driver").symlink_to(driver_dir)
+
+        subsystem_dir = sys_root / f"bus/{subsystem_name}"
+        (device_dir / "subsystem").symlink_to(subsystem_dir)
+
+
 @pytest.fixture
 def fake_sysfs(tmp_path):
     """Create a fake sysfs structure mimicking Home Assistant OS with a few devices."""
@@ -626,6 +656,34 @@ def test_list_serial_ports_native_device_disappears(tmp_path: Path) -> None:
     assert ports == []
 
 
+def test_list_serial_ports_unknown_subsystem(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that devices with unknown subsystems are skipped without error."""
+    sys_root = tmp_path / "sys"
+    dev_root = tmp_path / "dev"
+    sys_root.mkdir()
+    dev_root.mkdir()
+
+    create_unknown_subsystem_device(
+        sys_root,
+        dev_root,
+        tty_name="ttyXR0",
+        device_path="devices/platform/soc/fe123000.serial/fe123000.serial:0/fe123000.serial:0.0/tty/ttyXR0",
+        subsystem_name="some-unknown-bus",
+    )
+
+    with (
+        caplog.at_level(logging.WARNING),
+        patch.object(serial_linux, "SYS_ROOT", sys_root),
+        patch.object(serial_linux, "DEV_ROOT", dev_root),
+    ):
+        ports = linux_list_serial_ports()
+
+    assert ports == []
+    assert "Unknown serial device subsystem 'some-unknown-bus'" in caplog.text
+
+
 def test_list_serial_ports_no_subsystem(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
@@ -636,24 +694,13 @@ def test_list_serial_ports_no_subsystem(
     dev_root.mkdir()
 
     # Seen in GitHub Actions runner VM
-    tty_name = "tty28"
-    device_path = f"devices/virtual/tty/{tty_name}"
-    full_device_path = sys_root / device_path
-    device_dir = full_device_path.parent
-
-    tty_class = sys_root / "class/tty" / tty_name
-    tty_class.parent.mkdir(parents=True, exist_ok=True)
-    tty_class.symlink_to(Path("../..") / device_path)
-
-    full_device_path.mkdir(parents=True, exist_ok=True)
-    (full_device_path / "device").symlink_to(device_dir)
-
-    device_dir.mkdir(parents=True, exist_ok=True)
-
-    driver_dir = sys_root / "bus/platform/drivers/vtconsole"
-    driver_dir.mkdir(parents=True, exist_ok=True)
-    (device_dir / "driver").symlink_to(driver_dir)
-    # No subsystem symlink
+    create_unknown_subsystem_device(
+        sys_root,
+        dev_root,
+        tty_name="tty28",
+        device_path="devices/platform/soc/fe123000.serial/fe123000.serial:0/fe123000.serial:0.0/tty/tty28",
+        subsystem_name=None,
+    )
 
     with (
         caplog.at_level(logging.WARNING),

--- a/tests/test_list_serial_ports_linux.py
+++ b/tests/test_list_serial_ports_linux.py
@@ -136,47 +136,17 @@ def create_cdc_acm_device(
         (by_id_dir / by_id_name).symlink_to(dev_root / tty_name)
 
 
-def create_native_serial_device(
+def create_device(
     sys_root: Path,
     dev_root: Path,
     *,
     tty_name: str,
     device_path: str,
-    port_type: int,
+    bus: str | None,
+    subsystem: str | None,
+    port_type: int | None = None,
 ) -> None:
-    """Create a fake native serial device (ttyAMA*) in the fake sysfs."""
-    full_device_path = sys_root / device_path.lstrip("/")
-    serial_base_path = full_device_path.parent.parent
-
-    tty_class = sys_root / "class/tty" / tty_name
-    tty_class.parent.mkdir(parents=True, exist_ok=True)
-    tty_class.symlink_to(Path("../..") / device_path.lstrip("/"))
-
-    full_device_path.mkdir(parents=True, exist_ok=True)
-
-    (full_device_path / "type").write_text(f"{port_type}\n")
-    (full_device_path / "device").symlink_to(serial_base_path)
-
-    serial_base_path.mkdir(parents=True, exist_ok=True)
-
-    # Create driver and subsystem directories, then symlink to them
-    driver_dir = sys_root / "bus/serial-base/drivers/port"
-    driver_dir.mkdir(parents=True, exist_ok=True)
-    (serial_base_path / "driver").symlink_to(driver_dir)
-
-    subsystem_dir = sys_root / "bus/serial-base"
-    (serial_base_path / "subsystem").symlink_to(subsystem_dir)
-
-
-def create_unknown_subsystem_device(
-    sys_root: Path,
-    dev_root: Path,
-    *,
-    tty_name: str,
-    device_path: str,
-    subsystem_name: str | None,
-) -> None:
-    """Create a fake device with an unknown/unsupported subsystem."""
+    """Create a fake device in the fake sysfs."""
     full_device_path = sys_root / device_path.lstrip("/")
     device_dir = full_device_path.parent.parent
 
@@ -187,14 +157,18 @@ def create_unknown_subsystem_device(
     full_device_path.mkdir(parents=True, exist_ok=True)
     (full_device_path / "device").symlink_to(device_dir)
 
+    if port_type is not None:
+        (full_device_path / "type").write_text(f"{port_type}\n")
+
     device_dir.mkdir(parents=True, exist_ok=True)
 
-    if subsystem_name is not None:
-        driver_dir = sys_root / f"bus/{subsystem_name}/drivers/some_driver"
+    if bus is not None:
+        driver_dir = sys_root / f"bus/{bus}/drivers/some_driver"
         driver_dir.mkdir(parents=True, exist_ok=True)
         (device_dir / "driver").symlink_to(driver_dir)
 
-        subsystem_dir = sys_root / f"bus/{subsystem_name}"
+    if subsystem is not None:
+        subsystem_dir = sys_root / f"bus/{subsystem}"
         (device_dir / "subsystem").symlink_to(subsystem_dir)
 
 
@@ -303,39 +277,47 @@ def fake_sysfs(tmp_path):
     )
 
     # /dev/ttyAMA0: Raspberry Pi native UART
-    create_native_serial_device(
+    create_device(
         sys_root,
         dev_root,
         tty_name="ttyAMA0",
         device_path="devices/platform/soc/fe201000.serial/fe201000.serial:0/fe201000.serial:0.0/tty/ttyAMA0",
+        bus="serial-base",
+        subsystem="serial-base",
         port_type=32,
     )
 
     # /dev/ttyAMA1: Another Raspberry Pi native UART
-    create_native_serial_device(
+    create_device(
         sys_root,
         dev_root,
         tty_name="ttyAMA1",
         device_path="devices/platform/soc/fe201800.serial/fe201800.serial:0/fe201800.serial:0.0/tty/ttyAMA1",
+        bus="serial-base",
+        subsystem="serial-base",
         port_type=32,
     )
 
     # /dev/ttyAMA2: Third Raspberry Pi native UART
-    create_native_serial_device(
+    create_device(
         sys_root,
         dev_root,
         tty_name="ttyAMA2",
         device_path="devices/platform/soc/fe201a00.serial/fe201a00.serial:0/fe201a00.serial:0.0/tty/ttyAMA2",
+        bus="serial-base",
+        subsystem="serial-base",
         port_type=32,
     )
 
     # /dev/ttyS0-ttyS3: Phantom serial8250 ports (no hardware, PORT_UNKNOWN)
     for i in range(4):
-        create_native_serial_device(
+        create_device(
             sys_root,
             dev_root,
             tty_name=f"ttyS{i}",
             device_path=f"devices/platform/serial8250/serial8250:0/serial8250:0.{i}/tty/ttyS{i}",
+            bus="serial-base",
+            subsystem="serial-base",
             port_type=0,
         )
 
@@ -567,11 +549,13 @@ def test_list_serial_ports_device_disappears_during_scan(tmp_path: Path) -> None
     )
 
     # Create a device that stays
-    create_native_serial_device(
+    create_device(
         sys_root,
         dev_root,
         tty_name="ttyAMA0",
         device_path="devices/platform/soc/fe201000.serial/fe201000.serial:0/fe201000.serial:0.0/tty/ttyAMA0",
+        bus="serial-base",
+        subsystem="serial-base",
         port_type=32,
     )
 
@@ -632,11 +616,13 @@ def test_list_serial_ports_native_device_disappears(tmp_path: Path) -> None:
     sys_root.mkdir()
     dev_root.mkdir()
 
-    create_native_serial_device(
+    create_device(
         sys_root,
         dev_root,
         tty_name="ttyAMA0",
         device_path="devices/platform/soc/fe201000.serial/fe201000.serial:0/fe201000.serial:0.0/tty/ttyAMA0",
+        bus="serial-base",
+        subsystem="serial-base",
         port_type=32,
     )
 
@@ -665,12 +651,13 @@ def test_list_serial_ports_unknown_subsystem(
     sys_root.mkdir()
     dev_root.mkdir()
 
-    create_unknown_subsystem_device(
+    create_device(
         sys_root,
         dev_root,
         tty_name="ttyXR0",
         device_path="devices/platform/soc/fe123000.serial/fe123000.serial:0/fe123000.serial:0.0/tty/ttyXR0",
-        subsystem_name="some-unknown-bus",
+        bus="some-unknown-bus",
+        subsystem="some-unknown-bus",
     )
 
     with (
@@ -694,12 +681,13 @@ def test_list_serial_ports_no_subsystem(
     dev_root.mkdir()
 
     # Seen in GitHub Actions runner VM
-    create_unknown_subsystem_device(
+    create_device(
         sys_root,
         dev_root,
         tty_name="tty28",
         device_path="devices/platform/soc/fe123000.serial/fe123000.serial:0/fe123000.serial:0.0/tty/tty28",
-        subsystem_name=None,
+        bus="some-bus",
+        subsystem=None,
     )
 
     with (

--- a/tests/test_list_serial_ports_linux.py
+++ b/tests/test_list_serial_ports_linux.py
@@ -168,35 +168,6 @@ def create_native_serial_device(
     (serial_base_path / "subsystem").symlink_to(subsystem_dir)
 
 
-def create_unknown_subsystem_device(
-    sys_root: Path,
-    dev_root: Path,
-    *,
-    tty_name: str,
-    device_path: str,
-    subsystem_name: str,
-) -> None:
-    """Create a fake device with an unknown/unsupported subsystem."""
-    full_device_path = sys_root / device_path.lstrip("/")
-    device_dir = full_device_path.parent.parent
-
-    tty_class = sys_root / "class/tty" / tty_name
-    tty_class.parent.mkdir(parents=True, exist_ok=True)
-    tty_class.symlink_to(Path("../..") / device_path.lstrip("/"))
-
-    full_device_path.mkdir(parents=True, exist_ok=True)
-    (full_device_path / "device").symlink_to(device_dir)
-
-    device_dir.mkdir(parents=True, exist_ok=True)
-
-    driver_dir = sys_root / f"bus/{subsystem_name}/drivers/some_driver"
-    driver_dir.mkdir(parents=True, exist_ok=True)
-    (device_dir / "driver").symlink_to(driver_dir)
-
-    subsystem_dir = sys_root / f"bus/{subsystem_name}"
-    (device_dir / "subsystem").symlink_to(subsystem_dir)
-
-
 @pytest.fixture
 def fake_sysfs(tmp_path):
     """Create a fake sysfs structure mimicking Home Assistant OS with a few devices."""
@@ -655,22 +626,34 @@ def test_list_serial_ports_native_device_disappears(tmp_path: Path) -> None:
     assert ports == []
 
 
-def test_list_serial_ports_unknown_subsystem(
+def test_list_serial_ports_no_subsystem(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Test that devices with unknown subsystems are skipped without error."""
+    """Test that virtual consoles without a subsystem are filtered out."""
     sys_root = tmp_path / "sys"
     dev_root = tmp_path / "dev"
     sys_root.mkdir()
     dev_root.mkdir()
 
-    create_unknown_subsystem_device(
-        sys_root,
-        dev_root,
-        tty_name="ttyXR0",
-        device_path="devices/platform/soc/fe123000.serial/fe123000.serial:0/fe123000.serial:0.0/tty/ttyXR0",
-        subsystem_name="some-unknown-bus",
-    )
+    # Seen in GitHub Actions runner VM
+    tty_name = "tty28"
+    device_path = f"devices/virtual/tty/{tty_name}"
+    full_device_path = sys_root / device_path
+    device_dir = full_device_path.parent
+
+    tty_class = sys_root / "class/tty" / tty_name
+    tty_class.parent.mkdir(parents=True, exist_ok=True)
+    tty_class.symlink_to(Path("../..") / device_path)
+
+    full_device_path.mkdir(parents=True, exist_ok=True)
+    (full_device_path / "device").symlink_to(device_dir)
+
+    device_dir.mkdir(parents=True, exist_ok=True)
+
+    driver_dir = sys_root / "bus/platform/drivers/vtconsole"
+    driver_dir.mkdir(parents=True, exist_ok=True)
+    (device_dir / "driver").symlink_to(driver_dir)
+    # No subsystem symlink
 
     with (
         caplog.at_level(logging.WARNING),
@@ -680,7 +663,7 @@ def test_list_serial_ports_unknown_subsystem(
         ports = linux_list_serial_ports()
 
     assert ports == []
-    assert "Unknown serial device subsystem 'some-unknown-bus'" in caplog.text
+    assert not caplog.text
 
 
 def test_list_serial_ports_empty(tmp_path: Path) -> None:


### PR DESCRIPTION
Caught (again) in https://github.com/home-assistant/core/actions/runs/24216216900/job/70698025832?pr=167615.

```python
                    product=None,
                    bcd_device=None,
                    interface_description=None,
                    interface_num=None,
                )
            else:
                LOGGER.warning(
                    "Unknown serial device subsystem %r for device %r",
                    subsystem,
                    device,
                )
    
>           results.append(info)
                           ^^^^
E           UnboundLocalError: cannot access local variable 'info' where it is not associated with a value
```

A follow-up PR will enable as much of mypy as we can to catch things like this in the future.

---

The _underlying_ issue is that `Path.resolve()` on a nonexistent path will return the same path unless called with `strict=True`. The GitHub Actions runner VM seems to have a custom device with TTYs whose `platform` symlink is missing, causing an the "unknown serial device subsystem" branch to be taken erroneously. 