### PR TITLE
Enable basically all mypy checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,7 @@ repos:
     rev: v1.19.0
     hooks:
       - id: mypy
+        additional_dependencies: [types-pywin32]
   
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,9 +70,6 @@ disallow_untyped_globals = true
 warn_return_any = false
 disable_error_code = [
     "explicit-any",
-    "mutable-override",
-    "no-any-return",
-    "no-any-unimported",
 ]
 enable_error_code = [
     "abstract",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,9 +57,110 @@ asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 
 [tool.mypy]
+strict = true
 check_untyped_defs = true
 show_error_codes = true
 show_error_context = true
+warn_unreachable = true
+disallow_any_expr = false
+disallow_any_decorated = false
+disallow_any_explicit = false
+disallow_any_unimported = false
+disallow_untyped_globals = true
+warn_return_any = false
+disable_error_code = [
+    "explicit-any",
+    "no-any-return",
+    "no-any-unimported",
+]
+enable_error_code = [
+    "abstract",
+    "annotation-unchecked",
+    "arg-type",
+    "assert-type",
+    "assignment",
+    "attr-defined",
+    "await-not-async",
+    "call-arg",
+    "call-overload",
+    "comparison-overlap",
+    "deprecated",
+    "dict-item",
+    "empty-body",
+    "exhaustive-match",
+    "exit-return",
+    # "explicit-any",
+    # "explicit-override",
+    "func-returns-value",
+    "has-type",
+    "ignore-without-code",
+    "import",
+    "import-not-found",
+    "import-untyped",
+    "index",
+    "list-item",
+    "literal-required",
+    "maybe-unrecognized-str-typeform",
+    "metaclass",
+    "method-assign",
+    # "misc",
+    "mutable-override",
+    "name-defined",
+    "name-match",
+    "narrowed-type-not-subtype",
+    # "no-any-return",
+    # "no-any-unimported",
+    "no-overload-impl",
+    "no-redef",
+    "no-untyped-call",
+    "no-untyped-def",
+    "operator",
+    "overload-cannot-match",
+    "overload-overlap",
+    "override",
+    "possibly-undefined",
+    "prop-decorator",
+    "redundant-cast",
+    "redundant-expr",
+    "redundant-self",
+    "return",
+    "return-value",
+    "safe-super",
+    "str-bytes-safe",
+    "str-format",
+    "syntax",
+    "top-level-await",
+    "truthy-bool",
+    "truthy-function",
+    "truthy-iterable",
+    "type-abstract",
+    "type-arg",
+    "type-var",
+    "typeddict-item",
+    "typeddict-readonly-mutated",
+    "typeddict-unknown-key",
+    "unimported-reveal",
+    "union-attr",
+    "unreachable",
+    "untyped-decorator",
+    "unused-awaitable",
+    "unused-coroutine",
+    "unused-ignore",
+    "used-before-def",
+    "valid-newtype",
+    "valid-type",
+    "var-annotated",
+]
+
+[[tool.mypy.overrides]]
+module = ["tests.*"]
+disable_error_code = [
+    "no-untyped-call",
+    "no-untyped-def",
+    "redundant-expr",
+    "unreachable",
+    "untyped-decorator",
+]
 
 [tool.coverage.run]
 source = ["serialx"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ disallow_untyped_globals = true
 warn_return_any = false
 disable_error_code = [
     "explicit-any",
+    "mutable-override",
     "no-any-return",
     "no-any-unimported",
 ]
@@ -104,7 +105,7 @@ enable_error_code = [
     "metaclass",
     "method-assign",
     # "misc",
-    "mutable-override",
+    # "mutable-override",
     "name-defined",
     "name-match",
     "narrowed-type-not-subtype",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,13 +64,6 @@ show_error_context = true
 warn_unreachable = true
 disallow_any_expr = false
 disallow_any_decorated = false
-disallow_any_explicit = false
-disallow_any_unimported = false
-disallow_untyped_globals = true
-warn_return_any = false
-disable_error_code = [
-    "explicit-any",
-]
 enable_error_code = [
     "abstract",
     "annotation-unchecked",

--- a/serialx/__init__.py
+++ b/serialx/__init__.py
@@ -1,5 +1,7 @@
 """serialx serial port implementation."""
 
+from typing import Any
+
 from .async_serial import (
     SerialStreamWriter,
     create_serial_connection,
@@ -62,7 +64,7 @@ __all__ = [
 ]
 
 
-def serial_for_url(url, *args, **kwargs) -> BaseSerial:
+def serial_for_url(url: str, *args: Any, **kwargs: Any) -> BaseSerial:
     """Create a serial port for the given URL."""
     serial_cls, _serial_transport = get_serial_classes(url)
     return serial_cls(url, *args, **kwargs)

--- a/serialx/__init__.py
+++ b/serialx/__init__.py
@@ -1,7 +1,5 @@
 """serialx serial port implementation."""
 
-from typing import Any
-
 from .async_serial import (
     SerialStreamWriter,
     create_serial_connection,
@@ -33,11 +31,15 @@ from .compat import (
 )
 from .platforms import Serial, SerialTransport, list_serial_ports
 
+# Backwards compatibility export
+serial_for_url = Serial.from_url
+
 __all__ = [
     "create_serial_connection",
     "get_serial_classes",
     "list_serial_ports",
     "open_serial_connection",
+    "serial_for_url",
     "ModemPins",
     "Parity",
     "PinState",
@@ -62,9 +64,3 @@ __all__ = [
     "CR",
     "LF",
 ]
-
-
-def serial_for_url(url: str, *args: Any, **kwargs: Any) -> BaseSerial:
-    """Create a serial port for the given URL."""
-    serial_cls, _serial_transport = get_serial_classes(url)
-    return serial_cls(url, *args, **kwargs)

--- a/serialx/async_serial.py
+++ b/serialx/async_serial.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable
 import logging
-from typing import Generic, TypeVar
+from typing import Any, Generic, TypeVar, cast
 
 from .common import BaseSerialTransport, Parity, StopBits, get_serial_classes
 
@@ -18,24 +18,24 @@ class SerialStreamWriter(asyncio.StreamWriter, Generic[_T]):
     """StreamWriter with properly typed transport."""
 
     @property
-    def transport(self) -> _T:  # type: ignore[override]
+    def transport(self) -> _T:
         """Return the underlying transport."""
-        return super().transport  # type: ignore[return-value]
+        return cast(_T, super().transport)
 
 
 async def create_serial_connection(
-    loop,
+    loop: asyncio.AbstractEventLoop,
     protocol_factory: Callable[[], asyncio.Protocol],
     url: str | None,
     baudrate: int,
-    parity=Parity.NONE,
-    stopbits=StopBits.ONE,
-    xonxoff=False,
-    rtscts=False,
-    exclusive=True,
+    parity: Parity = Parity.NONE,
+    stopbits: StopBits = StopBits.ONE,
+    xonxoff: bool = False,
+    rtscts: bool = False,
+    exclusive: bool = True,
     *,
     transport_cls: type[BaseSerialTransport] | None = None,
-    **kwargs,
+    **kwargs: Any,
 ) -> tuple[BaseSerialTransport, asyncio.Protocol]:
     """Create a serial port connection with asyncio."""
     if not exclusive:
@@ -67,7 +67,7 @@ async def create_serial_connection(
 
 
 async def open_serial_connection(
-    *args, **kwargs
+    *args: Any, **kwargs: Any
 ) -> tuple[asyncio.StreamReader, SerialStreamWriter[BaseSerialTransport]]:
     """Open a serial port connection using StreamReader and StreamWriter."""
     loop = asyncio.get_running_loop()

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -12,6 +12,7 @@ from enum import Enum
 import io
 from pathlib import Path
 import time
+from types import TracebackType
 from typing import Any
 import urllib.parse
 import warnings
@@ -106,8 +107,8 @@ class ModemPins:
 @contextmanager
 def measure_time() -> Iterator[Callable[[], float]]:
     """Measure elapsed time in a context."""
-    start = time.monotonic()
-    end = None
+    start: float = time.monotonic()
+    end: float | None = None
 
     def get_result() -> float:
         if end is None:
@@ -416,7 +417,12 @@ class BaseSerial(io.RawIOBase):
         self.open()
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         """Exit context manager."""
         self.close()
 
@@ -630,7 +636,7 @@ class BaseSerialTransport(asyncio.Transport):
         return self._serial.exclusive
 
     @abstractmethod
-    async def _connect(self, **kwargs) -> None:
+    async def _connect(self, **kwargs: Any) -> None:
         """Connect to serial port."""
         raise NotImplementedError
 
@@ -644,7 +650,7 @@ class BaseSerialTransport(asyncio.Transport):
         xonxoff: bool = False,
         rtscts: bool = False,
         byte_size: int = 8,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         """Connect to serial port."""
         return await self._connect(

--- a/serialx/descriptor_transport.py
+++ b/serialx/descriptor_transport.py
@@ -7,7 +7,7 @@ from collections.abc import Coroutine
 import errno
 import logging
 import os
-import typing
+from typing import Any
 import warnings
 
 from .common import BaseSerialTransport
@@ -16,10 +16,10 @@ LOGGER = logging.getLogger(__name__)
 LOG_THRESHOLD_FOR_CONNLOST_WRITES = 5
 
 # Prevent tasks from being garbage collected.
-_BACKGROUND_TASKS: set[asyncio.Task] = set()
+_BACKGROUND_TASKS: set[asyncio.Task[None]] = set()
 
 
-def _create_background_task(coro: Coroutine) -> asyncio.Task[None]:
+def _create_background_task(coro: Coroutine[Any, Any, None]) -> asyncio.Task[None]:
     """Create a background task that will not be garbage collected."""
     task = asyncio.create_task(coro)
     _BACKGROUND_TASKS.add(task)
@@ -49,7 +49,7 @@ class DescriptorTransport(BaseSerialTransport):
         self,
         loop: asyncio.AbstractEventLoop,
         protocol: asyncio.Protocol,
-        extra: dict[str, typing.Any] | None = None,
+        extra: dict[str, Any] | None = None,
     ) -> None:
         """Initialize the descriptor transport."""
         super().__init__(loop, protocol)
@@ -61,14 +61,14 @@ class DescriptorTransport(BaseSerialTransport):
         self._buffer = bytearray()
         self._conn_lost_count = 0
         self._paused = False
-        self._empty_waiter: asyncio.Future | None = None
+        self._empty_waiter: asyncio.Future[None] | None = None
         if extra is not None:
             self._extra.update(extra)
 
         self._close_task: asyncio.Task[None] | None = None
         self._connection_made: bool = False
 
-    async def _open(self, path: os.PathLike) -> None:
+    async def _open(self, path: str | os.PathLike[str]) -> None:
         self._fileno = await self._loop.run_in_executor(
             None, os.open, path, os.O_RDWR | os.O_NOCTTY | os.O_NONBLOCK
         )
@@ -76,7 +76,7 @@ class DescriptorTransport(BaseSerialTransport):
         if self._closing:
             self._maybe_background_close(None)
 
-    async def _connect(self, **_kwargs) -> None:
+    async def _connect(self, **_kwargs: Any) -> None:
         assert self._fileno is not None
         self._loop.add_reader(self._fileno, self._read_ready)
         self._connection_made = True
@@ -165,7 +165,9 @@ class DescriptorTransport(BaseSerialTransport):
         """Get the write buffer low and high water limits."""
         return (self._low_water, self._high_water)
 
-    def _set_write_buffer_limits(self, high=None, low=None):
+    def _set_write_buffer_limits(
+        self, high: int | None = None, low: int | None = None
+    ) -> None:
         if high is None:
             if low is None:  # noqa: SIM108
                 high = 64 * 1024
@@ -180,7 +182,9 @@ class DescriptorTransport(BaseSerialTransport):
         self._high_water = high
         self._low_water = low
 
-    def set_write_buffer_limits(self, high=None, low=None) -> None:
+    def set_write_buffer_limits(
+        self, high: int | None = None, low: int | None = None
+    ) -> None:
         """Set the write buffer low and high water limits."""
         self._set_write_buffer_limits(high=high, low=low)
         self._maybe_pause_protocol()
@@ -189,7 +193,7 @@ class DescriptorTransport(BaseSerialTransport):
         """Get the number of bytes currently in the write buffer."""
         return len(self._buffer)
 
-    def _make_empty_waiter(self) -> asyncio.Future:
+    def _make_empty_waiter(self) -> asyncio.Future[None]:
         """Create a future that resolves when the write buffer is empty."""
         if self._empty_waiter is not None:
             raise RuntimeError("Empty waiter is already set")
@@ -202,7 +206,7 @@ class DescriptorTransport(BaseSerialTransport):
         """Reset the empty waiter."""
         self._empty_waiter = None
 
-    def write(self, data) -> None:
+    def write(self, data: bytes | bytearray | memoryview) -> None:
         """Write data to the file descriptor."""
         assert isinstance(data, (bytes, bytearray, memoryview)), repr(data)
         LOGGER.debug("Immediately writing %r", data)

--- a/serialx/platforms/serial_esphome.py
+++ b/serialx/platforms/serial_esphome.py
@@ -391,28 +391,25 @@ class ESPHomeSerialTransport(BaseSerialTransport):
         self._serial = ESPHomeSerial(loop=self._loop, **kwargs)
         self._extra["serial"] = self._serial
 
-        serial = self._serial
-        assert serial is not None
-        await serial._async_open()
-        serial.configure_port()
+        assert self._serial is not None
+        await self._serial._async_open()
+        self._serial.configure_port()
 
-        assert serial._api is not None
-        await serial._subscribe_instance()
-        self._unsub = serial._api.subscribe_serial_proxy_data(self._on_data)
+        assert self._serial._api is not None
+        await self._serial._subscribe_instance()
+        self._unsub = self._serial._api.subscribe_serial_proxy_data(self._on_data)
 
         self._protocol.connection_made(self)
 
     def _on_data(self, msg: SerialProxyDataReceived) -> None:
-        serial = self._serial
-        assert serial is not None
-        if msg.instance == serial._instance_id:
+        assert self._serial is not None
+        if msg.instance == self._serial._instance_id:
             self._protocol.data_received(msg.data)
 
     def write(self, data: bytes | bytearray | memoryview) -> None:
         """Write data to the serial proxy."""
-        serial = self._serial
-        assert serial is not None
-        serial.write(data)
+        assert self._serial is not None
+        self._serial.write(data)
 
     def is_closing(self) -> bool:
         """Return whether the transport is closing."""
@@ -428,13 +425,12 @@ class ESPHomeSerialTransport(BaseSerialTransport):
             self._unsub()
             self._unsub = None
 
-        serial = self._serial
-        assert serial is not None
-        serial._unsubscribe_instance()
+        assert self._serial is not None
+        self._serial._unsubscribe_instance()
 
-        if serial._disconnect_api:
-            api = serial._api
-            serial._api = None
+        if self._serial._disconnect_api:
+            api = self._serial._api
+            self._serial._api = None
             if api is not None:
                 self._close_task = self._loop.create_task(self._async_close(api))
             else:
@@ -455,15 +451,13 @@ class ESPHomeSerialTransport(BaseSerialTransport):
 
     async def flush(self) -> None:
         """Flush write buffers."""
-        serial = self._serial
-        assert serial is not None
-        await serial._async_flush()
+        assert self._serial is not None
+        await self._serial._async_flush()
 
     async def get_modem_pins(self) -> ModemPins:
         """Get modem control bits."""
-        serial = self._serial
-        assert serial is not None
-        return await serial._async_get_modem_pins()
+        assert self._serial is not None
+        return await self._serial._async_get_modem_pins()
 
     def get_write_buffer_size(self) -> int:
         """Get the number of bytes currently in the write buffer."""

--- a/serialx/platforms/serial_esphome.py
+++ b/serialx/platforms/serial_esphome.py
@@ -341,7 +341,7 @@ class ESPHomeSerial(BaseSerial):
             return 0
 
     async def _async_readinto(self, b: Buffer, timeout: float | None) -> int:
-        async with asyncio.timeout(timeout):
+        async with asyncio.timeout(timeout):  # type:ignore[unused-ignore,attr-defined]
             while not self._read_buffer:
                 self._read_event.clear()
                 await self._read_event.wait()

--- a/serialx/platforms/serial_esphome.py
+++ b/serialx/platforms/serial_esphome.py
@@ -9,7 +9,7 @@ from enum import IntFlag
 import functools
 import logging
 import threading
-from typing import Any, TypeVar, cast
+from typing import Any, ParamSpec, TypeVar, cast
 import urllib.parse
 
 import aioesphomeapi
@@ -33,7 +33,7 @@ from serialx.common import (
 )
 
 _T = TypeVar("_T")
-_F = TypeVar("_F", bound=Callable[..., Any])
+_P = ParamSpec("_P")
 
 LOGGER = logging.getLogger(__name__)
 
@@ -51,11 +51,13 @@ STOP_BITS_MAP = {
 }
 
 
-def translate_esphome_errors(func: _F) -> _F:
+def translate_esphome_errors(
+    func: Callable[_P, Coroutine[Any, Any, _T]],
+) -> Callable[_P, Coroutine[Any, Any, _T]]:
     """Translate aioesphomeapi errors into standard serialx exceptions."""
 
     @functools.wraps(func)
-    async def wrapper(*args, **kwargs):
+    async def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _T:
         try:
             return await func(*args, **kwargs)
         except TimeoutAPIError as exc:
@@ -63,7 +65,7 @@ def translate_esphome_errors(func: _F) -> _F:
         except APIConnectionError as exc:
             raise SerialException(str(exc)) from exc
 
-    return cast(_F, wrapper)
+    return cast(Callable[_P, Coroutine[Any, Any, _T]], wrapper)
 
 
 class LineStateFlag(IntFlag):
@@ -82,7 +84,7 @@ class ESPHomeSerial(BaseSerial):
 
     def __init__(
         self,
-        *args,
+        *args: Any,
         connect_timeout: float = 10.0,
         loop: asyncio.AbstractEventLoop | None = None,
         api: APIClient | None = None,
@@ -90,7 +92,7 @@ class ESPHomeSerial(BaseSerial):
         port_instance: int | None = None,
         password: str | None = None,
         noise_psk: str | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         """Initialize ESPHome serial port."""
         super().__init__(*args, **kwargs)
@@ -339,7 +341,7 @@ class ESPHomeSerial(BaseSerial):
             return 0
 
     async def _async_readinto(self, b: Buffer, timeout: float | None) -> int:
-        async with asyncio.timeout(timeout):  # type: ignore[attr-defined]
+        async with asyncio.timeout(timeout):
             while not self._read_buffer:
                 self._read_event.clear()
                 await self._read_event.wait()
@@ -374,7 +376,7 @@ class ESPHomeSerialTransport(BaseSerialTransport):
     """Serial transport over ESPHome serial proxy API."""
 
     transport_name = "esphome"
-    _serial: ESPHomeSerial
+    _serial: ESPHomeSerial | None
 
     def __init__(
         self, loop: asyncio.AbstractEventLoop, protocol: asyncio.Protocol
@@ -382,28 +384,35 @@ class ESPHomeSerialTransport(BaseSerialTransport):
         """Initialize the ESPHome serial transport."""
         super().__init__(loop, protocol)
         self._unsub: Callable[[], None] | None = None
+        self._close_task: asyncio.Task[None] | None = None
 
     @translate_esphome_errors
-    async def _connect(self, **kwargs) -> None:
+    async def _connect(self, **kwargs: Any) -> None:
         self._serial = ESPHomeSerial(loop=self._loop, **kwargs)
         self._extra["serial"] = self._serial
 
-        await self._serial._async_open()
-        self._serial.configure_port()
+        serial = self._serial
+        assert serial is not None
+        await serial._async_open()
+        serial.configure_port()
 
-        assert self._serial._api is not None
-        await self._serial._subscribe_instance()
-        self._unsub = self._serial._api.subscribe_serial_proxy_data(self._on_data)
+        assert serial._api is not None
+        await serial._subscribe_instance()
+        self._unsub = serial._api.subscribe_serial_proxy_data(self._on_data)
 
         self._protocol.connection_made(self)
 
     def _on_data(self, msg: SerialProxyDataReceived) -> None:
-        if msg.instance == self._serial._instance_id:
+        serial = self._serial
+        assert serial is not None
+        if msg.instance == serial._instance_id:
             self._protocol.data_received(msg.data)
 
     def write(self, data: bytes | bytearray | memoryview) -> None:
         """Write data to the serial proxy."""
-        self._serial.write(data)
+        serial = self._serial
+        assert serial is not None
+        serial.write(data)
 
     def is_closing(self) -> bool:
         """Return whether the transport is closing."""
@@ -419,12 +428,17 @@ class ESPHomeSerialTransport(BaseSerialTransport):
             self._unsub()
             self._unsub = None
 
-        self._serial._unsubscribe_instance()
+        serial = self._serial
+        assert serial is not None
+        serial._unsubscribe_instance()
 
-        if self._serial._disconnect_api:
-            api = self._serial._api
-            self._serial._api = None
-            self._loop.create_task(self._async_close(api))
+        if serial._disconnect_api:
+            api = serial._api
+            serial._api = None
+            if api is not None:
+                self._close_task = self._loop.create_task(self._async_close(api))
+            else:
+                self._call_protocol_connection_lost(None)
         else:
             self._call_protocol_connection_lost(None)
 
@@ -441,11 +455,15 @@ class ESPHomeSerialTransport(BaseSerialTransport):
 
     async def flush(self) -> None:
         """Flush write buffers."""
-        await self._serial._async_flush()
+        serial = self._serial
+        assert serial is not None
+        await serial._async_flush()
 
     async def get_modem_pins(self) -> ModemPins:
         """Get modem control bits."""
-        return await self._serial._async_get_modem_pins()
+        serial = self._serial
+        assert serial is not None
+        return await serial._async_get_modem_pins()
 
     def get_write_buffer_size(self) -> int:
         """Get the number of bytes currently in the write buffer."""

--- a/serialx/platforms/serial_linux.py
+++ b/serialx/platforms/serial_linux.py
@@ -11,6 +11,7 @@ import fcntl
 import logging
 from pathlib import Path
 import termios
+from typing import Any
 
 from ..common import Parity, SerialPortInfo, UnsupportedSetting
 from .serial_extended_posix import ExtendedPosixSerial, ExtendedPosixSerialTransport
@@ -43,23 +44,23 @@ NON_POSIX_FALLBACK_BAUDRATE_CONST = termios.B115200
 class TermiosStruct(ctypes.Structure):
     """The `termios` struct."""
 
-    _fields_ = [
+    _fields_ = (
         ("c_iflag", ctypes.c_uint32),
         ("c_oflag", ctypes.c_uint32),
         ("c_cflag", ctypes.c_uint32),
         ("c_lflag", ctypes.c_uint32),
         ("c_line", ctypes.c_uint8),
         ("c_cc", ctypes.c_uint8 * 64),  # NCCS is usually 19 bytes, let's be safe
-    ]
+    )
 
 
 class Termios2SpeedStruct(ctypes.Structure):
     """The extra `c_ispeed` and `c_ospeed` members at the end of `struct termios2`."""
 
-    _fields_ = [
+    _fields_ = (
         ("c_ispeed", ctypes.c_uint32),
         ("c_ospeed", ctypes.c_uint32),
-    ]
+    )
 
 
 class LinuxSerial(ExtendedPosixSerial):
@@ -67,10 +68,10 @@ class LinuxSerial(ExtendedPosixSerial):
 
     def __init__(
         self,
-        *args,
+        *args: Any,
         low_latency: bool = True,
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> None:
         """Initialize Linux serial port."""
         super().__init__(*args, **kwargs)
         self._low_latency = low_latency

--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -11,7 +11,7 @@ import select
 import sys
 import termios
 import time
-from typing import Any, NamedTuple
+from typing import Any, NamedTuple, cast
 
 if sys.version_info >= (3, 11):
     from asyncio import timeout as asyncio_timeout
@@ -204,13 +204,13 @@ class PosixSerial(BaseSerial):
 
     def _build_ispeed(self) -> int:
         try:
-            return getattr(termios, f"B{self._baudrate}")
+            return cast(int, getattr(termios, f"B{self._baudrate}"))
         except AttributeError as exc:
             raise UnsupportedSetting(f"Unsupported baudrate {self._baudrate}") from exc
 
     def _build_ospeed(self) -> int:
         try:
-            return getattr(termios, f"B{self._baudrate}")
+            return cast(int, getattr(termios, f"B{self._baudrate}"))
         except AttributeError as exc:
             raise UnsupportedSetting(f"Unsupported baudrate {self._baudrate}") from exc
 

--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -11,7 +11,7 @@ import select
 import sys
 import termios
 import time
-from typing import NamedTuple
+from typing import Any, NamedTuple
 
 if sys.version_info >= (3, 11):
     from asyncio import timeout as asyncio_timeout
@@ -95,12 +95,12 @@ class PosixSerial(BaseSerial):
 
     def __init__(
         self,
-        *args,
+        *args: Any,
         fileno: int | None = None,
         inter_byte_timeout: float = 0.01,
         min_read_size: int = 1,
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> None:
         """Initialize POSIX serial port."""
         super().__init__(*args, **kwargs)
         self._fileno: int | None = fileno
@@ -450,7 +450,7 @@ class PosixSerial(BaseSerial):
             if not ready:
                 raise TimeoutError("Write timeout")
 
-        return os.write(self._fileno, data)  # type: ignore[arg-type]
+        return os.write(self._fileno, data)
 
     def num_unread_bytes(self) -> int:
         """Return the number of bytes waiting to be read."""
@@ -484,15 +484,18 @@ class PosixSerial(BaseSerial):
 class PosixSerialTransport(DescriptorTransport):
     """POSIX serial port transport using asyncio."""
 
-    _serial_cls = PosixSerial
+    _serial_cls: type[PosixSerial] = PosixSerial
 
-    async def _connect(self, *, path: os.PathLike, **kwargs) -> None:  # type: ignore[override]
+    async def _connect(  # type: ignore[override]
+        self, *, path: str | os.PathLike[str], **kwargs: Any
+    ) -> None:
         """Connect to serial port."""
-        await super()._open(path)
+        normalized_path = str(path)
+        await super()._open(normalized_path)
 
         self._serial = self._serial_cls(
             **kwargs,
-            path=path,
+            path=normalized_path,
             # `DescriptorTransport` opened the port
             fileno=self._fileno,
             # Nonblocking mode

--- a/serialx/platforms/serial_rfc2217/__init__.py
+++ b/serialx/platforms/serial_rfc2217/__init__.py
@@ -719,17 +719,17 @@ class RFC2217SerialTransport(BaseSerialTransport):
     ) -> None:
         """Connect to the RFC 2217 server and negotiate COM-PORT-OPTION."""
         self._serial = RFC2217Serial(**kwargs)
+        assert self._serial is not None
+
         self._extra["serial"] = self._serial
-        serial = self._serial
-        assert serial is not None
 
         self._tcp_connection_lost_waiter = self._loop.create_future()
 
-        async with asyncio_timeout(serial._connect_timeout):
+        async with asyncio_timeout(self._serial._connect_timeout):
             tcp_transport, _ = await self._loop.create_connection(
                 lambda: _RFC2217ProxyProtocol(self),
-                host=serial._host,
-                port=serial._port,
+                host=self._serial._host,
+                port=self._serial._port,
             )
             self._tcp_transport = tcp_transport
 
@@ -780,34 +780,32 @@ class RFC2217SerialTransport(BaseSerialTransport):
         if isinstance(rsp, DontCmd):
             raise SerialException("Server refused COM-PORT-OPTION")
 
-        serial = self._serial
-        assert serial is not None
-        serial._engine.mark_negotiated()
+        assert self._serial is not None
+        self._serial._engine.mark_negotiated()
         LOGGER.debug("Negotiation complete: server accepted COM-PORT-OPTION")
 
     async def _configure_port(self) -> None:
         """Send serial port configuration to the access server."""
-        serial = self._serial
-        assert serial is not None
+        assert self._serial is not None
 
         LOGGER.debug(
             "Configuring port: baudrate=%d byte_size=%d parity=%s stopbits=%s "
             "rtscts=%s xonxoff=%s",
-            serial._baudrate,
-            serial._byte_size,
-            serial._parity,
-            serial._stopbits,
-            serial._rtscts,
-            serial._xonxoff,
+            self._serial._baudrate,
+            self._serial._byte_size,
+            self._serial._parity,
+            self._serial._stopbits,
+            self._serial._rtscts,
+            self._serial._xonxoff,
         )
 
-        for cmd in serial._engine.build_port_config_commands(
-            baudrate=serial._baudrate,
-            byte_size=serial._byte_size,
-            parity=serial._parity,
-            stopbits=serial._stopbits,
-            rtscts=serial._rtscts,
-            xonxoff=serial._xonxoff,
+        for cmd in self._serial._engine.build_port_config_commands(
+            baudrate=self._serial._baudrate,
+            byte_size=self._serial._byte_size,
+            parity=self._serial._parity,
+            stopbits=self._serial._stopbits,
+            rtscts=self._serial._rtscts,
+            xonxoff=self._serial._xonxoff,
         ):
             await self._send_and_wait(cmd)
 
@@ -847,9 +845,8 @@ class RFC2217SerialTransport(BaseSerialTransport):
             return None
 
         # Check if already pending
-        serial = self._serial
-        assert serial is not None
-        match = serial._engine.pop_matching_telnet(responses)
+        assert self._serial is not None
+        match = self._serial._engine.pop_matching_telnet(responses)
         if match is not None:
             fut: asyncio.Future[TelnetCommand] = self._loop.create_future()
             fut.set_result(match)
@@ -862,9 +859,8 @@ class RFC2217SerialTransport(BaseSerialTransport):
     def _data_received(self, data: bytes) -> None:
         """Handle raw data from the TCP transport."""
         LOGGER.debug("RX raw: %d bytes  [%s]", len(data), data.hex(" "))
-        serial = self._serial
-        assert serial is not None
-        serial_data, responses = serial._engine.feed(data)
+        assert self._serial is not None
+        serial_data, responses = self._serial._engine.feed(data)
         self._resolve_pending_waiters()
 
         for response in responses:
@@ -876,9 +872,8 @@ class RFC2217SerialTransport(BaseSerialTransport):
     async def _send_and_wait(self, cmd: Rfc2217Command) -> Rfc2217Command:
         """Send a command and wait for the matching server ack."""
         waiter: asyncio.Future[Rfc2217Command] = self._loop.create_future()
-        serial = self._serial
-        assert serial is not None
-        pending = serial._engine.pop_pending_rfc2217(cmd.CMD_ID)
+        assert self._serial is not None
+        pending = self._serial._engine.pop_pending_rfc2217(cmd.CMD_ID)
         if pending is not None:
             self._send_command(cmd)
             LOGGER.debug("RX ack (already pending): %r", pending)
@@ -905,23 +900,20 @@ class RFC2217SerialTransport(BaseSerialTransport):
 
     async def get_modem_pins(self) -> ModemPins:
         """Return modem pin state from the last NOTIFY-MODEMSTATE."""
-        serial = self._serial
-        assert serial is not None
-        return serial._engine.get_modem_pins()
+        assert self._serial is not None
+        return self._serial._engine.get_modem_pins()
 
     async def _set_modem_pins(self, modem_pins: ModemPins) -> None:
         """Set DTR/RTS via SET_CONTROL commands."""
         LOGGER.debug("Setting modem pins: %r", modem_pins)
-        serial = self._serial
-        assert serial is not None
+        assert self._serial is not None
 
-        for cmd in serial._engine.build_modem_pin_commands(modem_pins):
+        for cmd in self._serial._engine.build_modem_pin_commands(modem_pins):
             await self._send_and_wait(cmd)
 
     def _resolve_pending_waiters(self) -> None:
         """Resolve any async waiters whose commands have now been parsed."""
-        serial = self._serial
-        assert serial is not None
+        assert self._serial is not None
 
         remaining: list[tuple[list[TelnetCommand], asyncio.Future[TelnetCommand]]] = []
 
@@ -929,7 +921,7 @@ class RFC2217SerialTransport(BaseSerialTransport):
             if waiter.done():
                 continue
 
-            match = serial._engine.pop_matching_telnet(expected)
+            match = self._serial._engine.pop_matching_telnet(expected)
             if match is not None:
                 waiter.set_result(match)
             else:
@@ -942,7 +934,7 @@ class RFC2217SerialTransport(BaseSerialTransport):
                 self._rfc2217_waiters.pop(rfc_cmd_id, None)
                 continue
 
-            rfc_pending = serial._engine.pop_pending_rfc2217(rfc_cmd_id)
+            rfc_pending = self._serial._engine.pop_pending_rfc2217(rfc_cmd_id)
             if rfc_pending is not None:
                 self._rfc2217_waiters.pop(rfc_cmd_id, None)
                 rfc_waiter.set_result(rfc_pending)
@@ -976,9 +968,8 @@ class RFC2217SerialTransport(BaseSerialTransport):
                 rfc2217_waiter.set_exception(waiter_exc)
         self._rfc2217_waiters.clear()
 
-        serial = self._serial
-        if serial is not None:
-            serial._engine.reset()
+        if self._serial is not None:
+            self._serial._engine.reset()
 
         self._call_protocol_connection_lost(exc)
 

--- a/serialx/platforms/serial_rfc2217/__init__.py
+++ b/serialx/platforms/serial_rfc2217/__init__.py
@@ -14,7 +14,7 @@ if sys.version_info >= (3, 11):
 else:
     from async_timeout import timeout as asyncio_timeout
 
-from typing import overload
+from typing import Any, overload
 
 from typing_extensions import Buffer
 
@@ -207,9 +207,15 @@ class TelnetParser:
         if cmd_code >= 100:
             cmd_code -= 100
 
-        cmd_cls = CMD_ID_TO_CLASS.get(cmd_code)
-        if cmd_cls is None:
+        try:
+            cmd_id = Rfc2217CmdId(cmd_code)
+        except ValueError:
             LOGGER.debug("Unknown RFC 2217 command code: %d", cmd_code)
+            return None
+
+        cmd_cls = CMD_ID_TO_CLASS.get(cmd_id)
+        if cmd_cls is None:
+            LOGGER.debug("Unknown RFC 2217 command code: %d", cmd_id)
             return None
 
         cmd = cmd_cls.from_bytes(cmd_payload)
@@ -392,10 +398,10 @@ class RFC2217Serial(SocketSerial):
 
     def __init__(
         self,
-        *args,
+        *args: Any,
         receive_buffer_size: int = 4096,
         connect_timeout: float = 5.0,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         """Initialize the RFC 2217 serial port."""
         super().__init__(*args, **kwargs)
@@ -689,7 +695,7 @@ class RFC2217SerialTransport(BaseSerialTransport):
     """Async RFC 2217 serial transport over TCP."""
 
     transport_name = "rfc2217"
-    _serial: RFC2217Serial
+    _serial: RFC2217Serial | None
 
     def __init__(
         self, loop: asyncio.AbstractEventLoop, protocol: asyncio.Protocol
@@ -707,21 +713,23 @@ class RFC2217SerialTransport(BaseSerialTransport):
 
     # -- connection lifecycle -----------------------------------------------
 
-    async def _connect(  # type: ignore[override]
+    async def _connect(
         self,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         """Connect to the RFC 2217 server and negotiate COM-PORT-OPTION."""
         self._serial = RFC2217Serial(**kwargs)
         self._extra["serial"] = self._serial
+        serial = self._serial
+        assert serial is not None
 
         self._tcp_connection_lost_waiter = self._loop.create_future()
 
-        async with asyncio_timeout(self._serial._connect_timeout):
+        async with asyncio_timeout(serial._connect_timeout):
             tcp_transport, _ = await self._loop.create_connection(
                 lambda: _RFC2217ProxyProtocol(self),
-                host=self._serial._host,
-                port=self._serial._port,
+                host=serial._host,
+                port=serial._port,
             )
             self._tcp_transport = tcp_transport
 
@@ -772,12 +780,15 @@ class RFC2217SerialTransport(BaseSerialTransport):
         if isinstance(rsp, DontCmd):
             raise SerialException("Server refused COM-PORT-OPTION")
 
-        self._serial._engine.mark_negotiated()
+        serial = self._serial
+        assert serial is not None
+        serial._engine.mark_negotiated()
         LOGGER.debug("Negotiation complete: server accepted COM-PORT-OPTION")
 
     async def _configure_port(self) -> None:
         """Send serial port configuration to the access server."""
         serial = self._serial
+        assert serial is not None
 
         LOGGER.debug(
             "Configuring port: baudrate=%d byte_size=%d parity=%s stopbits=%s "
@@ -836,7 +847,9 @@ class RFC2217SerialTransport(BaseSerialTransport):
             return None
 
         # Check if already pending
-        match = self._serial._engine.pop_matching_telnet(responses)
+        serial = self._serial
+        assert serial is not None
+        match = serial._engine.pop_matching_telnet(responses)
         if match is not None:
             fut: asyncio.Future[TelnetCommand] = self._loop.create_future()
             fut.set_result(match)
@@ -849,7 +862,9 @@ class RFC2217SerialTransport(BaseSerialTransport):
     def _data_received(self, data: bytes) -> None:
         """Handle raw data from the TCP transport."""
         LOGGER.debug("RX raw: %d bytes  [%s]", len(data), data.hex(" "))
-        serial_data, responses = self._serial._engine.feed(data)
+        serial = self._serial
+        assert serial is not None
+        serial_data, responses = serial._engine.feed(data)
         self._resolve_pending_waiters()
 
         for response in responses:
@@ -861,7 +876,9 @@ class RFC2217SerialTransport(BaseSerialTransport):
     async def _send_and_wait(self, cmd: Rfc2217Command) -> Rfc2217Command:
         """Send a command and wait for the matching server ack."""
         waiter: asyncio.Future[Rfc2217Command] = self._loop.create_future()
-        pending = self._serial._engine.pop_pending_rfc2217(cmd.CMD_ID)
+        serial = self._serial
+        assert serial is not None
+        pending = serial._engine.pop_pending_rfc2217(cmd.CMD_ID)
         if pending is not None:
             self._send_command(cmd)
             LOGGER.debug("RX ack (already pending): %r", pending)
@@ -888,24 +905,31 @@ class RFC2217SerialTransport(BaseSerialTransport):
 
     async def get_modem_pins(self) -> ModemPins:
         """Return modem pin state from the last NOTIFY-MODEMSTATE."""
-        return self._serial._engine.get_modem_pins()
+        serial = self._serial
+        assert serial is not None
+        return serial._engine.get_modem_pins()
 
     async def _set_modem_pins(self, modem_pins: ModemPins) -> None:
         """Set DTR/RTS via SET_CONTROL commands."""
         LOGGER.debug("Setting modem pins: %r", modem_pins)
+        serial = self._serial
+        assert serial is not None
 
-        for cmd in self._serial._engine.build_modem_pin_commands(modem_pins):
+        for cmd in serial._engine.build_modem_pin_commands(modem_pins):
             await self._send_and_wait(cmd)
 
     def _resolve_pending_waiters(self) -> None:
         """Resolve any async waiters whose commands have now been parsed."""
+        serial = self._serial
+        assert serial is not None
+
         remaining: list[tuple[list[TelnetCommand], asyncio.Future[TelnetCommand]]] = []
 
         for expected, waiter in self._telnet_waiters:
             if waiter.done():
                 continue
 
-            match = self._serial._engine.pop_matching_telnet(expected)
+            match = serial._engine.pop_matching_telnet(expected)
             if match is not None:
                 waiter.set_result(match)
             else:
@@ -918,7 +942,7 @@ class RFC2217SerialTransport(BaseSerialTransport):
                 self._rfc2217_waiters.pop(rfc_cmd_id, None)
                 continue
 
-            rfc_pending = self._serial._engine.pop_pending_rfc2217(rfc_cmd_id)
+            rfc_pending = serial._engine.pop_pending_rfc2217(rfc_cmd_id)
             if rfc_pending is not None:
                 self._rfc2217_waiters.pop(rfc_cmd_id, None)
                 rfc_waiter.set_result(rfc_pending)
@@ -952,7 +976,9 @@ class RFC2217SerialTransport(BaseSerialTransport):
                 rfc2217_waiter.set_exception(waiter_exc)
         self._rfc2217_waiters.clear()
 
-        self._serial._engine.reset()
+        serial = self._serial
+        if serial is not None:
+            serial._engine.reset()
 
         self._call_protocol_connection_lost(exc)
 
@@ -1005,7 +1031,9 @@ class RFC2217SerialTransport(BaseSerialTransport):
 
         return self._tcp_transport.get_write_buffer_limits()
 
-    def set_write_buffer_limits(self, high=None, low=None) -> None:
+    def set_write_buffer_limits(
+        self, high: int | None = None, low: int | None = None
+    ) -> None:
         """Set the write buffer low and high water marks."""
         if self._tcp_transport is None:
             raise RuntimeError("Transport not connected")

--- a/serialx/platforms/serial_rfc2217/types.py
+++ b/serialx/platforms/serial_rfc2217/types.py
@@ -206,28 +206,28 @@ class TelnetOptionCommand(TelnetCommand, ABC):
 class WillCmd(TelnetOptionCommand):
     """IAC WILL <option> — offer to perform an option."""
 
-    CMD_ID = TelnetCmdId.WILL
+    CMD_ID: ClassVar[TelnetCmdId] = TelnetCmdId.WILL
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class WontCmd(TelnetOptionCommand):
     """IAC WONT <option> — refuse to perform an option."""  # codespell:ignore wont
 
-    CMD_ID = TelnetCmdId.WONT  # codespell:ignore wont
+    CMD_ID: ClassVar[TelnetCmdId] = TelnetCmdId.WONT  # codespell:ignore wont
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class DoCmd(TelnetOptionCommand):
     """IAC DO <option> — request the other side perform an option."""
 
-    CMD_ID = TelnetCmdId.DO
+    CMD_ID: ClassVar[TelnetCmdId] = TelnetCmdId.DO
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class DontCmd(TelnetOptionCommand):
     """IAC DONT <option> — demand the other side stop performing an option."""
 
-    CMD_ID = TelnetCmdId.DONT
+    CMD_ID: ClassVar[TelnetCmdId] = TelnetCmdId.DONT
 
 
 # ---------------------------------------------------------------------------
@@ -245,7 +245,7 @@ class Rfc2217Command(BaseCommand):
 class SignatureCmd(Rfc2217Command):
     """Exchange signature/identity strings. Empty = request."""
 
-    CMD_ID = Rfc2217CmdId.SIGNATURE
+    CMD_ID: ClassVar[Rfc2217CmdId] = Rfc2217CmdId.SIGNATURE
     signature: bytes = b""
 
     def to_bytes(self) -> bytes:
@@ -262,7 +262,7 @@ class SignatureCmd(Rfc2217Command):
 class SetBaudrateCmd(Rfc2217Command):
     """Set baud rate. 0 = query current value."""
 
-    CMD_ID = Rfc2217CmdId.SET_BAUDRATE
+    CMD_ID: ClassVar[Rfc2217CmdId] = Rfc2217CmdId.SET_BAUDRATE
     baudrate: int
 
     def to_bytes(self) -> bytes:
@@ -279,7 +279,7 @@ class SetBaudrateCmd(Rfc2217Command):
 class SetDatasizeCmd(Rfc2217Command):
     """Set data bit size. 0 = query, 5-8 = actual size."""
 
-    CMD_ID = Rfc2217CmdId.SET_DATASIZE
+    CMD_ID: ClassVar[Rfc2217CmdId] = Rfc2217CmdId.SET_DATASIZE
     size: int
 
     def to_bytes(self) -> bytes:
@@ -296,7 +296,7 @@ class SetDatasizeCmd(Rfc2217Command):
 class SetParityCmd(Rfc2217Command):
     """Set parity."""
 
-    CMD_ID = Rfc2217CmdId.SET_PARITY
+    CMD_ID: ClassVar[Rfc2217CmdId] = Rfc2217CmdId.SET_PARITY
     parity: Rfc2217Parity
 
     def to_bytes(self) -> bytes:
@@ -313,7 +313,7 @@ class SetParityCmd(Rfc2217Command):
 class SetStopsizeCmd(Rfc2217Command):
     """Set stop bits."""
 
-    CMD_ID = Rfc2217CmdId.SET_STOPSIZE
+    CMD_ID: ClassVar[Rfc2217CmdId] = Rfc2217CmdId.SET_STOPSIZE
     size: Rfc2217StopSize
 
     def to_bytes(self) -> bytes:
@@ -330,7 +330,7 @@ class SetStopsizeCmd(Rfc2217Command):
 class SetControlCmd(Rfc2217Command):
     """Set flow control, break, DTR, or RTS."""
 
-    CMD_ID = Rfc2217CmdId.SET_CONTROL
+    CMD_ID: ClassVar[Rfc2217CmdId] = Rfc2217CmdId.SET_CONTROL
     control: ControlCmdId
 
     def to_bytes(self) -> bytes:
@@ -347,7 +347,7 @@ class SetControlCmd(Rfc2217Command):
 class NotifyLinestateCmd(Rfc2217Command):
     """Server notification of UART line state change."""
 
-    CMD_ID = Rfc2217CmdId.NOTIFY_LINESTATE
+    CMD_ID: ClassVar[Rfc2217CmdId] = Rfc2217CmdId.NOTIFY_LINESTATE
     linestate: LineStateFlag
 
     def to_bytes(self) -> bytes:
@@ -364,7 +364,7 @@ class NotifyLinestateCmd(Rfc2217Command):
 class NotifyModemstateCmd(Rfc2217Command):
     """Server notification of modem state change."""
 
-    CMD_ID = Rfc2217CmdId.NOTIFY_MODEMSTATE
+    CMD_ID: ClassVar[Rfc2217CmdId] = Rfc2217CmdId.NOTIFY_MODEMSTATE
     modemstate: ModemStateFlag
 
     def to_bytes(self) -> bytes:
@@ -381,7 +381,7 @@ class NotifyModemstateCmd(Rfc2217Command):
 class FlowcontrolSuspendCmd(Rfc2217Command):
     """Request the receiver suspend transmission."""
 
-    CMD_ID = Rfc2217CmdId.FLOWCONTROL_SUSPEND
+    CMD_ID: ClassVar[Rfc2217CmdId] = Rfc2217CmdId.FLOWCONTROL_SUSPEND
 
     def to_bytes(self) -> bytes:
         """Serialize to bytes."""
@@ -397,7 +397,7 @@ class FlowcontrolSuspendCmd(Rfc2217Command):
 class FlowcontrolResumeCmd(Rfc2217Command):
     """Request the receiver resume transmission."""
 
-    CMD_ID = Rfc2217CmdId.FLOWCONTROL_RESUME
+    CMD_ID: ClassVar[Rfc2217CmdId] = Rfc2217CmdId.FLOWCONTROL_RESUME
 
     def to_bytes(self) -> bytes:
         """Serialize to bytes."""
@@ -413,7 +413,7 @@ class FlowcontrolResumeCmd(Rfc2217Command):
 class SetLinestateMaskCmd(Rfc2217Command):
     """Set which line state changes trigger NOTIFY_LINESTATE. Default: 0."""
 
-    CMD_ID = Rfc2217CmdId.SET_LINESTATE_MASK
+    CMD_ID: ClassVar[Rfc2217CmdId] = Rfc2217CmdId.SET_LINESTATE_MASK
     mask: LineStateFlag
 
     def to_bytes(self) -> bytes:
@@ -430,7 +430,7 @@ class SetLinestateMaskCmd(Rfc2217Command):
 class SetModemstateMaskCmd(Rfc2217Command):
     """Set which modem state changes trigger NOTIFY_MODEMSTATE. Default: 255."""
 
-    CMD_ID = Rfc2217CmdId.SET_MODEMSTATE_MASK
+    CMD_ID: ClassVar[Rfc2217CmdId] = Rfc2217CmdId.SET_MODEMSTATE_MASK
     mask: ModemStateFlag
 
     def to_bytes(self) -> bytes:
@@ -447,7 +447,7 @@ class SetModemstateMaskCmd(Rfc2217Command):
 class PurgeDataCmd(Rfc2217Command):
     """Purge access server data buffers."""
 
-    CMD_ID = Rfc2217CmdId.PURGE_DATA
+    CMD_ID: ClassVar[Rfc2217CmdId] = Rfc2217CmdId.PURGE_DATA
     what: PurgeDataValue
 
     def to_bytes(self) -> bytes:
@@ -460,7 +460,7 @@ class PurgeDataCmd(Rfc2217Command):
         return cls(what=PurgeDataValue(payload[0]))
 
 
-CMD_ID_TO_CLASS: dict[int, type[Rfc2217Command]] = {
+CMD_ID_TO_CLASS: dict[Rfc2217CmdId, type[Rfc2217Command]] = {
     cls.CMD_ID: cls
     for cls in (
         SignatureCmd,

--- a/serialx/platforms/serial_socket.py
+++ b/serialx/platforms/serial_socket.py
@@ -7,6 +7,7 @@ from collections.abc import Generator
 from contextlib import contextmanager
 import logging
 import socket
+from typing import Any
 import urllib.parse
 
 from typing_extensions import Buffer
@@ -21,10 +22,10 @@ class SocketSerial(BaseSerial):
 
     def __init__(
         self,
-        *args,
+        *args: Any,
         # Socket-specific kwargs
         connect_timeout: float | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         """Initialize socket serial port."""
         super().__init__(*args, **kwargs)
@@ -189,7 +190,6 @@ class SocketSerialTransport(BaseSerialTransport):
     """Serial transport over a TCP socket."""
 
     transport_name = "socket"
-    _serial: SocketSerial
 
     def __init__(
         self, loop: asyncio.AbstractEventLoop, protocol: asyncio.Protocol
@@ -210,7 +210,7 @@ class SocketSerialTransport(BaseSerialTransport):
         xonxoff: bool = False,
         rtscts: bool = False,
         byte_size: int = 8,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         self._serial = SocketSerial(
             path=path,
@@ -328,7 +328,9 @@ class SocketSerialTransport(BaseSerialTransport):
 
         return self._tcp_transport.get_write_buffer_limits()
 
-    def set_write_buffer_limits(self, high=None, low=None) -> None:
+    def set_write_buffer_limits(
+        self, high: int | None = None, low: int | None = None
+    ) -> None:
         """Set the write buffer low and high water marks."""
         if self._tcp_transport is None:
             raise RuntimeError("Transport not connected")

--- a/serialx/platforms/serial_win32.py
+++ b/serialx/platforms/serial_win32.py
@@ -102,7 +102,7 @@ WIN32_STOPBITS_MAP = {
 }
 
 
-def _normalize_windows_port_path(path: os.PathLike | str) -> str:
+def _normalize_windows_port_path(path: os.PathLike[str] | str) -> str:
     """Normalize a Windows serial device path for CreateFile."""
     path = str(path)
 
@@ -113,7 +113,7 @@ def _normalize_windows_port_path(path: os.PathLike | str) -> str:
     return path
 
 
-def _safe_close_handle(handle) -> None:
+def _safe_close_handle(handle: Any) -> None:
     """Close a Win32 handle, suppressing and logging errors."""
     try:
         CloseHandle(handle)
@@ -126,13 +126,13 @@ class Win32Serial(BaseSerial):
 
     def __init__(
         self,
-        *args,
+        *args: Any,
         handle: int | None = None,
         inter_byte_timeout: float = 0.01,
         read_buffer_size: int = 4096,
         write_buffer_size: int = 4096,
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> None:
         """Initialize the Windows serial port."""
         super().__init__(*args, **kwargs)
         self._handle = handle
@@ -264,7 +264,7 @@ class Win32Serial(BaseSerial):
         assert self._handle is not None
         return int(self._handle)
 
-    def _close(self):
+    def _close(self) -> None:
         """Close the serial port and release all handles."""
         if self._handle is not None:
             # Windows has no way to automatically do this on close, we do it manually
@@ -433,11 +433,12 @@ class Win32SerialTransport(BaseSerialTransport):
         super().__init__(loop, protocol)
 
         self._handle: int | None = None
-        self._internal_transport = None
+        self._internal_transport: Any | None = None
+        self._close_future: asyncio.Future[None] | None = None
         self._closing: bool = False
         self._connect_in_progress: bool = False
 
-    def serial_close(self):
+    def serial_close(self) -> None:
         """Close the serial port."""
 
         def _close_then_notify() -> None:
@@ -451,9 +452,9 @@ class Win32SerialTransport(BaseSerialTransport):
 
             self._loop.call_soon_threadsafe(self._call_protocol_connection_lost, exc)
 
-        self._loop.run_in_executor(None, _close_then_notify)
+        self._close_future = self._loop.run_in_executor(None, _close_then_notify)
 
-    def serial_shutdown(self, how) -> None:
+    def serial_shutdown(self, how: Any) -> None:
         """Shutdown the serial connection."""
         # Intentionally ignored
 
@@ -484,7 +485,7 @@ class Win32SerialTransport(BaseSerialTransport):
         """Forward resume_writing to the protocol."""
         self._protocol.resume_writing()
 
-    async def _open(self, path: os.PathLike) -> None:
+    async def _open(self, path: str | os.PathLike[str]) -> None:
         """Open the serial port."""
         normalized_path = _normalize_windows_port_path(path)
         self._handle = await self._loop.run_in_executor(
@@ -500,14 +501,16 @@ class Win32SerialTransport(BaseSerialTransport):
             ),
         )
 
-    async def _connect(self, **kwargs) -> None:
+    async def _connect(self, **kwargs: Any) -> None:
         """Connect to the serial port."""
         if self._closing:
             self._resolve_closed_waiter()
             return
 
         self._connect_in_progress = True
-        path = kwargs.pop("path")
+        path = kwargs.pop("path", None)
+        if path is None:
+            raise ValueError("A serial path is required")
         await self._open(path)
 
         try:
@@ -528,7 +531,7 @@ class Win32SerialTransport(BaseSerialTransport):
             await self._loop.run_in_executor(None, self._serial.configure_port)
 
             if self._closing:
-                await self._loop.run_in_executor(None, self._serial.close)
+                await self._loop.run_in_executor(None, self._serial.close)  # type: ignore[unreachable]
                 self._serial = None
                 self._handle = None
                 self._resolve_closed_waiter()
@@ -560,7 +563,7 @@ class Win32SerialTransport(BaseSerialTransport):
                 extra=self._extra,
             )
             if self._closing:
-                self._internal_transport.close()
+                self._internal_transport.close()  # type: ignore[unreachable]
         except BaseException:
             await self._loop.run_in_executor(None, _safe_close_handle, self._handle)
             self._serial = None
@@ -583,14 +586,16 @@ class Win32SerialTransport(BaseSerialTransport):
 
         return self._internal_transport.get_write_buffer_limits()
 
-    def set_write_buffer_limits(self, high=None, low=None) -> None:
+    def set_write_buffer_limits(
+        self, high: int | None = None, low: int | None = None
+    ) -> None:
         """Set the write buffer limits."""
         if self._internal_transport is None:
             raise RuntimeError("Transport not connected")
 
         self._internal_transport.set_write_buffer_limits(high=high, low=low)
 
-    def write(self, data):
+    def write(self, data: bytes | bytearray | memoryview) -> None:
         """Write data to the transport."""
         if self._internal_transport is None:
             raise RuntimeError("Transport not connected")
@@ -614,12 +619,12 @@ class Win32SerialTransport(BaseSerialTransport):
         elif not self._connect_in_progress:
             self._resolve_closed_waiter()
 
-    def pause_reading(self):
+    def pause_reading(self) -> None:
         """Pause reading from the transport."""
         if self._internal_transport is not None:
             self._internal_transport.pause_reading()
 
-    def resume_reading(self):
+    def resume_reading(self) -> None:
         """Resume reading from the transport."""
         if self._internal_transport is not None:
             self._internal_transport.resume_reading()

--- a/serialx/platforms/serial_win32.py
+++ b/serialx/platforms/serial_win32.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 import pywintypes
 from typing_extensions import Buffer
@@ -73,6 +73,9 @@ from ..common import (
     StopBits,
 )
 
+if TYPE_CHECKING:
+    from _win32typing import PyOVERLAPPED
+
 # Constants missing from win32con
 MS_CTS_ON = 0x0010
 MS_DSR_ON = 0x0020
@@ -139,8 +142,8 @@ class Win32Serial(BaseSerial):
         self._inter_byte_timeout = inter_byte_timeout
         self._read_buffer_size = read_buffer_size
         self._write_buffer_size = write_buffer_size
-        self._overlapped_read: OVERLAPPED | None = None
-        self._overlapped_write: OVERLAPPED | None = None
+        self._overlapped_read: PyOVERLAPPED | None = None
+        self._overlapped_write: PyOVERLAPPED | None = None
 
     def _open(self) -> None:
         """Open the serial port."""
@@ -155,7 +158,7 @@ class Win32Serial(BaseSerial):
         share_mode = 0 if self._exclusive else FILE_SHARE_READ | FILE_SHARE_WRITE
 
         try:
-            self._handle = CreateFile(
+            handle = CreateFile(
                 path,
                 GENERIC_READ | GENERIC_WRITE,
                 share_mode,
@@ -164,6 +167,8 @@ class Win32Serial(BaseSerial):
                 FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OVERLAPPED,
                 None,
             )
+
+            self._handle = cast(int, handle)
         except pywintypes.error as e:
             raise OSError(e.winerror, e.strerror, path) from e
 
@@ -181,6 +186,8 @@ class Win32Serial(BaseSerial):
 
     def _configure_port(self) -> None:
         """Configure the serial port settings."""
+        assert self._handle is not None
+
         try:
             interval = int(1000 * self._inter_byte_timeout)
             if interval <= 0 and self._inter_byte_timeout > 0:
@@ -210,7 +217,7 @@ class Win32Serial(BaseSerial):
             )
 
             # Configure DCB (Device Control Block)
-            dcb = GetCommState(self._handle)
+            dcb = cast(Any, GetCommState(self._handle))  # TODO: fix in typeshed
             dcb.BaudRate = self._baudrate
             dcb.ByteSize = self._byte_size
             dcb.StopBits = WIN32_STOPBITS_MAP[self._stopbits]
@@ -296,6 +303,8 @@ class Win32Serial(BaseSerial):
 
     def _get_modem_pins(self) -> ModemPins:
         """Get the current modem control bits."""
+        assert self._handle is not None
+
         stat = GetCommModemStatus(self._handle)
         return ModemPins(
             cts=PinState.HIGH if stat & MS_CTS_ON else PinState.LOW,
@@ -306,13 +315,15 @@ class Win32Serial(BaseSerial):
 
     def _set_modem_pins(self, modem_pins: ModemPins) -> None:
         """Set the modem control bits."""
+        assert self._handle is not None
+
         if modem_pins.rts is not PinState.UNDEFINED:
-            EscapeCommFunction(
+            EscapeCommFunction(  # type:ignore[call-arg]
                 self._handle, (SETRTS if modem_pins.rts is PinState.HIGH else CLRRTS)
             )
 
         if modem_pins.dtr is not PinState.UNDEFINED:
-            EscapeCommFunction(
+            EscapeCommFunction(  # type:ignore[call-arg]
                 self._handle, (SETDTR if modem_pins.dtr is PinState.HIGH else CLRDTR)
             )
 
@@ -340,15 +351,17 @@ class Win32Serial(BaseSerial):
 
     def flush(self) -> None:
         """Flush write buffers."""
+        assert self._handle is not None
         FlushFileBuffers(self._handle)
 
     def _readinto(self, b: Buffer, *, timeout: float | None) -> int:
         """Read data into the provided bytearray."""
         assert self._overlapped_read is not None
+        assert self._handle is not None
         ResetEvent(self._overlapped_read.hEvent)
 
         try:
-            rc, _ = ReadFile(self._handle, b, self._overlapped_read)
+            rc, _ = ReadFile(self._handle, b, self._overlapped_read)  # type:ignore[call-overload]
         except pywintypes.error as e:
             raise OSError(e.winerror, e.strerror) from e
 
@@ -374,10 +387,11 @@ class Win32Serial(BaseSerial):
     def _write(self, data: Buffer, *, timeout: float | None) -> int:
         """Write data to the serial port synchronously."""
         assert self._overlapped_write is not None
+        assert self._handle is not None
         ResetEvent(self._overlapped_write.hEvent)
 
         try:
-            err, n = WriteFile(self._handle, data, self._overlapped_write)
+            err, n = WriteFile(self._handle, data, self._overlapped_write)  # type:ignore[arg-type]
         except pywintypes.error as e:
             raise OSError(e.winerror, e.strerror) from e
 
@@ -433,7 +447,7 @@ class Win32SerialTransport(BaseSerialTransport):
         super().__init__(loop, protocol)
 
         self._handle: int | None = None
-        self._internal_transport: Any | None = None
+        self._internal_transport: asyncio.Transport | None = None
         self._close_future: asyncio.Future[None] | None = None
         self._closing: bool = False
         self._connect_in_progress: bool = False
@@ -488,7 +502,7 @@ class Win32SerialTransport(BaseSerialTransport):
     async def _open(self, path: str | os.PathLike[str]) -> None:
         """Open the serial port."""
         normalized_path = _normalize_windows_port_path(path)
-        self._handle = await self._loop.run_in_executor(
+        handle = await self._loop.run_in_executor(
             None,
             lambda: CreateFile(
                 normalized_path,
@@ -500,6 +514,7 @@ class Win32SerialTransport(BaseSerialTransport):
                 None,
             ),
         )
+        self._handle = cast(int, handle)
 
     async def _connect(self, **kwargs: Any) -> None:
         """Connect to the serial port."""
@@ -641,12 +656,12 @@ class Win32SerialTransport(BaseSerialTransport):
         assert self._internal_transport is not None
         try:
             # Wait for asyncio buffer to drain
-            await self._internal_transport._make_empty_waiter()
+            await self._internal_transport._make_empty_waiter()  # type:ignore[attr-defined]
 
             # Wait for hardware buffer to flush
             await self._loop.run_in_executor(None, self._serial.flush)
         finally:
-            self._internal_transport._reset_empty_waiter()
+            self._internal_transport._reset_empty_waiter()  # type:ignore[attr-defined]
 
 
 def win32_list_serial_ports() -> list[SerialPortInfo]:

--- a/tests/test_serial_linux.py
+++ b/tests/test_serial_linux.py
@@ -29,7 +29,7 @@ def test_tiocgserial_ioctl_not_supported() -> None:
     """Test that TIOCGSERIAL ioctl not supported is handled gracefully."""
     ioctl_orig = fcntl.ioctl
 
-    def ioctl(fd: int, request: int, arg: Any = 0, mutate_flag: bool = True) -> None:
+    def ioctl(fd: int, request: int, arg: Any = 0, mutate_flag: bool = True) -> Any:
         if request in (TIOCGSERIAL, TIOCSSERIAL):
             raise OSError(errno.EOPNOTSUPP, "Not supported")
 
@@ -52,7 +52,7 @@ def test_tiocgserial_ioctl_unexpected() -> None:
     """Test that TIOCGSERIAL ioctl not supported is handled gracefully."""
     ioctl_orig = fcntl.ioctl
 
-    def ioctl(fd: int, request: int, arg: Any = 0, mutate_flag: bool = True) -> None:
+    def ioctl(fd: int, request: int, arg: Any = 0, mutate_flag: bool = True) -> Any:
         if request in (TIOCGSERIAL, TIOCSSERIAL):
             raise OSError(errno.EINVAL, "Invalid argument")
 


### PR DESCRIPTION
MyPy by default doesn't check as much as it should, even with `strict`, so we missed an unbound local branchin the most recent release. This PR enables practically everything we reasonably can (save for `Any` checks) to prevent this from happening again and adds a lot of type hints.

Windows typing is a bit annoying here because there are a few issues with typeshed but I've managed to type check most code with this.