### PR TITLE
Fix `astral-sh/setup-uv` version for docs CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,6 @@
 name: Documentation
 on:
-  workflow_dispatch:
+  pull_request:
   push:
     branches:
       - dev
@@ -9,23 +9,28 @@ permissions:
   pages: write
   id-token: write
 jobs:
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/configure-pages@v5
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
           python-version: "3.14"
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.0.0
         with:
           enable-cache: true
       - run: uv run --extra docs sphinx-build -b html docs site
       - uses: actions/upload-pages-artifact@v4
         with:
           path: site
+  deploy:
+    if: github.event_name != 'pull_request'
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/configure-pages@v5
       - uses: actions/deploy-pages@v4
         id: deployment


### PR DESCRIPTION
`astral-sh/setup-uv`` switched to immutable releases so `v8` doesn't match `v8.0.0`.

I've set up CI to build docs on every PR to avoid things breaking again after merge.