### PR TITLE
Add more pyserial compatibility

### DIFF
--- a/serialx/common.py
+++ b/serialx/common.py
@@ -304,9 +304,13 @@ class BaseSerial(io.RawIOBase):
         """Write bytes to serial port, internal."""
         raise NotImplementedError
 
-    @abstractmethod
     def flush(self) -> None:
         """Flush write buffers."""
+        self._flush()
+
+    @abstractmethod
+    def _flush(self) -> None:
+        """Flush write buffers, internal."""
         raise NotImplementedError
 
     @property
@@ -441,14 +445,22 @@ class BaseSerial(io.RawIOBase):
         """Return the number of bytes waiting to be written."""
         raise NotImplementedError
 
-    @abstractmethod
     def reset_read_buffer(self) -> None:
         """Reset the read buffer."""
-        raise NotImplementedError
+        self._reset_read_buffer()
 
     @abstractmethod
+    def _reset_read_buffer(self) -> None:
+        """Reset the read buffer, internal."""
+        raise NotImplementedError
+
     def reset_write_buffer(self) -> None:
         """Reset the write buffer."""
+        self._reset_write_buffer()
+
+    @abstractmethod
+    def _reset_write_buffer(self) -> None:
+        """Reset the write buffer, internal."""
         raise NotImplementedError
 
     @property

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -9,11 +9,12 @@ from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 import dataclasses
 from enum import Enum
+import functools
 import io
 from pathlib import Path
 import time
 from types import TracebackType
-from typing import Any, cast
+from typing import Any, Concatenate, ParamSpec, TypeVar, cast
 import urllib.parse
 import warnings
 
@@ -122,6 +123,28 @@ def measure_time() -> Iterator[Callable[[], float]]:
         end = time.monotonic()
 
 
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+
+
+def maybe_wrap_exceptions(
+    func: Callable[Concatenate[BaseSerial, _P], _R],
+) -> Callable[Concatenate[BaseSerial, _P], _R]:
+    """Re-raise all exceptions as `SerialException` when the flag is set."""
+
+    @functools.wraps(func)
+    def replacement(self: BaseSerial, /, *args: _P.args, **kwargs: _P.kwargs) -> _R:
+        try:
+            return func(self, *args, **kwargs)
+        except Exception as exc:
+            if self._wrap_exceptions:
+                raise SerialException(str(exc)) from exc
+
+            raise
+
+    return replacement
+
+
 class BaseSerial(io.RawIOBase):
     """Base class for serial port communication."""
 
@@ -148,6 +171,8 @@ class BaseSerial(io.RawIOBase):
         do_not_open: bool | None = None,
         writeTimeout: float | None = None,
         inter_byte_timeout: int | None = None,
+        # Internal pyserial compatibility signal
+        _wrap_exceptions: bool = False,
     ) -> None:
         """Initialize serial port configuration."""
         super().__init__()
@@ -191,12 +216,15 @@ class BaseSerial(io.RawIOBase):
         if do_not_open is False:
             raise RuntimeError("do_not_open=False is not supported")
 
+        self._wrap_exceptions = _wrap_exceptions
+
     @classmethod
     def from_url(cls, url: str, *args: Any, **kwargs: Any) -> BaseSerial:
         """Create the appropriate serial port subclass for the given URL."""
         serial_cls, _ = get_serial_classes(url)
         return serial_cls(url, *args, **kwargs)
 
+    @maybe_wrap_exceptions
     def open(self) -> None:
         """Open the serial port."""
         self._open()
@@ -207,6 +235,7 @@ class BaseSerial(io.RawIOBase):
             self.close()
             raise
 
+    @maybe_wrap_exceptions
     def configure_port(self) -> None:
         """Configure the serial port settings."""
         self._configure_port()
@@ -221,6 +250,7 @@ class BaseSerial(io.RawIOBase):
         """Configure the serial port settings (platform-specific)."""
         raise NotImplementedError
 
+    @maybe_wrap_exceptions
     def close(self) -> None:
         """Close the serial port."""
         self._close()
@@ -244,6 +274,7 @@ class BaseSerial(io.RawIOBase):
         """Get modem control bits."""
         return self._get_modem_pins()
 
+    @maybe_wrap_exceptions
     def set_modem_pins(
         self,
         modem_pins: ModemPins | None = None,
@@ -284,6 +315,7 @@ class BaseSerial(io.RawIOBase):
         """Set modem control bits, internal."""
         raise NotImplementedError
 
+    @maybe_wrap_exceptions
     def readinto(self, b: Buffer, *, timeout: float | None = None) -> int:
         """Read bytes from serial port into buffer."""
         timeout = self._read_timeout if timeout is None else timeout
@@ -294,6 +326,7 @@ class BaseSerial(io.RawIOBase):
         """Read bytes from serial port into buffer, internal."""
         raise NotImplementedError
 
+    @maybe_wrap_exceptions
     def write(self, data: Buffer, *, timeout: float | None = None) -> int:
         """Write bytes to serial port."""
         timeout = self._write_timeout if timeout is None else timeout
@@ -445,6 +478,7 @@ class BaseSerial(io.RawIOBase):
         """Return the number of bytes waiting to be written."""
         raise NotImplementedError
 
+    @maybe_wrap_exceptions
     def reset_read_buffer(self) -> None:
         """Reset the read buffer."""
         self._reset_read_buffer()
@@ -454,6 +488,7 @@ class BaseSerial(io.RawIOBase):
         """Reset the read buffer, internal."""
         raise NotImplementedError
 
+    @maybe_wrap_exceptions
     def reset_write_buffer(self) -> None:
         """Reset the write buffer."""
         self._reset_write_buffer()

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -13,7 +13,7 @@ import io
 from pathlib import Path
 import time
 from types import TracebackType
-from typing import Any
+from typing import Any, cast
 import urllib.parse
 import warnings
 
@@ -488,6 +488,34 @@ class BaseSerial(io.RawIOBase):
             Use `byte_size` instead.
         """
         return self.byte_size
+
+    @property
+    def data_bits(self) -> int:
+        """Deprecated alias for `byte_size`.
+
+        Warning: Deprecated
+            Use `byte_size` instead.
+        """
+        return self.byte_size
+
+    @data_bits.setter
+    def data_bits(self, value: int) -> None:
+        """Set the byte size (deprecated)."""
+        self._byte_size = value
+
+    @property
+    def stop_bits(self) -> int | float:
+        """Deprecated alias for `stopbits`.
+
+        Warning: Deprecated
+            Use `stopbits` instead.
+        """
+        return cast(int | float, self._stopbits.value)
+
+    @stop_bits.setter
+    def stop_bits(self, value: int | float) -> None:
+        """Set the number of stop bits (deprecated)."""
+        self._stopbits = StopBits(value)
 
     @property
     def writeTimeout(self) -> float | None:

--- a/serialx/platforms/serial_esphome.py
+++ b/serialx/platforms/serial_esphome.py
@@ -311,11 +311,11 @@ class ESPHomeSerial(BaseSerial):
         """Return the number of bytes waiting to be written."""
         return 0
 
-    def reset_read_buffer(self) -> None:
+    def _reset_read_buffer(self) -> None:
         """Reset the read buffer."""
         self._read_buffer.clear()
 
-    def reset_write_buffer(self) -> None:
+    def _reset_write_buffer(self) -> None:
         """Reset the write buffer."""
 
     @translate_esphome_errors
@@ -324,7 +324,7 @@ class ESPHomeSerial(BaseSerial):
         assert self._api is not None
         await self._api.serial_proxy_flush(instance=self._instance_id)
 
-    def flush(self) -> None:
+    def _flush(self) -> None:
         """Flush write buffers."""
         self._call_on_loop(self._async_flush())
 

--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -380,7 +380,7 @@ class PosixSerial(BaseSerial):
             if exc.errno == errno.ENOTTY:
                 LOGGER.debug("Device is not a serial port, cannot set modem pins")
 
-    def flush(self) -> None:
+    def _flush(self) -> None:
         """Flush write buffers, waiting until all data is written."""
         assert self._fileno is not None
         LOGGER.debug("Flushing file descriptor %r", self._fileno)
@@ -470,12 +470,12 @@ class PosixSerial(BaseSerial):
 
         return int.from_bytes(buffer, "little")
 
-    def reset_read_buffer(self) -> None:
+    def _reset_read_buffer(self) -> None:
         """Reset the read buffer."""
         assert self._fileno is not None
         termios.tcflush(self._fileno, termios.TCIFLUSH)
 
-    def reset_write_buffer(self) -> None:
+    def _reset_write_buffer(self) -> None:
         """Reset the write buffer."""
         assert self._fileno is not None
         termios.tcflush(self._fileno, termios.TCOFLUSH)

--- a/serialx/platforms/serial_rfc2217/__init__.py
+++ b/serialx/platforms/serial_rfc2217/__init__.py
@@ -575,11 +575,11 @@ class RFC2217Serial(SocketSerial):
         """Return the number of buffered serial data bytes waiting to be read."""
         return len(self._data_buffer)
 
-    def reset_write_buffer(self) -> None:
+    def _reset_write_buffer(self) -> None:
         """Reset the write buffer."""
         self._send_and_wait(PurgeDataCmd(what=PurgeDataValue.RECEIVE))
 
-    def reset_read_buffer(self) -> None:
+    def _reset_read_buffer(self) -> None:
         """Reset the read buffer."""
         self._send_and_wait(PurgeDataCmd(what=PurgeDataValue.TRANSMIT))
         self._data_buffer.clear()
@@ -663,7 +663,7 @@ class RFC2217Serial(SocketSerial):
 
         return self._engine.get_modem_pins()
 
-    def flush(self) -> None:
+    def _flush(self) -> None:
         """Flush write buffers (no-op, TCP handles buffering)."""
 
 

--- a/serialx/platforms/serial_socket.py
+++ b/serialx/platforms/serial_socket.py
@@ -114,7 +114,7 @@ class SocketSerial(BaseSerial):
         """Return the number of bytes waiting to be written."""
         return 0
 
-    def reset_read_buffer(self) -> None:
+    def _reset_read_buffer(self) -> None:
         """Reset the read buffer."""
 
         # Drain all of the pending data in nonblocking mode
@@ -131,10 +131,10 @@ class SocketSerial(BaseSerial):
                 if not data:
                     break
 
-    def reset_write_buffer(self) -> None:
+    def _reset_write_buffer(self) -> None:
         """Reset the write buffer."""
 
-    def flush(self) -> None:
+    def _flush(self) -> None:
         """Flush write buffers (no-op for sockets)."""
 
     def _write(self, b: Buffer, *, timeout: float | None) -> int:

--- a/serialx/platforms/serial_win32.py
+++ b/serialx/platforms/serial_win32.py
@@ -339,17 +339,17 @@ class Win32Serial(BaseSerial):
         _flags, comstat = ClearCommError(self._handle)
         return comstat.cbOutQue
 
-    def reset_read_buffer(self) -> None:
+    def _reset_read_buffer(self) -> None:
         """Reset the read buffer."""
         assert self._handle is not None
         PurgeComm(self._handle, PURGE_RXABORT | PURGE_RXCLEAR)
 
-    def reset_write_buffer(self) -> None:
+    def _reset_write_buffer(self) -> None:
         """Reset the write buffer."""
         assert self._handle is not None
         PurgeComm(self._handle, PURGE_TXABORT | PURGE_TXCLEAR)
 
-    def flush(self) -> None:
+    def _flush(self) -> None:
         """Flush write buffers."""
         assert self._handle is not None
         FlushFileBuffers(self._handle)

--- a/serialx_compat/serial/__init__.py
+++ b/serialx_compat/serial/__init__.py
@@ -12,6 +12,7 @@ if importlib.util.find_spec("serial.serialcli"):
     )
 
 from importlib.metadata import version
+from typing import Any
 
 from serialx import (
     CR,
@@ -28,7 +29,7 @@ from serialx import (
     ModemPins,
     Parity,
     PinState,
-    Serial,
+    Serial as SerialxSerial,
     SerialException,
     SerialPortInfo,
     SerialStreamWriter,
@@ -40,7 +41,6 @@ from serialx import (
     get_serial_classes,
     list_serial_ports,
     open_serial_connection,
-    serial_for_url,
 )
 
 VERSION = version("serialx-compat")
@@ -77,3 +77,16 @@ __all__ = [
     "VERSION",
     "__version__",
 ]
+
+
+class CompatSerial(SerialxSerial):
+    """Compatibility base class, maintaining runtime-compatibility with pyserial."""
+
+    @classmethod
+    def from_url(cls, url: str, *args: Any, **kwargs: Any) -> BaseSerial:
+        """Create the appropriate serial port subclass for the given URL."""
+        return super().from_url(url, *args, _wrap_exceptions=True, **kwargs)
+
+
+Serial = CompatSerial
+serial_for_url = CompatSerial.from_url

--- a/tests/test_pyserial_compat.py
+++ b/tests/test_pyserial_compat.py
@@ -80,6 +80,36 @@ def test_compat_baudrate_setter(serial_pair: SerialPair) -> None:
         assert s.baudrate == 115200
 
 
+def test_compat_data_bits(serial_pair: SerialPair) -> None:
+    """Test that `data_bits` is a read/write alias for `byte_size`."""
+    with Serial.from_url(serial_pair.left, baudrate=9600, bytesize=7) as s:
+        assert s.data_bits == 7
+        assert s.byte_size == 7
+
+        s.data_bits = 8
+        assert s.data_bits == 8
+        assert s.byte_size == 8
+        assert s.bytesize == 8
+
+
+def test_compat_stop_bits(serial_pair: SerialPair) -> None:
+    """Test that `stop_bits` reads/writes as int/float and maps to `stopbits`."""
+    with Serial.from_url(serial_pair.left, baudrate=9600) as s:
+        assert s.stop_bits == 1
+        assert s.stopbits.value == 1
+
+        s.stop_bits = 2
+        assert s.stop_bits == 2
+        assert s.stopbits.value == 2
+
+        s.stop_bits = 1.5
+        assert s.stop_bits == 1.5
+        assert s.stopbits.value == 1.5
+
+        with pytest.raises(ValueError):
+            s.stop_bits = 3
+
+
 def test_compat_no_arg_construction() -> None:
     """Test that Serial can be constructed with no args (deferred open pattern)."""
     s = Serial()


### PR DESCRIPTION
- The serial object provided by `serialx-compat` maintains runtime exception compatibility with pyserial, allowing for code that relies on `except SerialException` to continue functioning.
- `data_bits`, `stop_bits`, and `portstr` have been added as property aliases.
