### PR TITLE
Add tests for pyserial compatibility and expand

### DIFF
--- a/serialx/common.py
+++ b/serialx/common.py
@@ -515,6 +515,15 @@ class BaseSerial(io.RawIOBase):
         return str(self.path) if self.path is not None else None
 
     @property
+    def portstr(self) -> str | None:
+        """Deprecated alias for `path`.
+
+        Warning: Deprecated
+            Use `path` instead.
+        """
+        return str(self.path) if self.path is not None else None
+
+    @property
     def timeout(self) -> float | None:
         """Deprecated alias for `read_timeout`.
 

--- a/serialx_compat/serial/__init__.py
+++ b/serialx_compat/serial/__init__.py
@@ -82,6 +82,11 @@ __all__ = [
 class CompatSerial(SerialxSerial):
     """Compatibility base class, maintaining runtime-compatibility with pyserial."""
 
+    def __init__(
+        self, *args: Any, _wrap_exceptions: bool = True, **kwargs: Any
+    ) -> None:
+        super().__init__(*args, _wrap_exceptions=_wrap_exceptions, **kwargs)
+
     @classmethod
     def from_url(cls, url: str, *args: Any, **kwargs: Any) -> BaseSerial:
         """Create the appropriate serial port subclass for the given URL."""

--- a/serialx_compat/tests/test_compat.py
+++ b/serialx_compat/tests/test_compat.py
@@ -1,7 +1,8 @@
-"""Smoke tests for import compatibility shims."""
+"""Tests for the pyserial compatibility shim package."""
 
 from __future__ import annotations
 
+import pytest
 import serial
 import serial.serialutil
 import serial.tools
@@ -9,6 +10,8 @@ import serial.tools.list_ports
 import serial.tools.list_ports_common
 import serial_asyncio
 import serial_asyncio_fast
+
+import serialx
 
 
 def test_serial_exports_versions_and_core_symbols() -> None:
@@ -40,3 +43,31 @@ def test_serial_asyncio_fast_exports_versions_and_core_symbols() -> None:
     assert hasattr(serial_asyncio_fast, "create_serial_connection")
     assert hasattr(serial_asyncio_fast, "open_serial_connection")
     assert hasattr(serial_asyncio_fast, "SerialTransport")
+
+
+def test_compat_serial_from_url_wraps_exceptions() -> None:
+    """`serial.Serial.from_url` wraps underlying exceptions as `SerialException`."""
+    port = serial.Serial.from_url("/nonexistent/serialx-compat/path")
+
+    with pytest.raises(serial.SerialException) as exc_info:
+        port.open()
+
+    assert isinstance(exc_info.value.__cause__, FileNotFoundError)
+
+
+def test_compat_serial_for_url_wraps_exceptions() -> None:
+    """`serial.serial_for_url` wraps underlying exceptions as `SerialException`."""
+    port = serial.serial_for_url("/nonexistent/serialx-compat/path")
+
+    with pytest.raises(serial.SerialException) as exc_info:
+        port.open()
+
+    assert isinstance(exc_info.value.__cause__, FileNotFoundError)
+
+
+def test_serialx_serial_does_not_wrap_exceptions() -> None:
+    """The underlying `serialx.Serial` leaves the original exception untouched."""
+    port = serialx.Serial.from_url("/nonexistent/serialx-compat/path")
+
+    with pytest.raises(FileNotFoundError):
+        port.open()

--- a/tests/test_pyserial_compat.py
+++ b/tests/test_pyserial_compat.py
@@ -24,6 +24,7 @@ def test_compat_constructor_kwargs(serial_pair: SerialPair) -> None:
 
         # pyserial deprecated property aliases read back correctly
         assert s.port == str(s.path)
+        assert s.portstr == str(s.path)
         assert s.timeout == 1.5
         assert s.writeTimeout == 2.0
         assert s.bytesize == 7


### PR DESCRIPTION
`_wrap_exceptions` is now set even when `Serial` is directly constructed without the `from_url` helper. I've expanded tests as well and added `portstr` as a compatibility alias.