### PR TITLE
Fix async locking for POSIX and allow shared usage on Windows

### DIFF
--- a/serialx/async_serial.py
+++ b/serialx/async_serial.py
@@ -38,9 +38,6 @@ async def create_serial_connection(
     **kwargs: Any,
 ) -> tuple[BaseSerialTransport, asyncio.Protocol]:
     """Create a serial port connection with asyncio."""
-    if not exclusive:
-        raise ValueError("Only exclusive=True is supported")
-
     if transport_cls is None:
         if url is None:
             raise ValueError("One of `url` or `transport_cls` must be provided.")

--- a/serialx/async_serial.py
+++ b/serialx/async_serial.py
@@ -57,6 +57,7 @@ async def create_serial_connection(
         stopbits=stopbits,
         xonxoff=xonxoff,
         rtscts=rtscts,
+        exclusive=exclusive,
         **kwargs,
     )
 

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -788,6 +788,8 @@ class BaseSerialTransport(asyncio.Transport):
                 **kwargs,
             )
         except BaseException:
+            # Intentionally catch cancellation too: callers should only observe
+            # connect failure/cancel after transport resources are released.
             self.close()
             await self.wait_closed()
 

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -776,16 +776,22 @@ class BaseSerialTransport(asyncio.Transport):
         **kwargs: Any,
     ) -> None:
         """Connect to serial port."""
-        return await self._connect(
-            path=path,
-            baudrate=baudrate,
-            parity=parity,
-            stopbits=stopbits,
-            xonxoff=xonxoff,
-            rtscts=rtscts,
-            byte_size=byte_size,
-            **kwargs,
-        )
+        try:
+            await self._connect(
+                path=path,
+                baudrate=baudrate,
+                parity=parity,
+                stopbits=stopbits,
+                xonxoff=xonxoff,
+                rtscts=rtscts,
+                byte_size=byte_size,
+                **kwargs,
+            )
+        except BaseException:
+            self.close()
+            await self.wait_closed()
+
+            raise
 
     async def get_modem_pins(self) -> ModemPins:
         """Get modem control bits."""

--- a/serialx/descriptor_transport.py
+++ b/serialx/descriptor_transport.py
@@ -397,11 +397,13 @@ class DescriptorTransport(BaseSerialTransport):
 
     def _close(self, exc: Exception | None = None) -> None:
         self._closing = True
-        assert self._fileno is not None
-        if self._buffer:
-            self._loop.remove_writer(self._fileno)
-        self._buffer.clear()
-        self._loop.remove_reader(self._fileno)
+
+        if self._fileno is not None:
+            if self._buffer:
+                self._loop.remove_writer(self._fileno)
+            self._buffer.clear()
+            self._loop.remove_reader(self._fileno)
+
         self._maybe_background_close(exc)
 
     def _maybe_background_close(self, exc: Exception | None) -> None:

--- a/serialx/descriptor_transport.py
+++ b/serialx/descriptor_transport.py
@@ -66,15 +66,49 @@ class DescriptorTransport(BaseSerialTransport):
             self._extra.update(extra)
 
         self._close_task: asyncio.Task[None] | None = None
+        self._open_fut: asyncio.Future[int] | None = None
         self._connection_made: bool = False
 
     async def _open(self, path: str | os.PathLike[str]) -> None:
-        self._fileno = await self._loop.run_in_executor(
+        if self._open_fut is not None:
+            raise RuntimeError("Open is already in progress")
+
+        self._open_fut = self._loop.run_in_executor(
             None, os.open, path, os.O_RDWR | os.O_NOCTTY | os.O_NONBLOCK
         )
 
+        try:
+            self._fileno = await self._open_fut
+        except asyncio.CancelledError:
+            # `os.open` may still finish in the executor after cancellation. If that
+            # happens, close the resulting fd to avoid leaks.
+            self._open_fut.add_done_callback(self._on_cancelled_open_done)
+            raise
+        except BaseException:
+            self._open_fut = None
+            raise
+        else:
+            self._open_fut = None
+
         if self._closing:
             self._maybe_background_close(None)
+
+    def _on_cancelled_open_done(self, open_fut: asyncio.Future[int]) -> None:
+        if self._open_fut is not open_fut:
+            return
+
+        self._open_fut = None
+
+        try:
+            fileno = open_fut.result()
+        except BaseException:
+            if self._closing and self._fileno is None and self._close_task is None:
+                self._resolve_closed_waiter()
+            return
+
+        self._fileno = fileno
+        self._closing = True
+        self._maybe_background_close(None)
 
     async def _connect(self, **_kwargs: Any) -> None:
         assert self._fileno is not None
@@ -309,6 +343,12 @@ class DescriptorTransport(BaseSerialTransport):
         """Close the transport."""
         LOGGER.debug("Closing at the request of the application")
         if self._closing:
+            if (
+                self._fileno is None
+                and self._open_fut is None
+                and self._close_task is None
+            ):
+                self._resolve_closed_waiter()
             return
 
         if self._fileno is not None:
@@ -317,6 +357,8 @@ class DescriptorTransport(BaseSerialTransport):
             # The fd hasn't been opened yet. Just set the flag; _open() will
             # trigger the close sequence once the executor finishes.
             self._closing = True
+            if self._open_fut is None:
+                self._resolve_closed_waiter()
 
     def __del__(self) -> None:
         """Clean up transport on deletion."""

--- a/serialx/platforms/serial_esphome.py
+++ b/serialx/platforms/serial_esphome.py
@@ -427,18 +427,20 @@ class ESPHomeSerialTransport(BaseSerialTransport):
             self._unsub()
             self._unsub = None
 
-        assert self._serial is not None
+        if self._serial is None:
+            self._call_protocol_connection_lost(None)
+            return
+
         self._serial._unsubscribe_instance()
 
         if self._serial._disconnect_api:
             api = self._serial._api
             self._serial._api = None
+
             if api is not None:
                 self._close_task = self._loop.create_task(self._async_close(api))
             else:
                 self._call_protocol_connection_lost(None)
-        else:
-            self._call_protocol_connection_lost(None)
 
     def abort(self) -> None:
         """Abort the transport immediately."""

--- a/serialx/platforms/serial_esphome.py
+++ b/serialx/platforms/serial_esphome.py
@@ -427,20 +427,25 @@ class ESPHomeSerialTransport(BaseSerialTransport):
             self._unsub()
             self._unsub = None
 
-        if self._serial is None:
+        serial = self._serial
+        if serial is None:
             self._call_protocol_connection_lost(None)
             return
 
-        self._serial._unsubscribe_instance()
+        serial._unsubscribe_instance()
 
-        if self._serial._disconnect_api:
-            api = self._serial._api
-            self._serial._api = None
+        if not serial._disconnect_api:
+            # Transport does not own the external API lifecycle.
+            self._call_protocol_connection_lost(None)
+            return
 
-            if api is not None:
-                self._close_task = self._loop.create_task(self._async_close(api))
-            else:
-                self._call_protocol_connection_lost(None)
+        api = serial._api
+        serial._api = None
+        if api is None:
+            self._call_protocol_connection_lost(None)
+            return
+
+        self._close_task = self._loop.create_task(self._async_close(api))
 
     def abort(self) -> None:
         """Abort the transport immediately."""

--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -142,13 +142,6 @@ class PosixSerial(BaseSerial):
                 f"Serial port {self._path!r} is already locked by another process",
             ) from exc
 
-    def _unlock(self) -> None:
-        """Unlock the serial port."""
-        LOGGER.debug("Unlocking serial port %r", self._path)
-
-        assert self._fileno is not None
-        fcntl.flock(self._fileno, fcntl.LOCK_UN)
-
     def _build_parity_flags(self) -> int:
         if self._parity == Parity.NONE:
             return 0
@@ -389,9 +382,6 @@ class PosixSerial(BaseSerial):
     def _close(self) -> None:
         """Close the serial port."""
         if self._fileno is not None:
-            if self._exclusive:
-                self._unlock()
-
             os.close(self._fileno)
             self._fileno = None
 

--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -504,6 +504,9 @@ class PosixSerialTransport(DescriptorTransport):
         )
         self._extra["serial"] = self._serial
 
+        if self._serial._exclusive:
+            await self._loop.run_in_executor(None, self._serial._lock)
+
         await asyncio.sleep(AFTER_OPEN_DELAY)
 
         await self._loop.run_in_executor(None, self._serial.configure_port)

--- a/serialx/platforms/serial_win32.py
+++ b/serialx/platforms/serial_win32.py
@@ -447,6 +447,7 @@ class Win32SerialTransport(BaseSerialTransport):
         super().__init__(loop, protocol)
 
         self._handle: int | None = None
+        self._open_fut: asyncio.Future[int] | None = None
         self._internal_transport: asyncio.Transport | None = None
         self._close_future: asyncio.Future[None] | None = None
         self._closing: bool = False
@@ -499,30 +500,71 @@ class Win32SerialTransport(BaseSerialTransport):
         """Forward resume_writing to the protocol."""
         self._protocol.resume_writing()
 
+    def _maybe_resolve_closed_waiter(self) -> None:
+        """Potentially resolve the closed future when the transport is closing."""
+        if not self._closing:
+            return
+        if self._connect_in_progress:
+            return
+        if self._open_fut is not None:
+            return
+        if self._internal_transport is not None:
+            return
+        if self._handle is not None:
+            return
+
+        self._resolve_closed_waiter()
+
+    def _on_cancelled_open_done(self, open_fut: asyncio.Future[int]) -> None:
+        if self._open_fut is not open_fut:
+            return
+
+        self._open_fut = None
+
+        try:
+            handle = open_fut.result()
+        except BaseException:
+            self._maybe_resolve_closed_waiter()
+            return
+
+        _safe_close_handle(handle)
+        self._maybe_resolve_closed_waiter()
+
     async def _open(
         self, path: str | os.PathLike[str], *, exclusive: bool = True
     ) -> None:
         """Open the serial port."""
+        if self._open_fut is not None:
+            raise RuntimeError("Open is already in progress")
+
         normalized_path = _normalize_windows_port_path(path)
         share_mode = 0 if exclusive else FILE_SHARE_READ | FILE_SHARE_WRITE
 
-        try:
-            handle = await self._loop.run_in_executor(
+        open_fut = self._loop.run_in_executor(
+            None,
+            lambda: CreateFile(
+                normalized_path,
+                GENERIC_READ | GENERIC_WRITE,
+                share_mode,
                 None,
-                lambda: CreateFile(
-                    normalized_path,
-                    GENERIC_READ | GENERIC_WRITE,
-                    share_mode,
-                    None,
-                    OPEN_EXISTING,
-                    FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OVERLAPPED,
-                    None,
-                ),
-            )
+                OPEN_EXISTING,
+                FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OVERLAPPED,
+                None,
+            ),
+        )
+        self._open_fut = cast(asyncio.Future[int], open_fut)
+
+        try:
+            handle = await self._open_fut
+        except asyncio.CancelledError:
+            self._open_fut.add_done_callback(self._on_cancelled_open_done)
+            raise
         except pywintypes.error as e:
+            self._open_fut = None
             raise OSError(e.winerror, e.strerror, normalized_path) from e
 
-        self._handle = cast(int, handle)
+        self._open_fut = None
+        self._handle = handle
 
     async def _connect(self, **kwargs: Any) -> None:
         """Connect to the serial port."""
@@ -599,6 +641,7 @@ class Win32SerialTransport(BaseSerialTransport):
             raise
         finally:
             self._connect_in_progress = False
+            self._maybe_resolve_closed_waiter()
 
     def get_write_buffer_size(self) -> int:
         """Return the current size of the write buffer."""
@@ -636,16 +679,16 @@ class Win32SerialTransport(BaseSerialTransport):
         if self._internal_transport is not None:
             # Internal transport closes self._serial via sock.close()
             self._internal_transport.close()
-        elif not self._connect_in_progress:
-            self._resolve_closed_waiter()
+        else:
+            self._maybe_resolve_closed_waiter()
 
     def abort(self) -> None:
         """Abort the transport immediately."""
         self._closing = True
         if self._internal_transport is not None:
             self._internal_transport.abort()
-        elif not self._connect_in_progress:
-            self._resolve_closed_waiter()
+        else:
+            self._maybe_resolve_closed_waiter()
 
     def pause_reading(self) -> None:
         """Pause reading from the transport."""

--- a/serialx/platforms/serial_win32.py
+++ b/serialx/platforms/serial_win32.py
@@ -468,7 +468,7 @@ class Win32SerialTransport(BaseSerialTransport):
 
         self._close_future = self._loop.run_in_executor(None, _close_then_notify)
 
-    def serial_shutdown(self, how: Any) -> None:
+    def serial_shutdown(self, how: int) -> None:
         """Shutdown the serial connection."""
         # Intentionally ignored
 

--- a/serialx/platforms/serial_win32.py
+++ b/serialx/platforms/serial_win32.py
@@ -499,21 +499,29 @@ class Win32SerialTransport(BaseSerialTransport):
         """Forward resume_writing to the protocol."""
         self._protocol.resume_writing()
 
-    async def _open(self, path: str | os.PathLike[str]) -> None:
+    async def _open(
+        self, path: str | os.PathLike[str], *, exclusive: bool = True
+    ) -> None:
         """Open the serial port."""
         normalized_path = _normalize_windows_port_path(path)
-        handle = await self._loop.run_in_executor(
-            None,
-            lambda: CreateFile(
-                normalized_path,
-                GENERIC_READ | GENERIC_WRITE,
-                0,  # Exclusive access
+        share_mode = 0 if exclusive else FILE_SHARE_READ | FILE_SHARE_WRITE
+
+        try:
+            handle = await self._loop.run_in_executor(
                 None,
-                OPEN_EXISTING,
-                FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OVERLAPPED,
-                None,
-            ),
-        )
+                lambda: CreateFile(
+                    normalized_path,
+                    GENERIC_READ | GENERIC_WRITE,
+                    share_mode,
+                    None,
+                    OPEN_EXISTING,
+                    FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OVERLAPPED,
+                    None,
+                ),
+            )
+        except pywintypes.error as e:
+            raise OSError(e.winerror, e.strerror, normalized_path) from e
+
         self._handle = cast(int, handle)
 
     async def _connect(self, **kwargs: Any) -> None:
@@ -523,12 +531,15 @@ class Win32SerialTransport(BaseSerialTransport):
             return
 
         self._connect_in_progress = True
+
         path = kwargs.pop("path", None)
         if path is None:
             raise ValueError("A serial path is required")
-        await self._open(path)
 
         try:
+            exclusive = kwargs.get("exclusive", True)
+            await self._open(path, exclusive=exclusive)
+
             # Ensure inter_byte_timeout is set to a small value to enable
             # "Wait for first byte, then return on gap" behavior for ReadFile.
             # If 0 (default), ReadFile with default timeouts might wait for full buffer.

--- a/serialx/platforms/serial_win32.py
+++ b/serialx/platforms/serial_win32.py
@@ -116,7 +116,7 @@ def _normalize_windows_port_path(path: os.PathLike[str] | str) -> str:
     return path
 
 
-def _safe_close_handle(handle: Any) -> None:
+def _safe_close_handle(handle: int) -> None:
     """Close a Win32 handle, suppressing and logging errors."""
     try:
         CloseHandle(handle)
@@ -591,7 +591,9 @@ class Win32SerialTransport(BaseSerialTransport):
             if self._closing:
                 self._internal_transport.close()  # type: ignore[unreachable]
         except BaseException:
-            await self._loop.run_in_executor(None, _safe_close_handle, self._handle)
+            if self._handle is not None:
+                await self._loop.run_in_executor(None, _safe_close_handle, self._handle)
+
             self._serial = None
             self._handle = None
             raise

--- a/tests/common.py
+++ b/tests/common.py
@@ -112,6 +112,7 @@ SERIAL_PAIR_DEFAULT_QUIRKS: dict[SerialBackend, frozenset[SerialQuirk]] = {
             # Host binary does not support flow control
             SerialQuirk.NO_DTR_DSR,
             SerialQuirk.NO_RTS_CTS,
+            SerialQuirk.NO_EXCLUSIVITY,
             SerialQuirk.NO_UNPLUG,
         }
     ),

--- a/tests/test_async_transports.py
+++ b/tests/test_async_transports.py
@@ -5,6 +5,7 @@ import contextlib
 import logging
 import os
 import sys
+from unittest.mock import Mock
 
 if sys.version_info >= (3, 11):
     from asyncio import timeout as asyncio_timeout
@@ -483,20 +484,9 @@ async def test_async_abort(serial_pair: SerialPair) -> None:
 async def test_async_close_before_connect(serial_pair: SerialPair) -> None:
     """Test close during connect does not crash and stays idempotent."""
 
-    class ProbeProtocol(asyncio.Protocol):
-        def __init__(self) -> None:
-            self.connection_made_calls = 0
-            self.connection_lost_calls = 0
-
-        def connection_made(self, transport: asyncio.BaseTransport) -> None:
-            self.connection_made_calls += 1
-
-        def connection_lost(self, exc: Exception | None) -> None:
-            self.connection_lost_calls += 1
-
     loop = asyncio.get_running_loop()
     _serial_cls, transport_cls = get_serial_classes(serial_pair.left)
-    protocol = ProbeProtocol()
+    protocol = Mock(spec=asyncio.Protocol)
     transport = transport_cls(loop=loop, protocol=protocol)
 
     connect_task = asyncio.create_task(
@@ -513,8 +503,34 @@ async def test_async_close_before_connect(serial_pair: SerialPair) -> None:
     await asyncio.wait_for(transport.wait_closed(), timeout=2.0)
 
     assert transport.is_closing()
-    assert protocol.connection_made_calls <= 1
-    assert protocol.connection_lost_calls <= 1
+    assert len(protocol.connection_made.mock_calls) <= 1
+    assert len(protocol.connection_lost.mock_calls) <= 1
+
+
+async def test_async_abort_before_connect(serial_pair: SerialPair) -> None:
+    """Test abort during connect does not crash and stays idempotent."""
+
+    loop = asyncio.get_running_loop()
+    _serial_cls, transport_cls = get_serial_classes(serial_pair.left)
+    protocol = Mock(spec=asyncio.Protocol)
+    transport = transport_cls(loop=loop, protocol=protocol)
+
+    connect_task = asyncio.create_task(
+        transport.connect(path=serial_pair.left, baudrate=115200)
+    )
+    await asyncio.sleep(0)
+    transport.abort()
+    transport.abort()
+
+    with contextlib.suppress(Exception):
+        await asyncio.wait_for(connect_task, timeout=2.0)
+
+    await asyncio.wait_for(transport.wait_closed(), timeout=2.0)
+    await asyncio.wait_for(transport.wait_closed(), timeout=2.0)
+
+    assert transport.is_closing()
+    assert len(protocol.connection_made.mock_calls) <= 1
+    assert len(protocol.connection_lost.mock_calls) <= 1
 
 
 async def test_async_write_bytearray(serial_pair: SerialPair) -> None:
@@ -892,7 +908,33 @@ async def test_async_fast_open_close(serial_pair: SerialPair) -> None:
         baudrate=115200,
     )
 
-    await connection_lost_event.wait()
+    await asyncio.wait_for(connection_lost_event.wait(), timeout=5.0)
+    await asyncio.wait_for(transport.wait_closed(), timeout=5.0)
+    assert transport.is_closing()
+
+
+async def test_async_fast_open_close_with_close(serial_pair: SerialPair) -> None:
+    """Test quickly opening and closing a port via close() doesn't crash."""
+    connection_lost_event = asyncio.Event()
+
+    class FastCloseProtocol(asyncio.Protocol):
+        def connection_made(self, transport: asyncio.BaseTransport) -> None:
+            assert isinstance(transport, BaseSerialTransport)
+            transport.close()
+
+        def connection_lost(self, exc: Exception | None) -> None:
+            connection_lost_event.set()
+
+    transport, _ = await create_serial_connection(
+        asyncio.get_running_loop(),
+        FastCloseProtocol,
+        serial_pair.left,
+        baudrate=115200,
+    )
+
+    await asyncio.wait_for(connection_lost_event.wait(), timeout=5.0)
+    await asyncio.wait_for(transport.wait_closed(), timeout=5.0)
+    assert transport.is_closing()
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="CloseHandle resets modem signals")
@@ -1121,6 +1163,23 @@ async def test_async_connect_cancel(serial_pair: SerialPair) -> None:
 
     await asyncio.wait_for(transport.wait_closed(), timeout=5.0)
     await asyncio.wait_for(transport.wait_closed(), timeout=5.0)
+    transport.close()
+    await asyncio.wait_for(transport.wait_closed(), timeout=5.0)
+    assert transport.is_closing()
+
+
+async def test_async_close_before_connect_wait_closed(serial_pair: SerialPair) -> None:
+    """Test close-before-connect still resolves wait_closed."""
+    loop = asyncio.get_running_loop()
+    _serial_cls, transport_cls = get_serial_classes(serial_pair.left)
+
+    transport = transport_cls(loop=loop, protocol=asyncio.Protocol())
+    transport.close()
+
+    await asyncio.wait_for(transport.wait_closed(), timeout=5.0)
+    await asyncio.wait_for(transport.wait_closed(), timeout=5.0)
+    transport.close()
+    await asyncio.wait_for(transport.wait_closed(), timeout=5.0)
     assert transport.is_closing()
 
 
@@ -1134,4 +1193,64 @@ async def test_async_abort_before_connect_wait_closed(serial_pair: SerialPair) -
 
     await asyncio.wait_for(transport.wait_closed(), timeout=5.0)
     await asyncio.wait_for(transport.wait_closed(), timeout=5.0)
+    transport.abort()
+    await asyncio.wait_for(transport.wait_closed(), timeout=5.0)
+    assert transport.is_closing()
+
+
+async def test_async_wait_closed_multiple_waiters_close(
+    serial_pair: SerialPair,
+) -> None:
+    """Test multiple wait_closed waiters are released together on close."""
+    loop = asyncio.get_running_loop()
+    connection_lost_event = asyncio.Event()
+
+    class WaitersProtocol(asyncio.Protocol):
+        def connection_lost(self, exc: Exception | None) -> None:
+            connection_lost_event.set()
+
+    transport, _ = await create_serial_connection(
+        loop,
+        WaitersProtocol,
+        serial_pair.left,
+        baudrate=115200,
+    )
+
+    wait_closed_1 = asyncio.create_task(transport.wait_closed())
+    wait_closed_2 = asyncio.create_task(transport.wait_closed())
+
+    await asyncio.sleep(0)
+    transport.close()
+
+    await asyncio.wait_for(connection_lost_event.wait(), timeout=5.0)
+    await asyncio.wait_for(asyncio.gather(wait_closed_1, wait_closed_2), timeout=5.0)
+    assert transport.is_closing()
+
+
+async def test_async_wait_closed_multiple_waiters_abort(
+    serial_pair: SerialPair,
+) -> None:
+    """Test multiple wait_closed waiters are released together on abort."""
+    loop = asyncio.get_running_loop()
+    connection_lost_event = asyncio.Event()
+
+    class WaitersProtocol(asyncio.Protocol):
+        def connection_lost(self, exc: Exception | None) -> None:
+            connection_lost_event.set()
+
+    transport, _ = await create_serial_connection(
+        loop,
+        WaitersProtocol,
+        serial_pair.left,
+        baudrate=115200,
+    )
+
+    wait_closed_1 = asyncio.create_task(transport.wait_closed())
+    wait_closed_2 = asyncio.create_task(transport.wait_closed())
+
+    await asyncio.sleep(0)
+    transport.abort()
+
+    await asyncio.wait_for(connection_lost_event.wait(), timeout=5.0)
+    await asyncio.wait_for(asyncio.gather(wait_closed_1, wait_closed_2), timeout=5.0)
     assert transport.is_closing()

--- a/tests/test_async_transports.py
+++ b/tests/test_async_transports.py
@@ -1033,3 +1033,16 @@ async def test_async_deassert_on_open_with_rtscts(
         ) as (reader_right, writer_right):
             await asyncio.sleep(serial_pair.modem_line_propagation_delay)
             assert (await writer_left.transport.get_modem_pins()).cts is expected_state
+
+
+@pytest.mark.skip_quirks(SerialQuirk.NO_EXCLUSIVITY)
+async def test_async_exclusive(serial_pair: SerialPair) -> None:
+    """Test that exclusive setting is respected for async connections."""
+    async with async_create_reader_writer(
+        serial_pair.left, baudrate=115200, exclusive=True
+    ):
+        with pytest.raises(OSError):
+            async with async_create_reader_writer(
+                serial_pair.left, baudrate=115200, exclusive=True
+            ):
+                pass

--- a/tests/test_async_transports.py
+++ b/tests/test_async_transports.py
@@ -1046,3 +1046,21 @@ async def test_async_exclusive(serial_pair: SerialPair) -> None:
                 serial_pair.left, baudrate=115200, exclusive=True
             ):
                 pass
+
+
+@pytest.mark.skip_quirks(SerialQuirk.NO_EXCLUSIVITY)
+async def test_async_exclusive_disabled(serial_pair: SerialPair) -> None:
+    """Test that non-exclusive mode allows multiple opens."""
+    if sys.platform == "win32":
+        pytest.skip("Windows does not support shared access")
+
+    if SerialBackend.SER2NET in serial_pair.backends:
+        pytest.skip("ser2net only allows one connection per port")
+
+    async with async_create_reader_writer(
+        serial_pair.left, baudrate=115200, exclusive=False
+    ) as (_, writer1):
+        async with async_create_reader_writer(
+            serial_pair.left, baudrate=115200, exclusive=False
+        ) as (_, writer2):
+            writer2.write(b"test")

--- a/tests/test_async_transports.py
+++ b/tests/test_async_transports.py
@@ -510,6 +510,7 @@ async def test_async_close_before_connect(serial_pair: SerialPair) -> None:
         await asyncio.wait_for(connect_task, timeout=2.0)
 
     await asyncio.wait_for(transport.wait_closed(), timeout=2.0)
+    await asyncio.wait_for(transport.wait_closed(), timeout=2.0)
 
     assert transport.is_closing()
     assert protocol.connection_made_calls <= 1
@@ -1076,3 +1077,48 @@ async def test_async_exclusive_disabled(serial_pair: SerialPair) -> None:
             serial_pair.left, baudrate=115200, exclusive=False
         ) as (_, writer2):
             writer2.write(b"test")
+
+
+async def test_async_connect_nonexistent_port() -> None:
+    """Test that a failed connect still leaves a closed transport."""
+    loop = asyncio.get_running_loop()
+    path = "COM25" if sys.platform == "win32" else "/dev/this_port_does_not_exist"
+    _, transport_cls = await loop.run_in_executor(None, get_serial_classes, path)
+    transport = transport_cls(loop=loop, protocol=asyncio.Protocol())
+
+    with pytest.raises(OSError):
+        await asyncio.wait_for(
+            transport.connect(path=path, baudrate=115200),
+            timeout=5.0,
+        )
+
+    # Closing and `wait_closed` are both idempotent
+    await asyncio.wait_for(transport.wait_closed(), timeout=5.0)
+    await asyncio.wait_for(transport.wait_closed(), timeout=5.0)
+    transport.close()
+    await asyncio.wait_for(transport.wait_closed(), timeout=5.0)
+    assert transport.is_closing()
+
+
+async def test_async_connect_cancel(serial_pair: SerialPair) -> None:
+    """Test that cancelling connect still leaves a closed transport."""
+    loop = asyncio.get_running_loop()
+    _, transport_cls = await loop.run_in_executor(
+        None, get_serial_classes, serial_pair.left
+    )
+
+    protocol = asyncio.Protocol()
+    transport = transport_cls(loop=loop, protocol=protocol)
+
+    connect_task = asyncio.create_task(
+        transport.connect(path=serial_pair.left, baudrate=115200)
+    )
+    await asyncio.sleep(0)
+    connect_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(connect_task, timeout=5.0)
+
+    await asyncio.wait_for(transport.wait_closed(), timeout=5.0)
+    await asyncio.wait_for(transport.wait_closed(), timeout=5.0)
+    assert transport.is_closing()

--- a/tests/test_async_transports.py
+++ b/tests/test_async_transports.py
@@ -1122,3 +1122,16 @@ async def test_async_connect_cancel(serial_pair: SerialPair) -> None:
     await asyncio.wait_for(transport.wait_closed(), timeout=5.0)
     await asyncio.wait_for(transport.wait_closed(), timeout=5.0)
     assert transport.is_closing()
+
+
+async def test_async_abort_before_connect_wait_closed(serial_pair: SerialPair) -> None:
+    """Test abort-before-connect still resolves wait_closed."""
+    loop = asyncio.get_running_loop()
+    _serial_cls, transport_cls = get_serial_classes(serial_pair.left)
+
+    transport = transport_cls(loop=loop, protocol=asyncio.Protocol())
+    transport.abort()
+
+    await asyncio.wait_for(transport.wait_closed(), timeout=5.0)
+    await asyncio.wait_for(transport.wait_closed(), timeout=5.0)
+    assert transport.is_closing()

--- a/tests/test_async_transports.py
+++ b/tests/test_async_transports.py
@@ -349,6 +349,18 @@ async def test_async_valid_byte_size(serial_pair: SerialPair, byte_size: int) ->
         writer.write(b"test")
 
 
+async def test_async_invalid_byte_size(serial_pair: SerialPair) -> None:
+    """Test that an invalid byte size is rejected."""
+    if SerialBackend.SOCKET in serial_pair.backends:
+        pytest.skip("socket transport does not validate serial settings")
+
+    with pytest.raises(Exception):
+        async with async_create_reader_writer(
+            serial_pair.left, baudrate=115200, byte_size=123
+        ):
+            pass
+
+
 @pytest.mark.parametrize("xonxoff", [True, False])
 async def test_async_xonxoff_setting(serial_pair: SerialPair, xonxoff: bool) -> None:
     """Test that xonxoff setting is accepted."""

--- a/tests/test_serial_rfc2217.py
+++ b/tests/test_serial_rfc2217.py
@@ -78,7 +78,7 @@ def test_sync_negotiate_timeout_silent_server() -> None:
                 ):
                     pass
 
-        assert 0.1 <= elapsed() < 1.0
+        assert 0.09 <= elapsed() < 1.1
 
 
 async def test_async_negotiate_timeout_silent_server() -> None:

--- a/tests/test_sync_transports.py
+++ b/tests/test_sync_transports.py
@@ -351,6 +351,16 @@ def test_sync_valid_byte_size(serial_pair: SerialPair, byte_size: int) -> None:
         serial.write(b"test")
 
 
+def test_sync_invalid_byte_size(serial_pair: SerialPair) -> None:
+    """Test that an invalid byte size is rejected."""
+    if SerialBackend.SOCKET in serial_pair.backends:
+        pytest.skip("socket transport does not validate serial settings")
+
+    with pytest.raises(Exception):
+        with Serial.from_url(serial_pair.left, baudrate=115200, byte_size=123):
+            pass
+
+
 @pytest.mark.parametrize("xonxoff", [True, False])
 def test_sync_xonxoff_setting(serial_pair: SerialPair, xonxoff: bool) -> None:
     """Test that xonxoff setting is accepted."""

--- a/tests/test_sync_transports.py
+++ b/tests/test_sync_transports.py
@@ -249,23 +249,6 @@ def test_sync_sustained_throughput(
 @pytest.mark.parametrize(
     "baudrate", [9600, 19200, 38400, 57600, 115200, 230400, 460800, 921600]
 )
-def test_sync_nonstandard_baudrate(serial_pair: SerialPair) -> None:
-    """Test that a non-standard baudrate (no termios constant) is accepted."""
-    if serial_pair.serial_class in ("PosixSerial", "ExtendedPosixSerial"):
-        pytest.skip("Base POSIX backends only support standard baudrates")
-
-    if sys.platform == "darwin" and SerialBackend.SER2NET in serial_pair.backends:
-        pytest.xfail("macOS termios lacks constants above B230400")
-
-    with (
-        Serial.from_url(serial_pair.left, baudrate=200000) as left,
-        Serial.from_url(serial_pair.right, baudrate=200000) as right,
-    ):
-        assert left.baudrate == 200000
-        left.write(b"test")
-        assert right.readexactly(4) == b"test"
-
-
 def test_sync_valid_baudrates(serial_pair: SerialPair, baudrate: int) -> None:
     """Test that valid baudrates are accepted."""
     if (
@@ -281,6 +264,23 @@ def test_sync_valid_baudrates(serial_pair: SerialPair, baudrate: int) -> None:
     with Serial.from_url(serial_pair.left, baudrate=baudrate) as serial:
         assert serial.baudrate == baudrate
         serial.write(b"test")
+
+
+def test_sync_nonstandard_baudrate(serial_pair: SerialPair) -> None:
+    """Test that a non-standard baudrate (no termios constant) is accepted."""
+    if serial_pair.serial_class in ("PosixSerial", "ExtendedPosixSerial"):
+        pytest.skip("Base POSIX backends only support standard baudrates")
+
+    if sys.platform == "darwin" and SerialBackend.SER2NET in serial_pair.backends:
+        pytest.xfail("macOS termios lacks constants above B230400")
+
+    with (
+        Serial.from_url(serial_pair.left, baudrate=200000) as left,
+        Serial.from_url(serial_pair.right, baudrate=200000) as right,
+    ):
+        assert left.baudrate == 200000
+        left.write(b"test")
+        assert right.readexactly(4) == b"test"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sync_transports.py
+++ b/tests/test_sync_transports.py
@@ -63,6 +63,28 @@ def test_sync_binary_payload_sizes(serial_pair: SerialPair, size: int) -> None:
         assert right.readexactly(len(data)) == data
 
 
+def test_sync_write_bytearray(serial_pair: SerialPair) -> None:
+    """Test writing bytearray data."""
+    with (
+        Serial.from_url(serial_pair.left, baudrate=115200) as left,
+        Serial.from_url(serial_pair.right, baudrate=115200) as right,
+    ):
+        data = bytearray(b"hello bytearray")
+        left.write(data)
+        assert right.readexactly(len(data)) == b"hello bytearray"
+
+
+def test_sync_write_empty(serial_pair: SerialPair) -> None:
+    """Test writing empty data is a no-op."""
+    with (
+        Serial.from_url(serial_pair.left, baudrate=115200) as left,
+        Serial.from_url(serial_pair.right, baudrate=115200) as right,
+    ):
+        left.write(b"")
+        left.write(b"after_empty")
+        assert right.readexactly(len(b"after_empty")) == b"after_empty"
+
+
 def test_sync_null_bytes(serial_pair: SerialPair) -> None:
     """Test that null bytes (0x00) can be transmitted."""
     with (
@@ -227,6 +249,23 @@ def test_sync_sustained_throughput(
 @pytest.mark.parametrize(
     "baudrate", [9600, 19200, 38400, 57600, 115200, 230400, 460800, 921600]
 )
+def test_sync_nonstandard_baudrate(serial_pair: SerialPair) -> None:
+    """Test that a non-standard baudrate (no termios constant) is accepted."""
+    if serial_pair.serial_class in ("PosixSerial", "ExtendedPosixSerial"):
+        pytest.skip("Base POSIX backends only support standard baudrates")
+
+    if sys.platform == "darwin" and SerialBackend.SER2NET in serial_pair.backends:
+        pytest.xfail("macOS termios lacks constants above B230400")
+
+    with (
+        Serial.from_url(serial_pair.left, baudrate=200000) as left,
+        Serial.from_url(serial_pair.right, baudrate=200000) as right,
+    ):
+        assert left.baudrate == 200000
+        left.write(b"test")
+        assert right.readexactly(4) == b"test"
+
+
 def test_sync_valid_baudrates(serial_pair: SerialPair, baudrate: int) -> None:
     """Test that valid baudrates are accepted."""
     if (
@@ -364,6 +403,16 @@ def test_sync_exclusive_disabled(serial_pair: SerialPair) -> None:
 
 
 # --- Lifecycle ---
+
+
+def test_sync_close_is_idempotent(serial_pair: SerialPair) -> None:
+    """Test closing multiple times is safe."""
+    serial = Serial.from_url(serial_pair.left, baudrate=115200)
+    serial.open()
+    serial.close()
+
+    # Second close should be no-op
+    serial.close()
 
 
 def test_sync_context_manager_multiple_times(serial_pair: SerialPair) -> None:


### PR DESCRIPTION
The async test suite did not test `exclusive=True` and thus we missed this very critical codepath. I've checked both test suites for parity and aligned the two, in addition to fixing a bug that could trigger during the failed lock case.

I've taken this opportunity to also allow Windows exclusivity to be disabled.