### PR TITLE
Custom URI handler registration

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,6 +7,8 @@ import sys
 
 sys.path.insert(0, os.path.abspath(".."))
 
+os.environ["SPHINX_BUILD"] = "1"
+
 project = "serialx"
 author = "puddly"
 copyright = "2026, serialx contributors"

--- a/docs/custom_uri_handlers.md
+++ b/docs/custom_uri_handlers.md
@@ -1,0 +1,73 @@
+# Custom URI handlers
+serialx dispatches URLs like `/dev/ttyUSB0`, `socket://host:port`, or
+`rfc2217://host:port` through a registration-based handler system. You can
+register your own scheme so that `serialx.serial_for_url(...)` and the async
+entry points route to your sync class and async transport.
+
+## Registering a handler
+Call {func}`serialx.register_uri_handler` at module import time:
+
+```python
+from serialx import BaseSerial, BaseSerialTransport, register_uri_handler
+
+
+class MySerial(BaseSerial):
+    """Synchronous implementation."""
+    # ... implement the BaseSerial interface ...
+
+
+class MySerialTransport(BaseSerialTransport):
+    """Async transport."""
+    # ... implement the BaseSerialTransport interface ...
+
+
+register_uri_handler(
+    scheme="my-backend://",
+    unique_scheme="my-backend://",
+    sync_cls=MySerial,
+    async_transport_cls=MySerialTransport,
+)
+```
+
+After registration, any call to `serial_for_url("my-backend://...")` or
+`create_serial_connection(url="my-backend://...")` dispatches to your classes.
+
+## Parameters
+`scheme` is the dispatch scheme. Multiple handlers may share the same
+`scheme` but the highest-`weight` registration wins. This is how the `device://`
+scheme is shared across the platform-native handlers (`linux://`, `darwin://`,
+`windows://`, and so on): they all register under `scheme="device://"` but
+with a distinct `unique_scheme`.
+
+`unique_scheme` is an address for a specific handler. It lets callers
+bypass the shared-scheme dispatch and force a specific backend:
+
+```python
+serialx.serial_for_url("posix:///dev/ttyUSB0")  # forces the generic POSIX handler
+```
+
+`weight` controls priority under a shared `scheme`. The platform-native
+handlers use `weight=3`, the extended POSIX handler uses `weight=2`, and the
+bare POSIX handler uses the default `weight=1`. You rarely need to set this
+unless you are layering a custom backend over an existing shared scheme.
+
+`strip_uri_scheme` is a convenience for backends whose underlying class
+expects a bare device path rather than a URI. When set, the leading
+`scheme` / `unique_scheme` is removed before the URI reaches
+`sync_cls.__init__` or `transport.connect(path=...)`. The platform `device://`
+handlers use this so that `posix:///dev/ttyUSB0` is passed to `PosixSerial`
+as `/dev/ttyUSB0`. Socket-style backends (`socket://`, `rfc2217://`,
+`esphome://`) leave this `False` because the class parses the full URI for
+host, port, and query parameters.
+
+`list_serial_ports_func` is a callable that enumerates ports for this backend.
+
+## Unregistering
+
+`register_uri_handler` returns a callable that removes the registration:
+
+```python
+unregister = register_uri_handler(...)
+# ... later ...
+unregister()
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ Each backend has protocol-specific options that can be passed as keyword argumen
 quickstart
 installation
 usage
+custom_uri_handlers
 api
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,7 @@ enable_error_code = [
 [[tool.mypy.overrides]]
 module = ["tests.*"]
 disable_error_code = [
+    "abstract",
     "no-untyped-call",
     "no-untyped-def",
     "redundant-expr",

--- a/serialx/__init__.py
+++ b/serialx/__init__.py
@@ -16,6 +16,7 @@ from .common import (
     StopBits,
     UnsupportedSetting,
     get_serial_classes,
+    register_uri_handler,
 )
 from .compat import (
     CR,
@@ -39,6 +40,7 @@ __all__ = [
     "get_serial_classes",
     "list_serial_ports",
     "open_serial_connection",
+    "register_uri_handler",
     "serial_for_url",
     "ModemPins",
     "Parity",

--- a/serialx/async_serial.py
+++ b/serialx/async_serial.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 import logging
 from typing import Any, Generic, TypeVar, cast
 
-from .common import BaseSerialTransport, Parity, StopBits, get_serial_classes
+from .common import BaseSerialTransport, Parity, StopBits, get_uri_handler
 
 LOGGER = logging.getLogger(__name__)
 
@@ -42,9 +42,10 @@ async def create_serial_connection(
         if url is None:
             raise ValueError("One of `url` or `transport_cls` must be provided.")
 
-        _, transport_cls = await asyncio.get_running_loop().run_in_executor(
-            None, get_serial_classes, url
+        handler = await asyncio.get_running_loop().run_in_executor(
+            None, get_uri_handler, url
         )
+        transport_cls = handler.async_transport_cls
 
     assert transport_cls is not None
     protocol = protocol_factory()

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -36,7 +36,7 @@ class RegisteredUriHandler:
     weight: int
     sync_cls: type[BaseSerial]
     async_transport_cls: type[BaseSerialTransport]
-    list_serial_ports_func: Callable[[], list[SerialPortInfo]] | None
+    list_serial_ports_func: Callable[[], list[SerialPortInfo]]
     strip_uri_scheme: bool
 
 
@@ -46,11 +46,39 @@ def register_uri_handler(
     unique_scheme: str,
     sync_cls: type[BaseSerial],
     async_transport_cls: type[BaseSerialTransport],
-    list_serial_ports_func: Callable[[], list[SerialPortInfo]] | None = None,
+    list_serial_ports_func: Callable[[], list[SerialPortInfo]],
     weight: int = 1,
     strip_uri_scheme: bool = False,
 ) -> Callable[[], None]:
-    """Register a URI handler."""
+    """Register a URI handler.
+
+    Call this at module import time to expose a new backend to
+    ``serial_for_url`` / ``create_serial_connection`` / ``open_serial_connection``.
+
+    Args:
+        scheme: Shared dispatch scheme. URLs with this scheme resolve to the
+            highest-weight handler registered under it.
+        unique_scheme: A scheme that uniquely identifies this handler. Must end
+            with ``://`` and must not collide with an existing registration.
+            Use this to address the handler directly.
+        sync_cls: Synchronous serial class, typically a subclass of
+            :class:`BaseSerial`.
+        async_transport_cls: Async transport class, typically a subclass of
+            :class:`BaseSerialTransport`.
+        list_serial_ports_func: Callable returning a list of :class:`SerialPortInfo`.
+        weight: Dispatch priority under ``scheme``. Higher wins.
+        strip_uri_scheme: If ``True``, the leading ``scheme`` / ``unique_scheme``
+            is removed before the URL is passed to the sync class. Set this when
+            the underlying class expects a bare device path rather than a URL.
+
+    Returns:
+        A callable that unregisters the handler.
+
+    Raises:
+        ValueError: if either scheme doesn't end with ``://`` or ``unique_scheme``
+            is already registered.
+
+    """
     if not scheme.endswith("://") or not unique_scheme.endswith("://"):
         raise ValueError(f"Schemes {scheme!r} and {unique_scheme!r} must end with ://")
 

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -16,15 +16,11 @@ import io
 from pathlib import Path
 import time
 from types import TracebackType
-from typing import Any, Concatenate, ParamSpec, TypeVar, cast
+from typing import Any, Concatenate, NamedTuple, ParamSpec, TypeVar, cast
 import urllib.parse
 import warnings
 
 from typing_extensions import Buffer, Self
-
-_REGISTERED_URI_HANDLERS: defaultdict[
-    str, list[tuple[int, float, RegisteredUriHandler]]
-] = defaultdict(list)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -38,6 +34,17 @@ class RegisteredUriHandler:
     async_transport_cls: type[BaseSerialTransport]
     list_serial_ports_func: Callable[[], list[SerialPortInfo]]
     strip_uri_scheme: bool
+
+
+class _RegistryEntry(NamedTuple):
+    """Entry in `_REGISTERED_URI_HANDLERS`, ordered by (weight, insertion_time)."""
+
+    weight: int
+    insertion_time: float  # To avoid comparing `RegisteredUriHandler` objects
+    handler: RegisteredUriHandler
+
+
+_REGISTERED_URI_HANDLERS: defaultdict[str, list[_RegistryEntry]] = defaultdict(list)
 
 
 def register_uri_handler(
@@ -88,10 +95,10 @@ def register_uri_handler(
             f" already registered to {_REGISTERED_URI_HANDLERS[unique_scheme]}"
         )
 
-    item = (
-        weight,
-        time.monotonic(),  # To avoid comparing `RegisteredUriHandler` objects
-        RegisteredUriHandler(
+    item = _RegistryEntry(
+        weight=weight,
+        insertion_time=time.monotonic(),
+        handler=RegisteredUriHandler(
             scheme=scheme,
             unique_scheme=unique_scheme,
             weight=weight,
@@ -121,7 +128,7 @@ def get_uri_handler(uri: str) -> RegisteredUriHandler:
     handlers = _REGISTERED_URI_HANDLERS.get(scheme)
     if not handlers:
         raise UnknownUriScheme(f"No handler registered for URI scheme {scheme!r}")
-    return handlers[-1][2]
+    return handlers[-1].handler
 
 
 class SerialException(Exception):

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from abc import abstractmethod
 import asyncio
 from asyncio import IncompleteReadError
+import bisect
+from collections import defaultdict
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 import dataclasses
@@ -19,6 +21,76 @@ import urllib.parse
 import warnings
 
 from typing_extensions import Buffer, Self
+
+_REGISTERED_URI_HANDLERS: defaultdict[
+    str, list[tuple[int, float, RegisteredUriHandler]]
+] = defaultdict(list)
+
+
+@dataclasses.dataclass(frozen=True)
+class RegisteredUriHandler:
+    """A URI handler registration entry."""
+
+    scheme: str
+    unique_scheme: str
+    weight: int
+    sync_cls: type[BaseSerial]
+    async_transport_cls: type[BaseSerialTransport]
+    list_serial_ports_func: Callable[[], list[SerialPortInfo]] | None
+    strip_uri_scheme: bool
+
+
+def register_uri_handler(
+    *,
+    scheme: str,
+    unique_scheme: str,
+    sync_cls: type[BaseSerial],
+    async_transport_cls: type[BaseSerialTransport],
+    list_serial_ports_func: Callable[[], list[SerialPortInfo]] | None = None,
+    weight: int = 1,
+    strip_uri_scheme: bool = False,
+) -> Callable[[], None]:
+    """Register a URI handler."""
+    if not scheme.endswith("://") or not unique_scheme.endswith("://"):
+        raise ValueError(f"Schemes {scheme!r} and {unique_scheme!r} must end with ://")
+
+    if _REGISTERED_URI_HANDLERS[unique_scheme]:
+        raise ValueError(
+            f"URI scheme {unique_scheme!r} is not unique,"
+            f" already registered to {_REGISTERED_URI_HANDLERS[unique_scheme]}"
+        )
+
+    item = (
+        weight,
+        time.monotonic(),  # To avoid comparing `RegisteredUriHandler` objects
+        RegisteredUriHandler(
+            scheme=scheme,
+            unique_scheme=unique_scheme,
+            weight=weight,
+            sync_cls=sync_cls,
+            async_transport_cls=async_transport_cls,
+            list_serial_ports_func=list_serial_ports_func,
+            strip_uri_scheme=strip_uri_scheme,
+        ),
+    )
+    bisect.insort_right(_REGISTERED_URI_HANDLERS[scheme], item)
+
+    if unique_scheme != scheme:
+        _REGISTERED_URI_HANDLERS[unique_scheme].append(item)
+
+    def remove_callback() -> None:
+        _REGISTERED_URI_HANDLERS[scheme].remove(item)
+        if unique_scheme != scheme:
+            _REGISTERED_URI_HANDLERS[unique_scheme].remove(item)
+
+    return remove_callback
+
+
+def get_uri_handler(uri: str) -> RegisteredUriHandler:
+    """Look up the registered handler for the given URI."""
+    parsed_uri = urllib.parse.urlparse(uri)
+    scheme = parsed_uri.scheme or "device"
+    return _REGISTERED_URI_HANDLERS[scheme + "://"][-1][2]
 
 
 class SerialException(Exception):
@@ -221,8 +293,10 @@ class BaseSerial(io.RawIOBase):
     @classmethod
     def from_url(cls, url: str, *args: Any, **kwargs: Any) -> BaseSerial:
         """Create the appropriate serial port subclass for the given URL."""
-        serial_cls, _ = get_serial_classes(url)
-        return serial_cls(url, *args, **kwargs)
+        handler = get_uri_handler(url)
+        if handler.strip_uri_scheme:
+            url = url.removeprefix(handler.scheme).removeprefix(handler.unique_scheme)
+        return handler.sync_cls(url, *args, **kwargs)
 
     @maybe_wrap_exceptions
     def open(self) -> None:
@@ -785,6 +859,13 @@ class BaseSerialTransport(asyncio.Transport):
         **kwargs: Any,
     ) -> None:
         """Connect to serial port."""
+        if path is not None:
+            handler = get_uri_handler(path)
+            if handler.strip_uri_scheme:
+                path = path.removeprefix(handler.scheme).removeprefix(
+                    handler.unique_scheme
+                )
+
         try:
             await self._connect(
                 path=path,
@@ -863,39 +944,8 @@ def get_serial_classes(
     url: str,
 ) -> tuple[type[BaseSerial], type[BaseSerialTransport]]:
     """Get the appropriate serial and transport classes based on the URL scheme."""
-    parsed_path = urllib.parse.urlparse(url)
-
-    if parsed_path.scheme in ("socket", "tcp"):
-        from .platforms.serial_socket import (  # noqa: PLC0415
-            SocketSerial,
-            SocketSerialTransport,
-        )
-
-        return SocketSerial, SocketSerialTransport
-    elif parsed_path.scheme == "rfc2217":
-        from .platforms.serial_rfc2217 import (  # noqa: PLC0415
-            RFC2217Serial,
-            RFC2217SerialTransport,
-        )
-
-        return RFC2217Serial, RFC2217SerialTransport
-    elif parsed_path.scheme == "esphome":
-        try:
-            from .platforms.serial_esphome import (  # noqa: PLC0415
-                ESPHomeSerial,
-                ESPHomeSerialTransport,
-            )
-        except ImportError as exc:
-            raise RuntimeError(
-                "ESPHome serial transport requires extra dependencies."
-                " Install with `pip install serialx[esphome]`"
-            ) from exc
-
-        return ESPHomeSerial, ESPHomeSerialTransport
-    else:
-        from .platforms import Serial, SerialTransport  # noqa: PLC0415
-
-        return Serial, SerialTransport
+    handler = get_uri_handler(url)
+    return handler.sync_cls, handler.async_transport_cls
 
 
 @dataclasses.dataclass

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -117,8 +117,11 @@ def register_uri_handler(
 def get_uri_handler(uri: str) -> RegisteredUriHandler:
     """Look up the registered handler for the given URI."""
     parsed_uri = urllib.parse.urlparse(uri)
-    scheme = parsed_uri.scheme or "device"
-    return _REGISTERED_URI_HANDLERS[scheme + "://"][-1][2]
+    scheme = (parsed_uri.scheme or "device") + "://"
+    handlers = _REGISTERED_URI_HANDLERS.get(scheme)
+    if not handlers:
+        raise UnknownUriScheme(f"No handler registered for URI scheme {scheme!r}")
+    return handlers[-1][2]
 
 
 class SerialException(Exception):
@@ -127,6 +130,10 @@ class SerialException(Exception):
 
 class UnsupportedSetting(SerialException):
     """Raised when an unsupported serial port setting is used."""
+
+
+class UnknownUriScheme(SerialException):
+    """Raised when a URI scheme has no registered handler."""
 
 
 class StopBits(Enum):

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -59,8 +59,8 @@ def register_uri_handler(
 ) -> Callable[[], None]:
     """Register a URI handler.
 
-    Call this at module import time to expose a new backend to
-    ``serial_for_url`` / ``create_serial_connection`` / ``open_serial_connection``.
+    Expose a new backend to ``serial_for_url`` / ``create_serial_connection`` /
+    ``open_serial_connection``.
 
     Args:
         scheme: Shared dispatch scheme. URLs with this scheme resolve to the

--- a/serialx/platforms/__init__.py
+++ b/serialx/platforms/__init__.py
@@ -1,54 +1,45 @@
 """Individual platform implementations."""
 
-import sys
+from contextlib import suppress
+from typing import TYPE_CHECKING
 
-try:
-    import termios  # noqa: F401
-except ImportError:
-    maybe_posix = False
+from ..common import SerialPortInfo, get_uri_handler
+from . import (
+    serial_rfc2217,  # noqa: F401
+    serial_socket,  # noqa: F401
+)
+
+with suppress(ImportError):
+    from . import serial_win32  # noqa: F401
+
+with suppress(ImportError):
+    from . import serial_posix  # noqa: F401
+
+with suppress(ImportError):
+    from . import serial_extended_posix  # noqa: F401
+
+with suppress(ImportError):
+    from . import serial_linux  # noqa: F401
+
+with suppress(ImportError):
+    from . import serial_darwin  # noqa: F401
+
+with suppress(ImportError):
+    from . import serial_freebsd  # noqa: F401
+
+with suppress(ImportError):
+    from . import serial_esphome  # noqa: F401
+
+if TYPE_CHECKING:
+    from ..common import BaseSerial as Serial, BaseSerialTransport as SerialTransport
+
+    def list_serial_ports() -> list[SerialPortInfo]:
+        """List serial ports for mypy."""
 else:
-    maybe_posix = True
-
-if sys.platform == "win32":
-    from .serial_win32 import (
-        Win32Serial as Serial,
-        Win32SerialTransport as SerialTransport,
-        win32_list_serial_ports as list_serial_ports,
-    )
-elif sys.platform == "linux":
-    from .serial_linux import (
-        LinuxSerial as Serial,
-        LinuxSerialTransport as SerialTransport,
-        linux_list_serial_ports as list_serial_ports,
-    )
-elif sys.platform == "darwin":
-    from .serial_darwin import (
-        DarwinSerial as Serial,
-        DarwinSerialTransport as SerialTransport,
-        darwin_list_serial_ports as list_serial_ports,
-    )
-elif sys.platform.startswith("freebsd"):
-    from .serial_freebsd import (
-        FreeBSDSerial as Serial,
-        FreeBSDSerialTransport as SerialTransport,
-        freebsd_list_serial_ports as list_serial_ports,
-    )
-elif maybe_posix:
-    from .serial_extended_posix import is_extended_posix
-
-    if is_extended_posix():
-        from .serial_extended_posix import (
-            ExtendedPosixSerial as Serial,
-            ExtendedPosixSerialTransport as SerialTransport,
-        )
-    else:
-        from .serial_posix import (
-            PosixSerial as Serial,
-            PosixSerialTransport as SerialTransport,
-        )
-    from .serial_posix import posix_list_serial_ports as list_serial_ports
-else:
-    raise RuntimeError(f"Unsupported platform: {sys.platform}")
+    _handler = get_uri_handler("device://")
+    Serial = _handler.sync_cls
+    SerialTransport = _handler.async_transport_cls
+    list_serial_ports = _handler.list_serial_ports_func
 
 __all__ = [
     "Serial",

--- a/serialx/platforms/serial_darwin.py
+++ b/serialx/platforms/serial_darwin.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import os
 import sys
 
-if sys.platform != "darwin":
+if sys.platform != "darwin" and not os.environ.get("SPHINX_BUILD"):
     raise ImportError("serial_darwin is only supported on macOS")
 
 import array

--- a/serialx/platforms/serial_darwin.py
+++ b/serialx/platforms/serial_darwin.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+import sys
+
+if sys.platform != "darwin":
+    raise ImportError("serial_darwin is only supported on macOS")
+
 import array
 import errno
 import fcntl
@@ -9,7 +14,7 @@ import logging
 import termios
 
 from serialx._serialx_rust import list_serial_ports_darwin_impl
-from serialx.common import SerialPortInfo
+from serialx.common import SerialPortInfo, register_uri_handler
 
 from .serial_extended_posix import ExtendedPosixSerial, ExtendedPosixSerialTransport
 
@@ -84,3 +89,14 @@ def darwin_list_serial_ports() -> list[SerialPortInfo]:
         )
         for port in list_serial_ports_darwin_impl()
     ]
+
+
+register_uri_handler(
+    scheme="device://",
+    unique_scheme="darwin://",
+    sync_cls=DarwinSerial,
+    async_transport_cls=DarwinSerialTransport,
+    list_serial_ports_func=darwin_list_serial_ports,
+    weight=3,
+    strip_uri_scheme=True,
+)

--- a/serialx/platforms/serial_darwin.py
+++ b/serialx/platforms/serial_darwin.py
@@ -2,16 +2,11 @@
 
 from __future__ import annotations
 
-import os
-import sys
-
-if sys.platform != "darwin" and not os.environ.get("SPHINX_BUILD"):
-    raise ImportError("serial_darwin is only supported on macOS")
-
 import array
 import errno
 import fcntl
 import logging
+import sys
 import termios
 
 from serialx._serialx_rust import list_serial_ports_darwin_impl
@@ -92,12 +87,13 @@ def darwin_list_serial_ports() -> list[SerialPortInfo]:
     ]
 
 
-register_uri_handler(
-    scheme="device://",
-    unique_scheme="darwin://",
-    sync_cls=DarwinSerial,
-    async_transport_cls=DarwinSerialTransport,
-    list_serial_ports_func=darwin_list_serial_ports,
-    weight=3,
-    strip_uri_scheme=True,
-)
+if sys.platform == "darwin":
+    register_uri_handler(
+        scheme="device://",
+        unique_scheme="darwin://",
+        sync_cls=DarwinSerial,
+        async_transport_cls=DarwinSerialTransport,
+        list_serial_ports_func=darwin_list_serial_ports,
+        weight=3,
+        strip_uri_scheme=True,
+    )

--- a/serialx/platforms/serial_esphome.py
+++ b/serialx/platforms/serial_esphome.py
@@ -29,6 +29,7 @@ from serialx.common import (
     ModemPins,
     Parity,
     PinState,
+    SerialPortInfo,
     StopBits,
     register_uri_handler,
 )
@@ -474,9 +475,15 @@ class ESPHomeSerialTransport(BaseSerialTransport):
         return 0
 
 
+def esphome_list_serial_ports() -> list[SerialPortInfo]:
+    """List serial ports for sockets."""
+    return []
+
+
 register_uri_handler(
     scheme="esphome://",
     unique_scheme="esphome://",
     sync_cls=ESPHomeSerial,
     async_transport_cls=ESPHomeSerialTransport,
+    list_serial_ports_func=esphome_list_serial_ports,
 )

--- a/serialx/platforms/serial_esphome.py
+++ b/serialx/platforms/serial_esphome.py
@@ -30,6 +30,7 @@ from serialx.common import (
     Parity,
     PinState,
     StopBits,
+    register_uri_handler,
 )
 
 _T = TypeVar("_T")
@@ -471,3 +472,11 @@ class ESPHomeSerialTransport(BaseSerialTransport):
     def get_write_buffer_size(self) -> int:
         """Get the number of bytes currently in the write buffer."""
         return 0
+
+
+register_uri_handler(
+    scheme="esphome://",
+    unique_scheme="esphome://",
+    sync_cls=ESPHomeSerial,
+    async_transport_cls=ESPHomeSerialTransport,
+)

--- a/serialx/platforms/serial_extended_posix.py
+++ b/serialx/platforms/serial_extended_posix.py
@@ -7,7 +7,8 @@ from __future__ import annotations
 
 import termios
 
-from .serial_posix import PosixSerial, PosixSerialTransport
+from ..common import register_uri_handler
+from .serial_posix import PosixSerial, PosixSerialTransport, posix_list_serial_ports
 
 CRTSCTS = getattr(termios, "CRTSCTS", getattr(termios, "CNEW_RTSCTS", None))
 
@@ -38,3 +39,14 @@ class ExtendedPosixSerialTransport(PosixSerialTransport):
     """Extended POSIX serial port transport with CRTSCTS support."""
 
     _serial_cls = ExtendedPosixSerial
+
+
+register_uri_handler(
+    scheme="device://",
+    unique_scheme="extended-posix://",
+    sync_cls=ExtendedPosixSerial,
+    async_transport_cls=ExtendedPosixSerialTransport,
+    list_serial_ports_func=posix_list_serial_ports,
+    weight=2,
+    strip_uri_scheme=True,
+)

--- a/serialx/platforms/serial_extended_posix.py
+++ b/serialx/platforms/serial_extended_posix.py
@@ -41,12 +41,13 @@ class ExtendedPosixSerialTransport(PosixSerialTransport):
     _serial_cls = ExtendedPosixSerial
 
 
-register_uri_handler(
-    scheme="device://",
-    unique_scheme="extended-posix://",
-    sync_cls=ExtendedPosixSerial,
-    async_transport_cls=ExtendedPosixSerialTransport,
-    list_serial_ports_func=posix_list_serial_ports,
-    weight=2,
-    strip_uri_scheme=True,
-)
+if is_extended_posix():
+    register_uri_handler(
+        scheme="device://",
+        unique_scheme="extended-posix://",
+        sync_cls=ExtendedPosixSerial,
+        async_transport_cls=ExtendedPosixSerialTransport,
+        list_serial_ports_func=posix_list_serial_ports,
+        weight=2,
+        strip_uri_scheme=True,
+    )

--- a/serialx/platforms/serial_freebsd.py
+++ b/serialx/platforms/serial_freebsd.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
-import logging
+import sys
+
+if not sys.platform.startswith("freebsd"):
+    raise ImportError("serial_freebsd is only supported on FreeBSD")
+
+import logging  # type: ignore[unreachable]
 import re
 import subprocess
 
-from ..common import SerialPortInfo
+from ..common import SerialPortInfo, register_uri_handler
 from .serial_extended_posix import ExtendedPosixSerial, ExtendedPosixSerialTransport
 
 LOGGER = logging.getLogger(__name__)
@@ -138,3 +143,14 @@ def freebsd_list_serial_ports() -> list[SerialPortInfo]:
         )
 
     return results
+
+
+register_uri_handler(
+    scheme="device://",
+    unique_scheme="freebsd://",
+    sync_cls=FreeBSDSerial,
+    async_transport_cls=FreeBSDSerialTransport,
+    list_serial_ports_func=freebsd_list_serial_ports,
+    weight=3,
+    strip_uri_scheme=True,
+)

--- a/serialx/platforms/serial_freebsd.py
+++ b/serialx/platforms/serial_freebsd.py
@@ -2,15 +2,10 @@
 
 from __future__ import annotations
 
-import os
-import sys
-
-if not sys.platform.startswith("freebsd") and not os.environ.get("SPHINX_BUILD"):
-    raise ImportError("serial_freebsd is only supported on FreeBSD")
-
 import logging
 import re
 import subprocess
+import sys
 
 from ..common import SerialPortInfo, register_uri_handler
 from .serial_extended_posix import ExtendedPosixSerial, ExtendedPosixSerialTransport
@@ -146,12 +141,13 @@ def freebsd_list_serial_ports() -> list[SerialPortInfo]:
     return results
 
 
-register_uri_handler(
-    scheme="device://",
-    unique_scheme="freebsd://",
-    sync_cls=FreeBSDSerial,
-    async_transport_cls=FreeBSDSerialTransport,
-    list_serial_ports_func=freebsd_list_serial_ports,
-    weight=3,
-    strip_uri_scheme=True,
-)
+if sys.platform.startswith("freebsd"):
+    register_uri_handler(
+        scheme="device://",
+        unique_scheme="freebsd://",
+        sync_cls=FreeBSDSerial,
+        async_transport_cls=FreeBSDSerialTransport,
+        list_serial_ports_func=freebsd_list_serial_ports,
+        weight=3,
+        strip_uri_scheme=True,
+    )

--- a/serialx/platforms/serial_freebsd.py
+++ b/serialx/platforms/serial_freebsd.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+import os
 import sys
 
-if not sys.platform.startswith("freebsd"):
+if not sys.platform.startswith("freebsd") and not os.environ.get("SPHINX_BUILD"):
     raise ImportError("serial_freebsd is only supported on FreeBSD")
 
-import logging  # type: ignore[unreachable]
+import logging
 import re
 import subprocess
 

--- a/serialx/platforms/serial_linux.py
+++ b/serialx/platforms/serial_linux.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-import array
+import sys
+
+if sys.platform != "linux":
+    raise ImportError("serial_linux is only supported on Linux")
+
+import array  # type: ignore[unreachable]
 from collections.abc import Iterator
 from contextlib import suppress
 import ctypes
@@ -13,7 +18,7 @@ from pathlib import Path
 import termios
 from typing import Any
 
-from ..common import Parity, SerialPortInfo, UnsupportedSetting
+from ..common import Parity, SerialPortInfo, UnsupportedSetting, register_uri_handler
 from .serial_extended_posix import ExtendedPosixSerial, ExtendedPosixSerialTransport
 
 LOGGER = logging.getLogger(__name__)
@@ -320,3 +325,14 @@ def linux_list_serial_ports() -> list[SerialPortInfo]:
         results.append(info)
 
     return results
+
+
+register_uri_handler(
+    scheme="device://",
+    unique_scheme="linux://",
+    sync_cls=LinuxSerial,
+    async_transport_cls=LinuxSerialTransport,
+    list_serial_ports_func=linux_list_serial_ports,
+    weight=3,
+    strip_uri_scheme=True,
+)

--- a/serialx/platforms/serial_linux.py
+++ b/serialx/platforms/serial_linux.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+import os
 import sys
 
-if sys.platform != "linux":
+if sys.platform != "linux" and not os.environ.get("SPHINX_BUILD"):
     raise ImportError("serial_linux is only supported on Linux")
 
-import array  # type: ignore[unreachable]
+import array
 from collections.abc import Iterator
 from contextlib import suppress
 import ctypes

--- a/serialx/platforms/serial_linux.py
+++ b/serialx/platforms/serial_linux.py
@@ -2,12 +2,6 @@
 
 from __future__ import annotations
 
-import os
-import sys
-
-if sys.platform != "linux" and not os.environ.get("SPHINX_BUILD"):
-    raise ImportError("serial_linux is only supported on Linux")
-
 import array
 from collections.abc import Iterator
 from contextlib import suppress
@@ -16,6 +10,7 @@ import errno
 import fcntl
 import logging
 from pathlib import Path
+import sys
 import termios
 from typing import Any
 
@@ -328,12 +323,13 @@ def linux_list_serial_ports() -> list[SerialPortInfo]:
     return results
 
 
-register_uri_handler(
-    scheme="device://",
-    unique_scheme="linux://",
-    sync_cls=LinuxSerial,
-    async_transport_cls=LinuxSerialTransport,
-    list_serial_ports_func=linux_list_serial_ports,
-    weight=3,
-    strip_uri_scheme=True,
-)
+if sys.platform == "linux":
+    register_uri_handler(
+        scheme="device://",
+        unique_scheme="linux://",
+        sync_cls=LinuxSerial,
+        async_transport_cls=LinuxSerialTransport,
+        list_serial_ports_func=linux_list_serial_ports,
+        weight=3,
+        strip_uri_scheme=True,
+    )

--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -28,6 +28,7 @@ from ..common import (
     SerialPortInfo,
     StopBits,
     UnsupportedSetting,
+    register_uri_handler,
 )
 from ..descriptor_transport import DescriptorTransport
 
@@ -527,3 +528,13 @@ class PosixSerialTransport(DescriptorTransport):
 def posix_list_serial_ports() -> list[SerialPortInfo]:
     """List available serial ports on POSIX."""
     return []
+
+
+register_uri_handler(
+    scheme="device://",
+    unique_scheme="posix://",
+    sync_cls=PosixSerial,
+    async_transport_cls=PosixSerialTransport,
+    list_serial_ports_func=posix_list_serial_ports,
+    strip_uri_scheme=True,
+)

--- a/serialx/platforms/serial_rfc2217/__init__.py
+++ b/serialx/platforms/serial_rfc2217/__init__.py
@@ -24,6 +24,7 @@ from ...common import (
     Parity,
     PinState,
     SerialException,
+    SerialPortInfo,
     StopBits,
     UnsupportedSetting,
     measure_time,
@@ -1040,9 +1041,15 @@ class RFC2217SerialTransport(BaseSerialTransport):
         return self._tcp_transport.can_write_eof()
 
 
+def rfc2217_list_serial_ports() -> list[SerialPortInfo]:
+    """List serial ports for sockets."""
+    return []
+
+
 register_uri_handler(
     scheme="rfc2217://",
     unique_scheme="rfc2217://",
     sync_cls=RFC2217Serial,
     async_transport_cls=RFC2217SerialTransport,
+    list_serial_ports_func=rfc2217_list_serial_ports,
 )

--- a/serialx/platforms/serial_rfc2217/__init__.py
+++ b/serialx/platforms/serial_rfc2217/__init__.py
@@ -27,6 +27,7 @@ from ...common import (
     StopBits,
     UnsupportedSetting,
     measure_time,
+    register_uri_handler,
 )
 from ..serial_socket import SocketSerial
 from .types import (
@@ -1037,3 +1038,11 @@ class RFC2217SerialTransport(BaseSerialTransport):
             return False
 
         return self._tcp_transport.can_write_eof()
+
+
+register_uri_handler(
+    scheme="rfc2217://",
+    unique_scheme="rfc2217://",
+    sync_cls=RFC2217Serial,
+    async_transport_cls=RFC2217SerialTransport,
+)

--- a/serialx/platforms/serial_socket.py
+++ b/serialx/platforms/serial_socket.py
@@ -12,7 +12,14 @@ import urllib.parse
 
 from typing_extensions import Buffer
 
-from serialx.common import BaseSerial, BaseSerialTransport, ModemPins, Parity, StopBits
+from serialx.common import (
+    BaseSerial,
+    BaseSerialTransport,
+    ModemPins,
+    Parity,
+    StopBits,
+    register_uri_handler,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -344,3 +351,17 @@ class SocketSerialTransport(BaseSerialTransport):
             if self._tcp_transport is not None
             else False
         )
+
+
+register_uri_handler(
+    scheme="socket://",
+    unique_scheme="socket://",
+    sync_cls=SocketSerial,
+    async_transport_cls=SocketSerialTransport,
+)
+register_uri_handler(
+    scheme="tcp://",
+    unique_scheme="tcp://",
+    sync_cls=SocketSerial,
+    async_transport_cls=SocketSerialTransport,
+)

--- a/serialx/platforms/serial_socket.py
+++ b/serialx/platforms/serial_socket.py
@@ -17,6 +17,7 @@ from serialx.common import (
     BaseSerialTransport,
     ModemPins,
     Parity,
+    SerialPortInfo,
     StopBits,
     register_uri_handler,
 )
@@ -353,15 +354,22 @@ class SocketSerialTransport(BaseSerialTransport):
         )
 
 
+def socket_list_serial_ports() -> list[SerialPortInfo]:
+    """List serial ports for sockets."""
+    return []
+
+
 register_uri_handler(
     scheme="socket://",
     unique_scheme="socket://",
     sync_cls=SocketSerial,
     async_transport_cls=SocketSerialTransport,
+    list_serial_ports_func=socket_list_serial_ports,
 )
 register_uri_handler(
     scheme="tcp://",
     unique_scheme="tcp://",
     sync_cls=SocketSerial,
     async_transport_cls=SocketSerialTransport,
+    list_serial_ports_func=socket_list_serial_ports,
 )

--- a/serialx/platforms/serial_win32.py
+++ b/serialx/platforms/serial_win32.py
@@ -71,6 +71,7 @@ from ..common import (
     Parity,
     PinState,
     StopBits,
+    register_uri_handler,
 )
 
 if TYPE_CHECKING:
@@ -737,3 +738,13 @@ def win32_list_serial_ports() -> list[SerialPortInfo]:
         )
         for port in list_serial_ports_windows_impl()
     ]
+
+
+register_uri_handler(
+    scheme="device://",
+    unique_scheme="windows://",
+    sync_cls=Win32Serial,
+    async_transport_cls=Win32SerialTransport,
+    list_serial_ports_func=win32_list_serial_ports,
+    strip_uri_scheme=True,
+)

--- a/tests/common.py
+++ b/tests/common.py
@@ -153,7 +153,7 @@ class UnresolvedSerialPair:
     # Accumulated quirks
     quirks: frozenset[SerialQuirk]
 
-    serial_class: str | None = None
+    uri_scheme: str | None = None
     modem_line_propagation_delay: float = 0.05
 
     def chain(self, *backends: SerialBackend) -> Self:
@@ -182,7 +182,7 @@ class SerialPair(UnresolvedSerialPair):
     original_left: str
     original_right: str
 
-    serial_class: str
+    uri_scheme: str
 
 
 def _get_listening_ports(pid: int) -> list[int]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,15 +5,13 @@ from __future__ import annotations
 from collections.abc import AsyncGenerator, Generator
 import contextlib
 import dataclasses
-import importlib
 import os
 import sys
-from unittest.mock import patch
+import urllib.parse
 
 import pytest
 
-import serialx
-import serialx.platforms
+from serialx.common import get_uri_handler
 from tests.common import (
     ESPHOME_HOST_BINARY,
     HUB4COM_BINARY,
@@ -33,12 +31,13 @@ from tests.common import (
 from tests.socket_relay import create_socket_pair
 
 
-def _get_posix_serial_classes() -> list[str]:
-    """Get extra POSIX serial class names to test on this platform.
+def _get_forced_posix_uri_schemes() -> list[str]:
+    """Get extra POSIX URI schemes to test on this platform.
 
-    On Linux (or any platform with a deeper class hierarchy), we also test
-    with the generic POSIX and extended POSIX backends by patching sys.platform
-    and is_extended_posix to force the fallback paths in serialx.platforms.
+    On Linux (or any platform with a deeper class hierarchy), we also test the
+    generic POSIX and extended POSIX backends by addressing the underlying
+    adapter with an explicit URI scheme so the registry dispatches to those
+    classes instead of the platform-native handler.
     """
     try:
         import termios  # noqa: F401, PLC0415
@@ -49,10 +48,10 @@ def _get_posix_serial_classes() -> list[str]:
         is_extended_posix,
     )
 
-    result = ["PosixSerial"]
+    result = ["posix://"]
 
     if is_extended_posix():
-        result.append("ExtendedPosixSerial")
+        result.append("extended-posix://")
 
     return result
 
@@ -190,9 +189,9 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
                 specs.append(adapter_spec.chain(SerialBackend.ESPHOME_HOST))
 
         # For POSIX, we should test base classes on platforms that extend them
-        for cls_name in _get_posix_serial_classes():
+        for uri_scheme in _get_forced_posix_uri_schemes():
             for adapter in adapters:
-                specs.append(dataclasses.replace(adapter, serial_class=cls_name))
+                specs.append(dataclasses.replace(adapter, uri_scheme=uri_scheme))
 
         # Build the pytest parameter groups to limit concurrency to underlying resources
         params = []
@@ -213,8 +212,8 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
 
             param_id = "+".join(backends)
 
-            if spec.serial_class:
-                param_id += f"({spec.serial_class})"
+            if spec.uri_scheme:
+                param_id += f"({spec.uri_scheme})"
 
             params.append(pytest.param(spec, marks=marks, id=param_id))
 
@@ -280,18 +279,17 @@ def serial_pair(request: pytest.FixtureRequest) -> Generator[SerialPair]:
     assert spec.original_left is not None
     assert spec.original_right is not None
 
-    # Check if a serial class override is requested (e.g. "PosixSerial")
-    if spec.serial_class:
-        with (
-            patch("sys.platform", "unknown"),
-            patch(
-                "serialx.platforms.serial_extended_posix.is_extended_posix",
-                return_value=(spec.serial_class == "ExtendedPosixSerial"),
-            ),
-        ):
-            importlib.reload(serialx.platforms)
-
-        assert serialx.platforms.Serial.__name__ == spec.serial_class
+    # If a URI scheme override is requested (e.g. "posix://"), rewrite the raw
+    # device paths to route through that handler. Paths that are already URIs
+    # (e.g. rfc2217://) are left alone.
+    if spec.uri_scheme:
+        if not urllib.parse.urlparse(left).scheme:
+            left = spec.uri_scheme + left
+        if not urllib.parse.urlparse(right).scheme:
+            right = spec.uri_scheme + right
+        effective_scheme = spec.uri_scheme
+    else:
+        effective_scheme = get_uri_handler("device://").unique_scheme
 
     # Finally, emit the spec
     try:
@@ -302,13 +300,10 @@ def serial_pair(request: pytest.FixtureRequest) -> Generator[SerialPair]:
             original_right=spec.original_right,
             backends=spec.backends,
             quirks=spec.quirks,
-            serial_class=serialx.platforms.Serial.__name__,
+            uri_scheme=effective_scheme,
         )
     finally:
         stack.close()
-
-        if spec.serial_class:
-            importlib.reload(serialx.platforms)
 
 
 def _snapshot_fds() -> dict[int, str]:

--- a/tests/test_async_transports.py
+++ b/tests/test_async_transports.py
@@ -127,7 +127,7 @@ async def test_async_random_large(
         baudrate > 230400
         and sys.platform == "darwin"
         and (
-            serial_pair.serial_class in ("PosixSerial", "ExtendedPosixSerial")
+            serial_pair.uri_scheme in ("posix://", "extended-posix://")
             or SerialBackend.SER2NET in serial_pair.backends
         )
     ):
@@ -179,7 +179,7 @@ async def test_async_buffered_writes_then_read(serial_pair: SerialPair) -> None:
 async def test_async_large_payload(serial_pair: SerialPair, payload_size: int) -> None:
     """Test large payload transmission."""
     if sys.platform == "darwin" and (
-        serial_pair.serial_class in ("PosixSerial", "ExtendedPosixSerial")
+        serial_pair.uri_scheme in ("posix://", "extended-posix://")
         or SerialBackend.SER2NET in serial_pair.backends
     ):
         pytest.xfail("macOS termios lacks constants above B230400")
@@ -220,7 +220,7 @@ async def test_async_sustained_throughput(
         baudrate > 230400
         and sys.platform == "darwin"
         and (
-            serial_pair.serial_class in ("PosixSerial", "ExtendedPosixSerial")
+            serial_pair.uri_scheme in ("posix://", "extended-posix://")
             or SerialBackend.SER2NET in serial_pair.backends
         )
     ):
@@ -248,7 +248,7 @@ async def test_async_valid_baudrates(serial_pair: SerialPair, baudrate: int) -> 
         baudrate > 230400
         and sys.platform == "darwin"
         and (
-            serial_pair.serial_class in ("PosixSerial", "ExtendedPosixSerial")
+            serial_pair.uri_scheme in ("posix://", "extended-posix://")
             or SerialBackend.SER2NET in serial_pair.backends
         )
     ):
@@ -264,7 +264,7 @@ async def test_async_valid_baudrates(serial_pair: SerialPair, baudrate: int) -> 
 
 async def test_async_nonstandard_baudrate(serial_pair: SerialPair) -> None:
     """Test that a non-standard baudrate (no termios constant) is accepted."""
-    if serial_pair.serial_class in ("PosixSerial", "ExtendedPosixSerial"):
+    if serial_pair.uri_scheme in ("posix://", "extended-posix://"):
         pytest.skip("Base POSIX backends only support standard baudrates")
 
     if sys.platform == "darwin" and SerialBackend.SER2NET in serial_pair.backends:
@@ -292,7 +292,7 @@ async def test_async_valid_parity(serial_pair: SerialPair, parity: Parity) -> No
     ):
         pytest.xfail("ESPHome backend does not support MARK/SPACE parity")
 
-    if serial_pair.serial_class not in ("LinuxSerial", "Win32Serial") and parity in (
+    if serial_pair.uri_scheme not in ("linux://", "windows://") and parity in (
         Parity.MARK,
         Parity.SPACE,
     ):
@@ -329,7 +329,7 @@ async def test_async_valid_stopbits(
         pytest.xfail("ESPHome backend does not support 1.5 stop bits")
 
     if (
-        serial_pair.serial_class not in ("Win32Serial",)
+        serial_pair.uri_scheme not in ("windows://",)
         and expected is StopBits.ONE_POINT_FIVE
     ):
         pytest.skip("1.5 stop bits only supported on Win32")
@@ -374,7 +374,7 @@ async def test_async_xonxoff_setting(serial_pair: SerialPair, xonxoff: bool) -> 
 @pytest.mark.parametrize("rtscts", [True, False])
 async def test_async_rtscts_setting(serial_pair: SerialPair, rtscts: bool) -> None:
     """Test that rtscts setting is accepted."""
-    if rtscts and serial_pair.serial_class == "PosixSerial":
+    if rtscts and serial_pair.uri_scheme == "posix://":
         pytest.xfail("Strict POSIX backend does not support RTS/CTS flow control")
 
     async with async_create_reader_writer(serial_pair.right, baudrate=115200):
@@ -942,11 +942,11 @@ async def test_async_fast_open_close_with_close(serial_pair: SerialPair) -> None
 async def test_async_deassert_on_open(serial_pair: SerialPair) -> None:
     """Test RTS/CTS deassertion on open."""
 
-    if serial_pair.serial_class in (
-        "LinuxSerial",
-        "DarwinSerial",
-        "PosixSerial",
-        "ExtendedPosixSerial",
+    if serial_pair.uri_scheme in (
+        "linux://",
+        "darwin://",
+        "posix://",
+        "extended-posix://",
     ):
         pytest.skip("POSIX backends do not support deasserting pins on open")
 
@@ -985,11 +985,11 @@ async def test_async_deassert_on_open(serial_pair: SerialPair) -> None:
 @pytest.mark.skip_quirks(SerialQuirk.NO_RTS_CTS, SerialQuirk.NO_DTR_DSR)
 async def test_async_hang_up_on_close(serial_pair: SerialPair) -> None:
     """Test RTS/CTS hang up on close."""
-    if serial_pair.serial_class in (
-        "LinuxSerial",
-        "DarwinSerial",
-        "PosixSerial",
-        "ExtendedPosixSerial",
+    if serial_pair.uri_scheme in (
+        "linux://",
+        "darwin://",
+        "posix://",
+        "extended-posix://",
     ):
         pytest.skip("POSIX backends do not support deasserting pins on open")
 
@@ -1054,11 +1054,11 @@ async def test_async_deassert_on_open_with_rtscts(
 ) -> None:
     """Test interaction of rtsdtr_on_open with rtscts."""
 
-    if serial_pair.serial_class in (
-        "LinuxSerial",
-        "DarwinSerial",
-        "PosixSerial",
-        "ExtendedPosixSerial",
+    if serial_pair.uri_scheme in (
+        "linux://",
+        "darwin://",
+        "posix://",
+        "extended-posix://",
     ):
         pytest.skip("POSIX backends do not support deasserting pins on open")
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,112 @@
+"""Tests for the URI handler registration API."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from unittest.mock import Mock
+
+import pytest
+
+from serialx import get_serial_classes, register_uri_handler
+from serialx.common import (
+    _REGISTERED_URI_HANDLERS,
+    BaseSerial,
+    BaseSerialTransport,
+    UnknownUriScheme,
+    get_uri_handler,
+)
+
+
+@pytest.fixture(autouse=True)
+def ensure_registry_untouched() -> Generator[None]:
+    """Snapshot the URI handler registry and restore it after each test."""
+    snapshot = {
+        scheme: list(items)
+        for scheme, items in _REGISTERED_URI_HANDLERS.items()
+        if items
+    }
+
+    try:
+        yield
+    finally:
+        after = {
+            scheme: list(items)
+            for scheme, items in _REGISTERED_URI_HANDLERS.items()
+            if items
+        }
+        if after != snapshot:
+            pytest.fail(
+                f"URI handlers were leaked by the test! Before: {snapshot}, after: {after}"
+            )
+
+
+def test_register_uri_handler_validation() -> None:
+    """`register_uri_handler` rejects bad schemes and duplicate registrations."""
+    with pytest.raises(ValueError, match="must end with"):
+        register_uri_handler(
+            scheme="bad",
+            unique_scheme="test-unique-1://",
+            sync_cls=BaseSerial,  # type:ignore[type-abstract]
+            async_transport_cls=BaseSerialTransport,  # type:ignore[type-abstract]
+            list_serial_ports_func=list,
+        )
+
+    with pytest.raises(ValueError, match="must end with"):
+        register_uri_handler(
+            scheme="test-shared-1://",
+            unique_scheme="bad",
+            sync_cls=BaseSerial,  # type:ignore[type-abstract]
+            async_transport_cls=BaseSerialTransport,  # type:ignore[type-abstract]
+            list_serial_ports_func=list,
+        )
+
+    unregister = register_uri_handler(
+        scheme="test-shared-1://",
+        unique_scheme="test-unique-1://",
+        sync_cls=BaseSerial,  # type:ignore[type-abstract]
+        async_transport_cls=BaseSerialTransport,  # type:ignore[type-abstract]
+        list_serial_ports_func=list,
+    )
+
+    try:
+        with pytest.raises(ValueError, match="not unique"):
+            register_uri_handler(
+                scheme="test-shared-1://",
+                unique_scheme="test-unique-1://",
+                sync_cls=BaseSerial,  # type:ignore[type-abstract]
+                async_transport_cls=BaseSerialTransport,  # type:ignore[type-abstract]
+                list_serial_ports_func=list,
+            )
+    finally:
+        unregister()
+
+
+def test_register_uri_handler_dispatch_and_unregister() -> None:
+    """Registered handlers are discoverable via the public sync/async APIs."""
+    mock_sync_cls = Mock(spec=type[BaseSerial])
+    mock_async_transport_cls = Mock(spec=type[BaseSerialTransport])
+
+    unregister = register_uri_handler(
+        scheme="test-shared-2://",
+        unique_scheme="test-unique-2://",
+        sync_cls=mock_sync_cls,
+        async_transport_cls=mock_async_transport_cls,
+        list_serial_ports_func=list,
+    )
+
+    for url in ("test-unique-2://", "test-shared-2://host/path"):
+        handler = get_uri_handler(url)
+        assert handler.sync_cls is mock_sync_cls
+        assert handler.async_transport_cls is mock_async_transport_cls
+
+        sync_cls, async_transport_cls = get_serial_classes(url)
+        assert sync_cls is mock_sync_cls
+        assert async_transport_cls is mock_async_transport_cls
+
+    unregister()
+
+    with pytest.raises(UnknownUriScheme):
+        get_uri_handler("test-unique-2://")
+
+    with pytest.raises(UnknownUriScheme):
+        get_uri_handler("test-shared-2://")

--- a/tests/test_list_serial_ports_freebsd.py
+++ b/tests/test_list_serial_ports_freebsd.py
@@ -6,7 +6,7 @@ import sys
 
 import pytest
 
-if not sys.platform.startswith("freebsd"):
+if not sys.platform.startswith(("freebsd", "darwin", "linux")):
     pytest.skip("FreeBSD-only tests", allow_module_level=True)
 
 

--- a/tests/test_list_serial_ports_freebsd.py
+++ b/tests/test_list_serial_ports_freebsd.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
+import sys
+
 import pytest
 
-try:
-    import termios  # noqa: F401
-except ImportError:
+if not sys.platform.startswith("freebsd"):
     pytest.skip("FreeBSD-only tests", allow_module_level=True)
 
 

--- a/tests/test_sync_transports.py
+++ b/tests/test_sync_transports.py
@@ -138,7 +138,7 @@ def test_sync_random_large(
         baudrate > 230400
         and sys.platform == "darwin"
         and (
-            serial_pair.serial_class in ("PosixSerial", "ExtendedPosixSerial")
+            serial_pair.uri_scheme in ("posix://", "extended-posix://")
             or SerialBackend.SER2NET in serial_pair.backends
         )
     ):
@@ -188,7 +188,7 @@ def test_sync_buffered_writes_then_read(serial_pair: SerialPair) -> None:
 def test_sync_large_payload(serial_pair: SerialPair, payload_size: int) -> None:
     """Test large payload transmission."""
     if sys.platform == "darwin" and (
-        serial_pair.serial_class in ("PosixSerial", "ExtendedPosixSerial")
+        serial_pair.uri_scheme in ("posix://", "extended-posix://")
         or SerialBackend.SER2NET in serial_pair.backends
     ):
         pytest.xfail("macOS termios lacks constants above B230400")
@@ -227,7 +227,7 @@ def test_sync_sustained_throughput(
         baudrate > 230400
         and sys.platform == "darwin"
         and (
-            serial_pair.serial_class in ("PosixSerial", "ExtendedPosixSerial")
+            serial_pair.uri_scheme in ("posix://", "extended-posix://")
             or SerialBackend.SER2NET in serial_pair.backends
         )
     ):
@@ -255,7 +255,7 @@ def test_sync_valid_baudrates(serial_pair: SerialPair, baudrate: int) -> None:
         baudrate > 230400
         and sys.platform == "darwin"
         and (
-            serial_pair.serial_class in ("PosixSerial", "ExtendedPosixSerial")
+            serial_pair.uri_scheme in ("posix://", "extended-posix://")
             or SerialBackend.SER2NET in serial_pair.backends
         )
     ):
@@ -268,7 +268,7 @@ def test_sync_valid_baudrates(serial_pair: SerialPair, baudrate: int) -> None:
 
 def test_sync_nonstandard_baudrate(serial_pair: SerialPair) -> None:
     """Test that a non-standard baudrate (no termios constant) is accepted."""
-    if serial_pair.serial_class in ("PosixSerial", "ExtendedPosixSerial"):
+    if serial_pair.uri_scheme in ("posix://", "extended-posix://"):
         pytest.skip("Base POSIX backends only support standard baudrates")
 
     if sys.platform == "darwin" and SerialBackend.SER2NET in serial_pair.backends:
@@ -296,7 +296,7 @@ def test_sync_valid_parity(serial_pair: SerialPair, parity: Parity) -> None:
         Parity.SPACE,
     ):
         pytest.xfail("ESPHome backend does not support MARK/SPACE parity")
-    if serial_pair.serial_class not in ("LinuxSerial", "Win32Serial") and parity in (
+    if serial_pair.uri_scheme not in ("linux://", "windows://") and parity in (
         Parity.MARK,
         Parity.SPACE,
     ):
@@ -330,7 +330,7 @@ def test_sync_valid_stopbits(
     ) and expected is StopBits.ONE_POINT_FIVE:
         pytest.xfail("ESPHome backend does not support 1.5 stop bits")
     if (
-        serial_pair.serial_class not in ("Win32Serial",)
+        serial_pair.uri_scheme not in ("windows://",)
         and expected is StopBits.ONE_POINT_FIVE
     ):
         pytest.skip("1.5 stop bits only supported on Win32")
@@ -371,7 +371,7 @@ def test_sync_xonxoff_setting(serial_pair: SerialPair, xonxoff: bool) -> None:
 @pytest.mark.parametrize("rtscts", [True, False])
 def test_sync_rtscts_setting(serial_pair: SerialPair, rtscts: bool) -> None:
     """Test that rtscts setting is accepted."""
-    if rtscts and serial_pair.serial_class == "PosixSerial":
+    if rtscts and serial_pair.uri_scheme == "posix://":
         pytest.xfail("Strict POSIX backend does not support RTS/CTS flow control")
 
     # Open both sides: on com0com, opening right asserts DTR which raises CTS on left
@@ -871,11 +871,11 @@ def test_fast_open_close(serial_pair: SerialPair) -> None:
 @pytest.mark.skip_quirks(SerialQuirk.NO_RTS_CTS)
 def test_deassert_on_open(serial_pair: SerialPair) -> None:
     """Test RTS/CTS deassertion on open."""
-    if serial_pair.serial_class in (
-        "LinuxSerial",
-        "DarwinSerial",
-        "PosixSerial",
-        "ExtendedPosixSerial",
+    if serial_pair.uri_scheme in (
+        "linux://",
+        "darwin://",
+        "posix://",
+        "extended-posix://",
     ):
         pytest.skip("POSIX backends do not support deasserting pins on open")
 
@@ -914,11 +914,11 @@ def test_deassert_on_open(serial_pair: SerialPair) -> None:
 @pytest.mark.skip_quirks(SerialQuirk.NO_RTS_CTS)
 def test_hang_up_on_close(serial_pair: SerialPair) -> None:
     """Test RTS/CTS hang up on close."""
-    if serial_pair.serial_class in (
-        "LinuxSerial",
-        "DarwinSerial",
-        "PosixSerial",
-        "ExtendedPosixSerial",
+    if serial_pair.uri_scheme in (
+        "linux://",
+        "darwin://",
+        "posix://",
+        "extended-posix://",
     ):
         pytest.skip("POSIX backends do not support deasserting pins on open")
 
@@ -979,11 +979,11 @@ def test_deassert_on_open_with_rtscts(
     expected_state: PinState,
 ) -> None:
     """Test interaction of rtsdtr_on_open with rtscts."""
-    if serial_pair.serial_class in (
-        "LinuxSerial",
-        "DarwinSerial",
-        "PosixSerial",
-        "ExtendedPosixSerial",
+    if serial_pair.uri_scheme in (
+        "linux://",
+        "darwin://",
+        "posix://",
+        "extended-posix://",
     ):
         pytest.skip("POSIX backends do not support deasserting pins on open")
 


### PR DESCRIPTION
This PR adds `serialx.register_uri_handler`, our new system of registering platforms. For example:

```python
serialx.register_uri_handler(
    scheme="device://",
    unique_scheme="linux://",
    sync_cls=LinuxSerial,
    async_transport_cls=LinuxSerialTransport,
    list_serial_ports_func=linux_list_serial_ports,
    weight=3,
    strip_uri_scheme=True,
)
```

This will be used in the future to allow Home Assistant to register its own `esphome-hass://` URI scheme to centralize ESPHome API connections within Core and to keep encryption keys out of integration config.