### PR TITLE
Rename `noise_psk` to `key` in ESPHome

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ It can either create the API instance directly, for simplicity:
 from serialx import open_serial_connection
 
 reader, writer = await open_serial_connection(
-    url="esphome://192.168.1.42:6053/?port_name=Zigbee&noise_psk=...",
+    url="esphome://192.168.1.42:6053/?port_name=Zigbee&key=...",
     baudrate=115200,
 )
 ```
@@ -89,7 +89,7 @@ from serialx import open_serial_connection
 from serialx.platforms.serial_esphome import ESPHomeSerialTransport
 
 # An external API instance
-api = APIClient(address="192.168.1.42", port=6053, noise_psk="...", password=None)
+api = APIClient(address="192.168.1.42", port=6053, key="...", password=None)
 await api.connect(login=True)
 
 reader, writer = await open_serial_connection(

--- a/docs/how-to/esphome.md
+++ b/docs/how-to/esphome.md
@@ -1,0 +1,81 @@
+# Connecting to an ESPHome serial port
+[ESPHome](https://esphome.io/) can expose UARTs over its native API using the [`serial_proxy`](https://esphome.io/components/serial_proxy/) component. serialx can connect to ESPHome serial proxies with the `esphome://host:port?port_name=Name` URL scheme and expose a complete serial port implementation, with flow control, modem pin control, and buffer flushing.
+
+Install the ESPHome extras first, since `aioesphomeapi` is not installed by default:
+```bash
+pip install 'serialx[esphome]'
+```
+
+## Example script
+
+Open a connection straight from the URL. serialx will create and tear down an ESPHome API client at the end of a session:
+
+```python
+import asyncio
+import serialx
+
+async def main() -> None:
+    reader, writer = await serialx.open_serial_connection(
+        url="esphome://192.168.1.42:6053/?port_name=Zigbee",
+        key="base64-psk-here",
+        baudrate=115200,
+    )
+
+    try:
+        writer.write(b"ping\n")
+        await writer.drain()
+
+        data = await reader.readexactly(5)
+        print(data)
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+Use `password=` instead of `noise_psk=` in the query string if the device uses legacy API password authentication. If the device does not use any authentication, you can omit this keyword argument.
+
+## Reusing an existing API client
+If your application already holds an `aioesphomeapi.APIClient`, pass it to the transport directly to avoid opening a second connection:
+
+```python
+import asyncio
+import serialx
+
+from aioesphomeapi import APIClient
+from serialx.platforms.serial_esphome import ESPHomeSerialTransport
+
+
+async def main() -> None:
+    api = APIClient(
+        address="192.168.1.42",
+        port=6053,
+        noise_psk="base64-psk-here",
+        password=None,
+    )
+    await api.connect(login=True)
+
+    reader, writer = await serialx.open_serial_connection(
+        url=None,
+        transport_cls=ESPHomeSerialTransport,
+        api=api,
+        port_name="Zigbee",
+        baudrate=115200,
+    )
+
+    try:
+        data = await reader.readexactly(5)
+        print(data)
+    finally:
+        writer.close()
+        await writer.wait_closed()
+        await api.disconnect()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+When the API client is passed in externally, serialx does not disconnect it on close, it only unsubscribes from the specific serial port.

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,13 @@ api
 ```
 
 ```{toctree}
+:caption: How-to
+:hidden:
+
+how-to/esphome
+```
+
+```{toctree}
 :caption: Development
 :hidden:
 

--- a/serialx/platforms/serial_esphome.py
+++ b/serialx/platforms/serial_esphome.py
@@ -94,11 +94,16 @@ class ESPHomeSerial(BaseSerial):
         api: APIClient | None = None,
         port_name: str | None = None,
         port_instance: int | None = None,
+        key: str | None = None,
         password: str | None = None,
         noise_psk: str | None = None,
         **kwargs: Any,
     ) -> None:
-        """Initialize ESPHome serial port."""
+        """Initialize ESPHome serial port.
+
+        ``key`` is an alias for ``noise_psk`` and maps to the same pre-shared key
+        used for Noise-encrypted connections. Passing both raises ``ValueError``.
+        """
         super().__init__(*args, **kwargs)
 
         if self._parity not in PARITY_MAP:
@@ -106,6 +111,9 @@ class ESPHomeSerial(BaseSerial):
 
         if self._stopbits not in STOP_BITS_MAP:
             raise UnsupportedSetting(f"Unsupported stop bits: {self._stopbits}")
+
+        if key and noise_psk:
+            raise ValueError("Both `key` and `noise_psk` cannot be provided")
 
         # This API is used by both the sync API and the async API. The sync API manages
         # a temporary event loop while the async one passes through its own.
@@ -117,7 +125,7 @@ class ESPHomeSerial(BaseSerial):
         self._port_name: str | None = port_name
         self._instance_id: int | None = port_instance
         self._password: str | None = password
-        self._noise_psk: str | None = noise_psk
+        self._noise_psk: str | None = key or noise_psk
         self._disconnect_api: bool = False
 
         self._read_buffer = bytearray()
@@ -175,8 +183,12 @@ class ESPHomeSerial(BaseSerial):
             if "password" in params:
                 self._password = params["password"][0]
 
-            if "noise_psk" in params:
+            if "noise_psk" in params and "key" in params:
+                raise ValueError("Both `key` and `noise_psk` cannot be provided")
+            elif "noise_psk" in params:
                 self._noise_psk = params["noise_psk"][0]
+            elif "key" in params:
+                self._noise_psk = params["key"][0]
 
             self._api = aioesphomeapi.APIClient(
                 address=parsed.hostname,

--- a/serialx/platforms/serial_esphome.py
+++ b/serialx/platforms/serial_esphome.py
@@ -177,7 +177,7 @@ class ESPHomeSerial(BaseSerial):
 
             if port_value.isdigit():
                 self._instance_id = int(port_value)
-            else:
+            elif not self._port_name:
                 self._port_name = port_value
 
             if "password" in params:

--- a/tests/test_serial_esphome.py
+++ b/tests/test_serial_esphome.py
@@ -164,7 +164,7 @@ async def test_connect_encrypted_plaintext_to_server() -> None:
             url = (
                 f"esphome://{parsed.hostname}:{parsed.port}"
                 f"?port_name=Serial+Proxy+Left"
-                f"&noise_psk={noise_psk}"
+                f"&key={noise_psk}"
             )
 
             with pytest.raises(
@@ -182,3 +182,45 @@ async def test_connect_timeout_raises_timeout_error() -> None:
             await open_serial_connection(
                 url="esphome://192.0.2.1:6053?port_name=test", baudrate=115200
             )
+
+
+@pytest.mark.skipif(not ESPHOME_HOST_BINARY, reason="esphome host binary not available")
+async def test_noise_psk_key_alias() -> None:
+    """Test that connecting without encryption to an encrypted server raises."""
+    key = base64(b"A noise PSK 32 bytes in length..")
+
+    with create_socat_pair() as (socat_left, socat_right):
+        with create_esphome_pair(
+            socat_left,
+            socat_right,
+            noise_psk=key,
+        ) as (left, _right):
+            parsed = urllib.parse.urlparse(left)
+            with pytest.raises(
+                ValueError, match="Both `key` and `noise_psk` cannot be provided"
+            ):
+                await open_serial_connection(
+                    url=f"esphome://{parsed.hostname}:{parsed.port}",
+                    noise_psk=key,
+                    key=key,
+                    baudrate=115200,
+                )
+
+            with pytest.raises(
+                ValueError, match="Both `key` and `noise_psk` cannot be provided"
+            ):
+                await open_serial_connection(
+                    url=f"esphome://{parsed.hostname}:{parsed.port}?key={key}&noise_psk={key}",
+                    noise_psk=key,
+                    key=key,
+                    baudrate=115200,
+                )
+
+            reader, writer = await open_serial_connection(
+                url=f"esphome://{parsed.hostname}:{parsed.port}",
+                noise_psk=key,  # alias
+                baudrate=115200,
+            )
+
+            writer.close()
+            await writer.wait_closed()

--- a/tests/test_serial_esphome.py
+++ b/tests/test_serial_esphome.py
@@ -201,6 +201,7 @@ async def test_noise_psk_key_alias() -> None:
             ):
                 await open_serial_connection(
                     url=f"esphome://{parsed.hostname}:{parsed.port}",
+                    port_name="Serial Proxy Left",
                     noise_psk=key,
                     key=key,
                     baudrate=115200,
@@ -211,6 +212,7 @@ async def test_noise_psk_key_alias() -> None:
             ):
                 await open_serial_connection(
                     url=f"esphome://{parsed.hostname}:{parsed.port}?key={key}&noise_psk={key}",
+                    port_name="Serial Proxy Left",
                     noise_psk=key,
                     key=key,
                     baudrate=115200,
@@ -218,6 +220,7 @@ async def test_noise_psk_key_alias() -> None:
 
             reader, writer = await open_serial_connection(
                 url=f"esphome://{parsed.hostname}:{parsed.port}",
+                port_name="Serial Proxy Left",
                 noise_psk=key,  # alias
                 baudrate=115200,
             )

--- a/tests/test_serial_esphome.py
+++ b/tests/test_serial_esphome.py
@@ -213,8 +213,6 @@ async def test_noise_psk_key_alias() -> None:
                 await open_serial_connection(
                     url=f"esphome://{parsed.hostname}:{parsed.port}?key={key}&noise_psk={key}",
                     port_name="Serial Proxy Left",
-                    noise_psk=key,
-                    key=key,
                     baudrate=115200,
                 )
 


### PR DESCRIPTION
To be consistent with Home Assistant discovery naming, rename `noise_psk` to `key`. Both are still accepted. I've also added a small how-to document to the docs with self-contained scripts.