### PR TITLE
Implement async serial port listing for ESPHome

### DIFF
--- a/serialx/__init__.py
+++ b/serialx/__init__.py
@@ -11,12 +11,16 @@ from .common import (
     ModemPins,
     Parity,
     PinState,
+    Platform,
     SerialException,
     SerialPortInfo,
     StopBits,
     UnsupportedSetting,
+    async_list_serial_ports,
     get_serial_classes,
+    list_serial_ports,
     register_uri_handler,
+    serial_for_url,
 )
 from .compat import (
     CR,
@@ -30,21 +34,20 @@ from .compat import (
     STOPBITS_TWO,
     SerialTimeoutException,
 )
-from .platforms import Serial, SerialTransport, list_serial_ports
-
-# Backwards compatibility export
-serial_for_url = Serial.from_url
+from .platforms import Serial, SerialTransport
 
 __all__ = [
     "create_serial_connection",
     "get_serial_classes",
     "list_serial_ports",
+    "async_list_serial_ports",
     "open_serial_connection",
     "register_uri_handler",
     "serial_for_url",
     "ModemPins",
     "Parity",
     "PinState",
+    "Platform",
     "BaseSerial",
     "BaseSerialTransport",
     "Serial",

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -7,7 +7,7 @@ import asyncio
 from asyncio import IncompleteReadError
 import bisect
 from collections import defaultdict
-from collections.abc import Callable, Iterator
+from collections.abc import Awaitable, Callable, Iterator
 from contextlib import contextmanager
 import dataclasses
 from enum import Enum
@@ -33,6 +33,7 @@ class RegisteredUriHandler:
     sync_cls: type[BaseSerial]
     async_transport_cls: type[BaseSerialTransport]
     list_serial_ports_func: Callable[[], list[SerialPortInfo]]
+    async_list_serial_ports_func: Callable[[], Awaitable[list[SerialPortInfo]]]
     strip_uri_scheme: bool
 
 
@@ -54,6 +55,7 @@ def register_uri_handler(
     sync_cls: type[BaseSerial],
     async_transport_cls: type[BaseSerialTransport],
     list_serial_ports_func: Callable[[], list[SerialPortInfo]],
+    async_list_serial_ports_func: Callable[[], Awaitable[list[SerialPortInfo]]],
     weight: int = 1,
     strip_uri_scheme: bool = False,
 ) -> Callable[[], None]:
@@ -73,6 +75,8 @@ def register_uri_handler(
         async_transport_cls: Async transport class, typically a subclass of
             :class:`BaseSerialTransport`.
         list_serial_ports_func: Callable returning a list of :class:`SerialPortInfo`.
+        async_list_serial_ports_func: Async callable returning a list of
+            :class:`SerialPortInfo`.
         weight: Dispatch priority under ``scheme``. Higher wins.
         strip_uri_scheme: If ``True``, the leading ``scheme`` / ``unique_scheme``
             is removed before the URL is passed to the sync class. Set this when
@@ -105,6 +109,7 @@ def register_uri_handler(
             sync_cls=sync_cls,
             async_transport_cls=async_transport_cls,
             list_serial_ports_func=list_serial_ports_func,
+            async_list_serial_ports_func=async_list_serial_ports_func,
             strip_uri_scheme=strip_uri_scheme,
         ),
     )

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -23,6 +23,22 @@ import warnings
 from typing_extensions import Buffer, Self
 
 
+class Platform(str, Enum):
+    """Built-in platform name."""
+
+    DEVICE = "device"
+
+    POSIX = "posix"
+    EXTENDED_POSIX = "extended_posix"
+    FREEBSD = "freebsd"
+    LINUX = "linux"
+    DARWIN = "darwin"
+    WIN32 = "win32"
+    SOCKET = "socket"
+    RFC2217 = "rfc2217"
+    ESPHOME = "esphome"
+
+
 @dataclasses.dataclass(frozen=True)
 class RegisteredUriHandler:
     """A URI handler registration entry."""
@@ -32,8 +48,8 @@ class RegisteredUriHandler:
     weight: int
     sync_cls: type[BaseSerial]
     async_transport_cls: type[BaseSerialTransport]
-    list_serial_ports_func: Callable[[], list[SerialPortInfo]]
-    async_list_serial_ports_func: Callable[[], Awaitable[list[SerialPortInfo]]]
+    list_serial_ports_func: Callable[..., list[SerialPortInfo]]
+    async_list_serial_ports_func: Callable[..., Awaitable[list[SerialPortInfo]]]
     strip_uri_scheme: bool
 
 
@@ -54,8 +70,8 @@ def register_uri_handler(
     unique_scheme: str,
     sync_cls: type[BaseSerial],
     async_transport_cls: type[BaseSerialTransport],
-    list_serial_ports_func: Callable[[], list[SerialPortInfo]],
-    async_list_serial_ports_func: Callable[[], Awaitable[list[SerialPortInfo]]],
+    list_serial_ports_func: Callable[..., list[SerialPortInfo]],
+    async_list_serial_ports_func: Callable[..., Awaitable[list[SerialPortInfo]]],
     weight: int = 1,
     strip_uri_scheme: bool = False,
 ) -> Callable[[], None]:
@@ -1033,3 +1049,24 @@ class SerialPortInfo:
             stacklevel=2,
         )
         return self.product
+
+
+def list_serial_ports(
+    platform: Platform | str = Platform.DEVICE, **kwargs: Any
+) -> list[SerialPortInfo]:
+    """List serial ports, defaulting to the system platform."""
+    handler = get_uri_handler(platform + "://")
+    return handler.list_serial_ports_func(**kwargs)
+
+
+async def async_list_serial_ports(
+    platform: Platform | str = Platform.DEVICE, **kwargs: Any
+) -> list[SerialPortInfo]:
+    """List serial ports (async), defaulting to the system platform."""
+    handler = get_uri_handler(platform + "://")
+    return await handler.async_list_serial_ports_func(**kwargs)
+
+
+def serial_for_url(url: str, *args: Any, **kwargs: Any) -> BaseSerial:
+    """Create the appropriate serial port subclass for the given URL."""
+    return BaseSerial.from_url(url, *args, **kwargs)

--- a/serialx/platforms/__init__.py
+++ b/serialx/platforms/__init__.py
@@ -3,7 +3,7 @@
 from contextlib import suppress
 from typing import TYPE_CHECKING
 
-from ..common import SerialPortInfo, get_uri_handler
+from ..common import get_uri_handler
 from . import (
     serial_rfc2217,  # noqa: F401
     serial_socket,  # noqa: F401
@@ -32,17 +32,12 @@ with suppress(ImportError):
 
 if TYPE_CHECKING:
     from ..common import BaseSerial as Serial, BaseSerialTransport as SerialTransport
-
-    def list_serial_ports() -> list[SerialPortInfo]:
-        """List serial ports for mypy."""
 else:
     _handler = get_uri_handler("device://")
     Serial = _handler.sync_cls
     SerialTransport = _handler.async_transport_cls
-    list_serial_ports = _handler.list_serial_ports_func
 
 __all__ = [
     "Serial",
     "SerialTransport",
-    "list_serial_ports",
 ]

--- a/serialx/platforms/serial_darwin.py
+++ b/serialx/platforms/serial_darwin.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import array
+import asyncio
 import errno
 import fcntl
 import logging
@@ -69,7 +70,7 @@ class DarwinSerialTransport(ExtendedPosixSerialTransport):
 
 
 def darwin_list_serial_ports() -> list[SerialPortInfo]:
-    """List available serial ports on macOS using native IOKit via Rust."""
+    """List available serial ports on macOS."""
     return [
         SerialPortInfo(
             device=port.device,
@@ -87,6 +88,11 @@ def darwin_list_serial_ports() -> list[SerialPortInfo]:
     ]
 
 
+async def async_darwin_list_serial_ports() -> list[SerialPortInfo]:
+    """List available serial ports on macOS, async."""
+    return await asyncio.to_thread(darwin_list_serial_ports)
+
+
 if sys.platform == "darwin":
     register_uri_handler(
         scheme="device://",
@@ -94,6 +100,7 @@ if sys.platform == "darwin":
         sync_cls=DarwinSerial,
         async_transport_cls=DarwinSerialTransport,
         list_serial_ports_func=darwin_list_serial_ports,
+        async_list_serial_ports_func=async_darwin_list_serial_ports,
         weight=3,
         strip_uri_scheme=True,
     )

--- a/serialx/platforms/serial_esphome.py
+++ b/serialx/platforms/serial_esphome.py
@@ -53,6 +53,10 @@ STOP_BITS_MAP = {
 }
 
 
+class InvalidSettingsError(SerialException):
+    """Raised when the provided settings are invalid."""
+
+
 def translate_esphome_errors(
     func: Callable[_P, Coroutine[Any, Any, _T]],
 ) -> Callable[_P, Coroutine[Any, Any, _T]]:
@@ -140,6 +144,14 @@ class ESPHomeSerial(BaseSerial):
         assert self._loop is not None
         return asyncio.run_coroutine_threadsafe(coro, self._loop).result()
 
+    def _maybe_start_new_event_loop(self) -> None:
+        """Start a new event loop in a background thread if one isn't set."""
+        if self._loop is not None:
+            return
+        self._loop = asyncio.new_event_loop()
+        self._loop_thread = threading.Thread(target=self._loop.run_forever)
+        self._loop_thread.start()
+
     def _on_data(self, msg: SerialProxyDataReceived) -> None:
         if msg.instance == self._instance_id:
             self._read_buffer.extend(msg.data)
@@ -147,10 +159,7 @@ class ESPHomeSerial(BaseSerial):
 
     def _open(self) -> None:
         """Open the serial port."""
-        if self._loop is None:
-            self._loop = asyncio.new_event_loop()
-            self._loop_thread = threading.Thread(target=self._loop.run_forever)
-            self._loop_thread.start()
+        self._maybe_start_new_event_loop()
 
         self._read_event = asyncio.Event()
         self._call_on_loop(self._async_open())
@@ -165,7 +174,11 @@ class ESPHomeSerial(BaseSerial):
     async def _async_open(self) -> None:
         # Only connect if the API was not passed in externally
         if self._api is None:
-            assert self._path is not None
+            if self._path is None:
+                raise InvalidSettingsError(
+                    "Cannot open a connection without a URI or a API instance"
+                )
+
             parsed = urllib.parse.urlparse(str(self._path))
             params = urllib.parse.parse_qs(parsed.query)
 
@@ -202,6 +215,45 @@ class ESPHomeSerial(BaseSerial):
         else:
             # Don't disconnect an externally-passed API
             self._disconnect_api = False
+
+    @translate_esphome_errors
+    async def _async_list_serial_ports(self) -> list[SerialPortInfo]:
+        assert self._api is not None
+
+        device_info = await self._api.device_info()
+        ports = []
+
+        for proxy in device_info.serial_proxies:
+            url = urllib.parse.urlunparse(
+                urllib.parse.ParseResult(
+                    scheme="esphome",
+                    netloc=f"{self._api.address}:{self._api.port}",
+                    path="/",
+                    params="",
+                    query=urllib.parse.urlencode({"port_name": proxy.name}),
+                    fragment="",
+                )
+            )
+
+            ports.append(
+                SerialPortInfo(
+                    device=url,
+                    resolved_device=url,
+                    vid=None,
+                    pid=None,
+                    serial_number=device_info.mac_address,
+                    manufacturer=device_info.manufacturer,
+                    product=device_info.model,
+                    bcd_device=None,
+                    interface_description=proxy.name,
+                    interface_num=None,
+                )
+            )
+
+        return ports
+
+    def _list_serial_ports(self) -> list[SerialPortInfo]:
+        return self._call_on_loop(self._async_list_serial_ports())
 
     @translate_esphome_errors
     async def _async_subscribe(self) -> None:
@@ -487,49 +539,38 @@ class ESPHomeSerialTransport(BaseSerialTransport):
         return 0
 
 
-def esphome_list_serial_ports() -> list[SerialPortInfo]:
+def esphome_list_serial_ports(*args: Any, **kwargs: Any) -> list[SerialPortInfo]:
     """List serial ports for ESPhome."""
-    return []
+    serial = ESPHomeSerial(*args, **kwargs)
+    serial._maybe_start_new_event_loop()
+
+    try:
+        try:
+            serial._call_on_loop(serial._async_open())
+        except InvalidSettingsError:
+            return []
+        return serial._list_serial_ports()
+    finally:
+        serial._close()
 
 
 async def async_esphome_list_serial_ports(
-    *, api: APIClient | None = None
+    *args: Any, **kwargs: Any
 ) -> list[SerialPortInfo]:
     """List serial ports for ESPhome."""
-    if api is None:
+    serial = ESPHomeSerial(*args, **kwargs)
+
+    try:
+        await serial._async_open()
+    except InvalidSettingsError:
         return []
 
-    device_info = await api.device_info()
-    ports = []
-
-    for proxy in device_info.serial_proxies:
-        url = urllib.parse.urlunparse(
-            urllib.parse.ParseResult(
-                scheme="esphome",
-                netloc=f"{api.address}:{api.port}",
-                path="/",
-                params="",
-                query=urllib.parse.urlencode({"port_name": proxy.name}),
-                fragment="",
-            )
-        )
-
-        ports.append(
-            SerialPortInfo(
-                device=url,
-                resolved_device=url,
-                vid=None,
-                pid=None,
-                serial_number=device_info.mac_address,
-                manufacturer=device_info.manufacturer,
-                product=device_info.model,
-                bcd_device=None,
-                interface_description=proxy.name,
-                interface_num=None,
-            )
-        )
-
-    return ports
+    try:
+        return await serial._async_list_serial_ports()
+    finally:
+        if serial._disconnect_api and serial._api is not None:
+            await serial._api.disconnect()
+            serial._api = None
 
 
 register_uri_handler(

--- a/serialx/platforms/serial_esphome.py
+++ b/serialx/platforms/serial_esphome.py
@@ -488,8 +488,48 @@ class ESPHomeSerialTransport(BaseSerialTransport):
 
 
 def esphome_list_serial_ports() -> list[SerialPortInfo]:
-    """List serial ports for sockets."""
+    """List serial ports for ESPhome."""
     return []
+
+
+async def async_esphome_list_serial_ports(
+    *, api: APIClient | None = None
+) -> list[SerialPortInfo]:
+    """List serial ports for ESPhome."""
+    if api is None:
+        return []
+
+    device_info = await api.device_info()
+    ports = []
+
+    for proxy in device_info.serial_proxies:
+        url = urllib.parse.urlunparse(
+            urllib.parse.ParseResult(
+                scheme="esphome",
+                netloc=f"{api.address}:{api.port}",
+                path="/",
+                params="",
+                query=urllib.parse.urlencode({"port_name": proxy.name}),
+                fragment="",
+            )
+        )
+
+        ports.append(
+            SerialPortInfo(
+                device=url,
+                resolved_device=url,
+                vid=None,
+                pid=None,
+                serial_number=device_info.mac_address,
+                manufacturer=device_info.manufacturer,
+                product=device_info.model,
+                bcd_device=None,
+                interface_description=proxy.name,
+                interface_num=None,
+            )
+        )
+
+    return ports
 
 
 register_uri_handler(
@@ -498,4 +538,5 @@ register_uri_handler(
     sync_cls=ESPHomeSerial,
     async_transport_cls=ESPHomeSerialTransport,
     list_serial_ports_func=esphome_list_serial_ports,
+    async_list_serial_ports_func=async_esphome_list_serial_ports,
 )

--- a/serialx/platforms/serial_extended_posix.py
+++ b/serialx/platforms/serial_extended_posix.py
@@ -8,7 +8,12 @@ from __future__ import annotations
 import termios
 
 from ..common import register_uri_handler
-from .serial_posix import PosixSerial, PosixSerialTransport, posix_list_serial_ports
+from .serial_posix import (
+    PosixSerial,
+    PosixSerialTransport,
+    async_posix_list_serial_ports,
+    posix_list_serial_ports,
+)
 
 CRTSCTS = getattr(termios, "CRTSCTS", getattr(termios, "CNEW_RTSCTS", None))
 
@@ -48,6 +53,7 @@ if is_extended_posix():
         sync_cls=ExtendedPosixSerial,
         async_transport_cls=ExtendedPosixSerialTransport,
         list_serial_ports_func=posix_list_serial_ports,
+        async_list_serial_ports_func=async_posix_list_serial_ports,
         weight=2,
         strip_uri_scheme=True,
     )

--- a/serialx/platforms/serial_freebsd.py
+++ b/serialx/platforms/serial_freebsd.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 import subprocess
@@ -141,6 +142,11 @@ def freebsd_list_serial_ports() -> list[SerialPortInfo]:
     return results
 
 
+async def async_freebsd_list_serial_ports() -> list[SerialPortInfo]:
+    """List serial ports on FreeBSD, async."""
+    return await asyncio.to_thread(freebsd_list_serial_ports)
+
+
 if sys.platform.startswith("freebsd"):
     register_uri_handler(
         scheme="device://",
@@ -148,6 +154,7 @@ if sys.platform.startswith("freebsd"):
         sync_cls=FreeBSDSerial,
         async_transport_cls=FreeBSDSerialTransport,
         list_serial_ports_func=freebsd_list_serial_ports,
+        async_list_serial_ports_func=async_freebsd_list_serial_ports,
         weight=3,
         strip_uri_scheme=True,
     )

--- a/serialx/platforms/serial_linux.py
+++ b/serialx/platforms/serial_linux.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import array
+import asyncio
 from collections.abc import Iterator
 from contextlib import suppress
 import ctypes
@@ -323,6 +324,11 @@ def linux_list_serial_ports() -> list[SerialPortInfo]:
     return results
 
 
+async def async_linux_list_serial_ports() -> list[SerialPortInfo]:
+    """List serial ports on Linux, async."""
+    return await asyncio.to_thread(linux_list_serial_ports)
+
+
 if sys.platform == "linux":
     register_uri_handler(
         scheme="device://",
@@ -330,6 +336,7 @@ if sys.platform == "linux":
         sync_cls=LinuxSerial,
         async_transport_cls=LinuxSerialTransport,
         list_serial_ports_func=linux_list_serial_ports,
+        async_list_serial_ports_func=async_linux_list_serial_ports,
         weight=3,
         strip_uri_scheme=True,
     )

--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -530,11 +530,17 @@ def posix_list_serial_ports() -> list[SerialPortInfo]:
     return []
 
 
+async def async_posix_list_serial_ports() -> list[SerialPortInfo]:
+    """List available serial ports on POSIX, async."""
+    return []
+
+
 register_uri_handler(
     scheme="device://",
     unique_scheme="posix://",
     sync_cls=PosixSerial,
     async_transport_cls=PosixSerialTransport,
     list_serial_ports_func=posix_list_serial_ports,
+    async_list_serial_ports_func=async_posix_list_serial_ports,
     strip_uri_scheme=True,
 )

--- a/serialx/platforms/serial_rfc2217/__init__.py
+++ b/serialx/platforms/serial_rfc2217/__init__.py
@@ -1042,7 +1042,12 @@ class RFC2217SerialTransport(BaseSerialTransport):
 
 
 def rfc2217_list_serial_ports() -> list[SerialPortInfo]:
-    """List serial ports for sockets."""
+    """List serial ports for RFC2217."""
+    return []
+
+
+async def async_rfc2217_list_serial_ports() -> list[SerialPortInfo]:
+    """List serial ports for RFC2217, async."""
     return []
 
 
@@ -1052,4 +1057,5 @@ register_uri_handler(
     sync_cls=RFC2217Serial,
     async_transport_cls=RFC2217SerialTransport,
     list_serial_ports_func=rfc2217_list_serial_ports,
+    async_list_serial_ports_func=async_rfc2217_list_serial_ports,
 )

--- a/serialx/platforms/serial_socket.py
+++ b/serialx/platforms/serial_socket.py
@@ -359,12 +359,18 @@ def socket_list_serial_ports() -> list[SerialPortInfo]:
     return []
 
 
+async def async_socket_list_serial_ports() -> list[SerialPortInfo]:
+    """List serial ports for sockets, async."""
+    return []
+
+
 register_uri_handler(
     scheme="socket://",
     unique_scheme="socket://",
     sync_cls=SocketSerial,
     async_transport_cls=SocketSerialTransport,
     list_serial_ports_func=socket_list_serial_ports,
+    async_list_serial_ports_func=async_socket_list_serial_ports,
 )
 register_uri_handler(
     scheme="tcp://",
@@ -372,4 +378,5 @@ register_uri_handler(
     sync_cls=SocketSerial,
     async_transport_cls=SocketSerialTransport,
     list_serial_ports_func=socket_list_serial_ports,
+    async_list_serial_ports_func=async_socket_list_serial_ports,
 )

--- a/serialx/platforms/serial_win32.py
+++ b/serialx/platforms/serial_win32.py
@@ -740,11 +740,17 @@ def win32_list_serial_ports() -> list[SerialPortInfo]:
     ]
 
 
+async def async_win32_list_serial_ports() -> list[SerialPortInfo]:
+    """List available serial ports on Windows, async."""
+    return await asyncio.to_thread(win32_list_serial_ports)
+
+
 register_uri_handler(
     scheme="device://",
     unique_scheme="windows://",
     sync_cls=Win32Serial,
     async_transport_cls=Win32SerialTransport,
     list_serial_ports_func=win32_list_serial_ports,
+    async_list_serial_ports_func=async_win32_list_serial_ports,
     strip_uri_scheme=True,
 )

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -12,9 +12,14 @@ from serialx.common import (
     _REGISTERED_URI_HANDLERS,
     BaseSerial,
     BaseSerialTransport,
+    SerialPortInfo,
     UnknownUriScheme,
     get_uri_handler,
 )
+
+
+async def _async_list_serial_ports() -> list[SerialPortInfo]:
+    return []
 
 
 @pytest.fixture(autouse=True)
@@ -49,6 +54,7 @@ def test_register_uri_handler_validation() -> None:
             sync_cls=BaseSerial,  # type:ignore[type-abstract]
             async_transport_cls=BaseSerialTransport,  # type:ignore[type-abstract]
             list_serial_ports_func=list,
+            async_list_serial_ports_func=_async_list_serial_ports,
         )
 
     with pytest.raises(ValueError, match="must end with"):
@@ -58,6 +64,7 @@ def test_register_uri_handler_validation() -> None:
             sync_cls=BaseSerial,  # type:ignore[type-abstract]
             async_transport_cls=BaseSerialTransport,  # type:ignore[type-abstract]
             list_serial_ports_func=list,
+            async_list_serial_ports_func=_async_list_serial_ports,
         )
 
     unregister = register_uri_handler(
@@ -66,6 +73,7 @@ def test_register_uri_handler_validation() -> None:
         sync_cls=BaseSerial,  # type:ignore[type-abstract]
         async_transport_cls=BaseSerialTransport,  # type:ignore[type-abstract]
         list_serial_ports_func=list,
+        async_list_serial_ports_func=_async_list_serial_ports,
     )
 
     try:
@@ -76,6 +84,7 @@ def test_register_uri_handler_validation() -> None:
                 sync_cls=BaseSerial,  # type:ignore[type-abstract]
                 async_transport_cls=BaseSerialTransport,  # type:ignore[type-abstract]
                 list_serial_ports_func=list,
+                async_list_serial_ports_func=_async_list_serial_ports,
             )
     finally:
         unregister()
@@ -92,6 +101,7 @@ def test_register_uri_handler_dispatch_and_unregister() -> None:
         sync_cls=mock_sync_cls,
         async_transport_cls=mock_async_transport_cls,
         list_serial_ports_func=list,
+        async_list_serial_ports_func=_async_list_serial_ports,
     )
 
     for url in ("test-unique-2://", "test-shared-2://host/path"):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -7,7 +7,13 @@ from unittest.mock import Mock
 
 import pytest
 
-from serialx import get_serial_classes, register_uri_handler
+from serialx import (
+    Platform,
+    async_list_serial_ports,
+    get_serial_classes,
+    list_serial_ports,
+    register_uri_handler,
+)
 from serialx.common import (
     _REGISTERED_URI_HANDLERS,
     BaseSerial,
@@ -120,3 +126,31 @@ def test_register_uri_handler_dispatch_and_unregister() -> None:
 
     with pytest.raises(UnknownUriScheme):
         get_uri_handler("test-shared-2://")
+
+
+@pytest.mark.parametrize("platform", list(Platform))
+def test_list_serial_ports_all_platforms(platform: Platform) -> None:
+    """Sync listing returns a list of `SerialPortInfo` for every platform."""
+    try:
+        ports = list_serial_ports(platform)
+    except UnknownUriScheme:
+        pytest.skip(f"{platform} is not registered in this environment")
+        return
+
+    assert isinstance(ports, list)
+    for port in ports:
+        assert isinstance(port, SerialPortInfo)
+
+
+@pytest.mark.parametrize("platform", list(Platform))
+async def test_async_list_serial_ports_all_platforms(platform: Platform) -> None:
+    """Async listing returns a list of `SerialPortInfo` for every platform."""
+    try:
+        ports = await async_list_serial_ports(platform)
+    except UnknownUriScheme:
+        pytest.skip(f"{platform} is not registered in this environment")
+        return
+
+    assert isinstance(ports, list)
+    for port in ports:
+        assert isinstance(port, SerialPortInfo)

--- a/tests/test_list_serial_ports_freebsd.py
+++ b/tests/test_list_serial_ports_freebsd.py
@@ -13,15 +13,18 @@ if not sys.platform.startswith(("freebsd", "darwin", "linux")):
 from pathlib import Path
 from unittest.mock import patch
 
-from serialx.common import SerialPortInfo
-from serialx.platforms.serial_freebsd import freebsd_list_serial_ports
+from serialx import SerialPortInfo
+from serialx.platforms.serial_freebsd import (
+    async_freebsd_list_serial_ports,
+    freebsd_list_serial_ports,
+)
 
 DATA_DIR = Path(__file__).parent / "data" / "freebsd"
 SYSCTL_OUTPUT = (DATA_DIR / "sysctl_dev.txt").read_text()
 USBCONFIG_OUTPUT = (DATA_DIR / "usbconfig_dump_device_desc.txt").read_text()
 
 
-def test_freebsd_list_serial_ports() -> None:
+async def test_freebsd_list_serial_ports() -> None:
     """Test listing all serial ports with captured FreeBSD command output."""
 
     def _mock_subprocess_run(args, **kwargs):
@@ -39,84 +42,83 @@ def test_freebsd_list_serial_ports() -> None:
         raise ValueError(f"Unexpected command: {args}")
 
     with patch("subprocess.run", side_effect=_mock_subprocess_run):
-        ports = freebsd_list_serial_ports()
+        ports_sync = freebsd_list_serial_ports()
+        ports_async = await async_freebsd_list_serial_ports()
 
-    assert len(ports) == 5
-
-    ports_by_device = {str(p.device): p for p in ports}
-
-    # /dev/cuaU0: Nabu Casa ZBT-2 (CDC ACM via umodem)
-    assert ports_by_device["/dev/cuaU0"] == SerialPortInfo(
-        device="/dev/cuaU0",
-        resolved_device="/dev/cuaU0",
-        vid=0x303A,
-        pid=0x4001,
-        serial_number="80B54EEFAE18",
-        manufacturer="Nabu Casa",
-        product="ZBT-2",
-        bcd_device=0x0101,
-        interface_description=None,
-        interface_num=0,
+    assert (
+        sorted(ports_sync, key=lambda p: p.device)
+        == sorted(ports_async, key=lambda p: p.device)
+        == [
+            # /dev/cuaU0: Nabu Casa ZBT-2 (CDC ACM via umodem)
+            SerialPortInfo(
+                device="/dev/cuaU0",
+                resolved_device="/dev/cuaU0",
+                vid=0x303A,
+                pid=0x4001,
+                serial_number="80B54EEFAE18",
+                manufacturer="Nabu Casa",
+                product="ZBT-2",
+                bcd_device=0x0101,
+                interface_description=None,
+                interface_num=0,
+            ),
+            # /dev/cuaU1: FTDI FT232R (ugen8.2)
+            SerialPortInfo(
+                device="/dev/cuaU1",
+                resolved_device="/dev/cuaU1",
+                vid=0x0403,
+                pid=0x6001,
+                serial_number="A5069RR4",
+                manufacturer="FTDI",
+                product="FT232R USB UART",
+                bcd_device=0x0600,
+                interface_description=None,
+                interface_num=0,
+            ),
+            # /dev/cuaU2: FTDI FT232R (ugen8.3)
+            SerialPortInfo(
+                device="/dev/cuaU2",
+                resolved_device="/dev/cuaU2",
+                vid=0x0403,
+                pid=0x6001,
+                serial_number="A5069RR4",
+                manufacturer="FTDI",
+                product="FT232R USB UART",
+                bcd_device=0x0600,
+                interface_description=None,
+                interface_num=0,
+            ),
+            # /dev/cuaU3: Silicon Labs CP2102 (ugen8.5)
+            SerialPortInfo(
+                device="/dev/cuaU3",
+                resolved_device="/dev/cuaU3",
+                vid=0x10C4,
+                pid=0xEA60,
+                serial_number="ec4903cb",
+                manufacturer="Silicon Labs",
+                product="CP2102 USB to UART Bridge Controller",
+                bcd_device=0x0100,
+                interface_description=None,
+                interface_num=0,
+            ),
+            # /dev/cuaU4: FTDI FT232R with custom serial (ugen8.6)
+            SerialPortInfo(
+                device="/dev/cuaU4",
+                resolved_device="/dev/cuaU4",
+                vid=0x0403,
+                pid=0x6001,
+                serial_number="rutabaga",
+                manufacturer="FTDI",
+                product="FT232R USB UART",
+                bcd_device=0x0600,
+                interface_description=None,
+                interface_num=0,
+            ),
+        ]
     )
 
-    # /dev/cuaU1: FTDI FT232R (ugen8.2)
-    assert ports_by_device["/dev/cuaU1"] == SerialPortInfo(
-        device="/dev/cuaU1",
-        resolved_device="/dev/cuaU1",
-        vid=0x0403,
-        pid=0x6001,
-        serial_number="A5069RR4",
-        manufacturer="FTDI",
-        product="FT232R USB UART",
-        bcd_device=0x0600,
-        interface_description=None,
-        interface_num=0,
-    )
 
-    # /dev/cuaU2: FTDI FT232R (ugen8.3)
-    assert ports_by_device["/dev/cuaU2"] == SerialPortInfo(
-        device="/dev/cuaU2",
-        resolved_device="/dev/cuaU2",
-        vid=0x0403,
-        pid=0x6001,
-        serial_number="A5069RR4",
-        manufacturer="FTDI",
-        product="FT232R USB UART",
-        bcd_device=0x0600,
-        interface_description=None,
-        interface_num=0,
-    )
-
-    # /dev/cuaU3: Silicon Labs CP2102 (ugen8.5)
-    assert ports_by_device["/dev/cuaU3"] == SerialPortInfo(
-        device="/dev/cuaU3",
-        resolved_device="/dev/cuaU3",
-        vid=0x10C4,
-        pid=0xEA60,
-        serial_number="ec4903cb",
-        manufacturer="Silicon Labs",
-        product="CP2102 USB to UART Bridge Controller",
-        bcd_device=0x0100,
-        interface_description=None,
-        interface_num=0,
-    )
-
-    # /dev/cuaU4: FTDI FT232R with custom serial (ugen8.6)
-    assert ports_by_device["/dev/cuaU4"] == SerialPortInfo(
-        device="/dev/cuaU4",
-        resolved_device="/dev/cuaU4",
-        vid=0x0403,
-        pid=0x6001,
-        serial_number="rutabaga",
-        manufacturer="FTDI",
-        product="FT232R USB UART",
-        bcd_device=0x0600,
-        interface_description=None,
-        interface_num=0,
-    )
-
-
-def test_freebsd_list_serial_ports_no_devices() -> None:
+async def test_freebsd_list_serial_ports_no_devices() -> None:
     """Test listing when no serial devices are present."""
 
     def mock_run(args, **kwargs):
@@ -134,6 +136,7 @@ def test_freebsd_list_serial_ports_no_devices() -> None:
         raise ValueError(f"Unexpected command: {args}")
 
     with patch("subprocess.run", side_effect=mock_run):
-        ports = freebsd_list_serial_ports()
+        ports_sync = freebsd_list_serial_ports()
+        ports_async = await async_freebsd_list_serial_ports()
 
-    assert ports == []
+    assert ports_sync == ports_async == []

--- a/tests/test_serial_esphome.py
+++ b/tests/test_serial_esphome.py
@@ -14,12 +14,17 @@ from base64 import b64encode
 from unittest.mock import patch
 import urllib.parse
 
-from serialx import SerialException, SerialPortInfo, open_serial_connection
+from serialx import (
+    Platform,
+    SerialException,
+    SerialPortInfo,
+    async_list_serial_ports,
+    list_serial_ports,
+    open_serial_connection,
+)
 from serialx.platforms.serial_esphome import (
     ESPHOME_DEFAULT_PORT,
     ESPHomeSerialTransport,
-    async_esphome_list_serial_ports,
-    esphome_list_serial_ports,
 )
 
 from .common import ESPHOME_HOST_BINARY, create_esphome_pair, create_socat_pair
@@ -232,8 +237,8 @@ async def test_noise_psk_key_alias() -> None:
 @pytest.mark.skipif(not ESPHOME_HOST_BINARY, reason="esphome host binary not available")
 async def test_esphome_list_serial_ports() -> None:
     """Test listing ESPHome serial ports."""
-    assert esphome_list_serial_ports() == []
-    assert await async_esphome_list_serial_ports() == []
+    assert list_serial_ports(Platform.ESPHOME) == []
+    assert await async_list_serial_ports(Platform.ESPHOME) == []
 
     with create_socat_pair() as (socat_left, socat_right):
         with create_esphome_pair(socat_left, socat_right) as (left, _right):
@@ -245,7 +250,7 @@ async def test_esphome_list_serial_ports() -> None:
             )
             await api.connect(login=True)
 
-            serial_ports = await async_esphome_list_serial_ports(api=api)
+            serial_ports = await async_list_serial_ports(Platform.ESPHOME, api=api)
             assert serial_ports == [
                 SerialPortInfo(
                     device=f"esphome://{parsed.netloc}/?port_name=Serial+Proxy+Left",

--- a/tests/test_serial_esphome.py
+++ b/tests/test_serial_esphome.py
@@ -14,10 +14,12 @@ from base64 import b64encode
 from unittest.mock import patch
 import urllib.parse
 
-from serialx import SerialException, open_serial_connection
+from serialx import SerialException, SerialPortInfo, open_serial_connection
 from serialx.platforms.serial_esphome import (
     ESPHOME_DEFAULT_PORT,
     ESPHomeSerialTransport,
+    async_esphome_list_serial_ports,
+    esphome_list_serial_ports,
 )
 
 from .common import ESPHOME_HOST_BINARY, create_esphome_pair, create_socat_pair
@@ -225,3 +227,48 @@ async def test_noise_psk_key_alias() -> None:
 
             writer.close()
             await writer.wait_closed()
+
+
+@pytest.mark.skipif(not ESPHOME_HOST_BINARY, reason="esphome host binary not available")
+async def test_esphome_list_serial_ports() -> None:
+    """Test listing ESPHome serial ports."""
+    assert esphome_list_serial_ports() == []
+    assert await async_esphome_list_serial_ports() == []
+
+    with create_socat_pair() as (socat_left, socat_right):
+        with create_esphome_pair(socat_left, socat_right) as (left, _right):
+            parsed = urllib.parse.urlparse(left)
+            api = APIClient(
+                address=parsed.hostname,
+                port=parsed.port or ESPHOME_DEFAULT_PORT,
+                password=None,
+            )
+            await api.connect(login=True)
+
+            serial_ports = await async_esphome_list_serial_ports(api=api)
+            assert serial_ports == [
+                SerialPortInfo(
+                    device=f"esphome://{parsed.netloc}/?port_name=Serial+Proxy+Left",
+                    resolved_device=f"esphome://{parsed.netloc}/?port_name=Serial+Proxy+Left",
+                    vid=None,
+                    pid=None,
+                    serial_number="98:35:69:AB:F6:79",
+                    manufacturer="Host",
+                    product="host",
+                    bcd_device=None,
+                    interface_description="Serial Proxy Left",
+                    interface_num=None,
+                ),
+                SerialPortInfo(
+                    device=f"esphome://{parsed.netloc}/?port_name=Serial+Proxy+Right",
+                    resolved_device=f"esphome://{parsed.netloc}/?port_name=Serial+Proxy+Right",
+                    vid=None,
+                    pid=None,
+                    serial_number="98:35:69:AB:F6:79",
+                    manufacturer="Host",
+                    product="host",
+                    bcd_device=None,
+                    interface_description="Serial Proxy Right",
+                    interface_num=None,
+                ),
+            ]

--- a/tests/test_serial_esphome.py
+++ b/tests/test_serial_esphome.py
@@ -10,6 +10,7 @@ except ImportError:
         allow_module_level=True,
     )
 
+import asyncio
 from base64 import b64encode
 from unittest.mock import patch
 import urllib.parse
@@ -234,9 +235,38 @@ async def test_noise_psk_key_alias() -> None:
             await writer.wait_closed()
 
 
+def _expected_esphome_ports(netloc: str) -> list[SerialPortInfo]:
+    return [
+        SerialPortInfo(
+            device=f"esphome://{netloc}/?port_name=Serial+Proxy+Left",
+            resolved_device=f"esphome://{netloc}/?port_name=Serial+Proxy+Left",
+            vid=None,
+            pid=None,
+            serial_number="98:35:69:AB:F6:79",
+            manufacturer="Host",
+            product="host",
+            bcd_device=None,
+            interface_description="Serial Proxy Left",
+            interface_num=None,
+        ),
+        SerialPortInfo(
+            device=f"esphome://{netloc}/?port_name=Serial+Proxy+Right",
+            resolved_device=f"esphome://{netloc}/?port_name=Serial+Proxy+Right",
+            vid=None,
+            pid=None,
+            serial_number="98:35:69:AB:F6:79",
+            manufacturer="Host",
+            product="host",
+            bcd_device=None,
+            interface_description="Serial Proxy Right",
+            interface_num=None,
+        ),
+    ]
+
+
 @pytest.mark.skipif(not ESPHOME_HOST_BINARY, reason="esphome host binary not available")
 async def test_esphome_list_serial_ports() -> None:
-    """Test listing ESPHome serial ports."""
+    """Test listing ESPHome serial ports asynchronously via an externally-passed API."""
     assert list_serial_ports(Platform.ESPHOME) == []
     assert await async_list_serial_ports(Platform.ESPHOME) == []
 
@@ -251,29 +281,53 @@ async def test_esphome_list_serial_ports() -> None:
             await api.connect(login=True)
 
             serial_ports = await async_list_serial_ports(Platform.ESPHOME, api=api)
-            assert serial_ports == [
-                SerialPortInfo(
-                    device=f"esphome://{parsed.netloc}/?port_name=Serial+Proxy+Left",
-                    resolved_device=f"esphome://{parsed.netloc}/?port_name=Serial+Proxy+Left",
-                    vid=None,
-                    pid=None,
-                    serial_number="98:35:69:AB:F6:79",
-                    manufacturer="Host",
-                    product="host",
-                    bcd_device=None,
-                    interface_description="Serial Proxy Left",
-                    interface_num=None,
-                ),
-                SerialPortInfo(
-                    device=f"esphome://{parsed.netloc}/?port_name=Serial+Proxy+Right",
-                    resolved_device=f"esphome://{parsed.netloc}/?port_name=Serial+Proxy+Right",
-                    vid=None,
-                    pid=None,
-                    serial_number="98:35:69:AB:F6:79",
-                    manufacturer="Host",
-                    product="host",
-                    bcd_device=None,
-                    interface_description="Serial Proxy Right",
-                    interface_num=None,
-                ),
-            ]
+            assert serial_ports == _expected_esphome_ports(parsed.netloc)
+
+
+@pytest.mark.skipif(not ESPHOME_HOST_BINARY, reason="esphome host binary not available")
+async def test_async_esphome_list_serial_ports_via_uri() -> None:
+    """Test listing ESPHome serial ports asynchronously via a URI."""
+    with create_socat_pair() as (socat_left, socat_right):
+        with create_esphome_pair(socat_left, socat_right) as (left, _right):
+            parsed = urllib.parse.urlparse(left)
+
+            serial_ports = await async_list_serial_ports(Platform.ESPHOME, path=left)
+            assert serial_ports == _expected_esphome_ports(parsed.netloc)
+
+
+@pytest.mark.skipif(not ESPHOME_HOST_BINARY, reason="esphome host binary not available")
+def test_sync_esphome_list_serial_ports_via_uri() -> None:
+    """Test listing ESPHome serial ports synchronously via a URI."""
+    assert list_serial_ports(Platform.ESPHOME) == []
+
+    with create_socat_pair() as (socat_left, socat_right):
+        with create_esphome_pair(socat_left, socat_right) as (left, _right):
+            parsed = urllib.parse.urlparse(left)
+
+            serial_ports = list_serial_ports(Platform.ESPHOME, path=left)
+            assert serial_ports == _expected_esphome_ports(parsed.netloc)
+
+
+@pytest.mark.skipif(not ESPHOME_HOST_BINARY, reason="esphome host binary not available")
+async def test_sync_esphome_list_serial_ports_external_api() -> None:
+    """Test sync listing of ESPHome serial ports with an externally-passed API."""
+    test_loop = asyncio.get_running_loop()
+
+    with create_socat_pair() as (socat_left, socat_right):
+        with create_esphome_pair(socat_left, socat_right) as (left, _right):
+            parsed = urllib.parse.urlparse(left)
+            api = APIClient(
+                address=parsed.hostname,
+                port=parsed.port or ESPHOME_DEFAULT_PORT,
+                password=None,
+            )
+            await api.connect(login=True)
+
+            serial_ports = await asyncio.to_thread(
+                list_serial_ports, Platform.ESPHOME, api=api, loop=test_loop
+            )
+            assert serial_ports == _expected_esphome_ports(parsed.netloc)
+
+            # The externally-passed API must remain connected.
+            await api.device_info()
+            await api.disconnect()


### PR DESCRIPTION
This PR adds a new API: `await serialx.async_list_serial_ports()`. This function can take a platform name (built-in names are exposed as `serialx.Platform`) to list serial ports for a specific platform. The default implementation remains the same, listing system serial ports.

The main motivation here is to allow listing ESPHome serial ports. Since you need to connect to ESPHome to list serial ports, which itself may require `key`/`password`, I've opted to make this API mirror the normal connection API and just directly reuse it. All of these work:

- `await serialx.async_list_serial_ports(Platform.ESPHOME, path="esphome://host:port/?key=key")`
- `await serialx.async_list_serial_ports(Platform.ESPHOME, api=api)`

The sync APIs work the same.

---

Overall, I'm questioning whether this approach of using a central function to list serial ports is good. I almost would prefer exporting the serial port objects directly but there's no clean API to work with them unless we attach the serial port listing functions onto the sync serial class and make an "async-sync" one to mirror it, since the async transport doesn't work like one.