### PR TITLE
Allow ESPHome transport to be used across threads and event loops

### DIFF
--- a/docs/api/platforms/esphome.md
+++ b/docs/api/platforms/esphome.md
@@ -1,6 +1,11 @@
 # ESPHome
 
 ```{eval-rst}
+.. automodule:: serialx.platforms.serial_esphome
+   :no-members:
+```
+
+```{eval-rst}
 .. autoclass:: serialx.platforms.serial_esphome.ESPHomeSerial
    :members:
    :member-order: bysource

--- a/serialx/platforms/serial_esphome.py
+++ b/serialx/platforms/serial_esphome.py
@@ -1,4 +1,24 @@
-"""ESPHome serial proxy transport."""
+"""ESPHome serial proxy transport.
+
+The `ESPHome serial proxy component <https://esphome.io/components/serial_proxy/>`_
+exposes any ESPHome serial instance through the ESPHome API. This is used by serialx to
+create a fully functional remote serial port, similar to RFC2217 but with many quality
+of life, performance, and security improvements.
+
+This platform requires the `aioesphomeapi <https://github.com/esphome/aioesphomeapi>`_
+package to be installed, provided by the ``esphome`` dependency group:
+
+.. code-block:: bash
+
+    pip install 'serialx[esphome]'
+
+.. note::
+    The aioesphomeapi package does not provide a synchronous interface so the sync
+    serial transport relies on spawning an asyncio event loop in a secondary thread in
+    order to proxy the async methods. This interface is far from ideal. If you'd like to
+    make use of this transport, please migrate your application to the async APIs for
+    better compatibility.
+"""
 
 from __future__ import annotations
 
@@ -11,6 +31,7 @@ import logging
 import threading
 from typing import Any, ParamSpec, TypeVar, cast
 import urllib.parse
+import warnings
 
 import aioesphomeapi
 from aioesphomeapi import APIClient, SerialProxyDataReceived, SerialProxyParity
@@ -105,8 +126,29 @@ class ESPHomeSerial(BaseSerial):
     ) -> None:
         """Initialize ESPHome serial port.
 
-        ``key`` is an alias for ``noise_psk`` and maps to the same pre-shared key
-        used for Noise-encrypted connections. Passing both raises ``ValueError``.
+        Args:
+            connect_timeout: Total timeout for connecting to the ESPHome device and
+                subscribing to events.
+            loop: Event loop to offload async operations to, optional. This is mostly
+                intended for internal use from the async transport. If an event loop is
+                not provided, the default for the synchronous API, a new one will be
+                created at runtime.
+            api: An instance of `aioesphomeapi.APIClient` to use. Authentication will
+                be skipped and the API will not be disconnected once the serial object
+                is closed.
+            port_name: The `name` attribute of the ESPHome serial proxy to connect to.
+            port_instance: The numerical instance ID of the ESPHome serial proxy
+                instance to connect to.
+
+                .. deprecated:: 1.2.0
+            key: The Noise PSK to use when creating an `aioesphomeapi.APIClient`
+                instance.
+            password: The API password to use when creating an `aioesphomeapi.APIClient`
+                instance.
+            noise_psk: An alias for `key`. Both cannot be passed at once.
+            *args: Passed through to `BaseSerial`.
+            **kwargs: Passed through to `BaseSerial`.
+
         """
         super().__init__(*args, **kwargs)
 
@@ -126,6 +168,9 @@ class ESPHomeSerial(BaseSerial):
         self._connect_timeout = connect_timeout
 
         self._api: APIClient | None = api
+        self._client_loop: asyncio.AbstractEventLoop | None = (
+            api._loop if api is not None else None
+        )
         self._port_name: str | None = port_name
         self._instance_id: int | None = port_instance
         self._password: str | None = password
@@ -139,10 +184,52 @@ class ESPHomeSerial(BaseSerial):
 
         self._last_line_state = LineStateFlag(0)
 
+    def _in_event_loop(self) -> bool:
+        """Check if we are currently running in the event loop."""
+        if self._loop is None:
+            return False
+
+        try:
+            return asyncio.get_running_loop() is self._loop
+        except RuntimeError:
+            return False
+
     def _call_on_loop(self, coro: Coroutine[Any, Any, _T]) -> _T:
         """Dispatch a coroutine to the event loop thread and block."""
         assert self._loop is not None
+
+        # XXX: Running a coroutine synchronously in its own event loop is an instant
+        # deadlock of the loop! For projects like Home Assistant that register signal
+        # handlers, this deadlock extends to nullifying CTRL-C!
+        if self._in_event_loop():
+            coro.close()
+            raise RuntimeError(
+                "Cannot call this sync ESPHomeSerial method from its own event "
+                "loop thread; use the async API instead."
+            )
+
         return asyncio.run_coroutine_threadsafe(coro, self._loop).result()
+
+    async def _call_on_client_loop(self, coro: Coroutine[Any, Any, _T]) -> _T:
+        """Await `coro` on the `APIClient`'s loop, bridging if needed."""
+        client_loop = self._client_loop
+        if client_loop is None or client_loop is self._loop:
+            return await coro
+
+        return await asyncio.wrap_future(
+            asyncio.run_coroutine_threadsafe(coro, client_loop)
+        )
+
+    def _schedule_on_client_loop(
+        self, fn: Callable[..., Any], *args: Any, **kwargs: Any
+    ) -> None:
+        """Invoke a synchronous `APIClient` method on the client's loop."""
+        client_loop = self._client_loop
+        if client_loop is None or client_loop is self._loop:
+            fn(*args, **kwargs)
+            return
+
+        client_loop.call_soon_threadsafe(functools.partial(fn, *args, **kwargs))
 
     def _maybe_start_new_event_loop(self) -> None:
         """Start a new event loop in a background thread if one isn't set."""
@@ -153,9 +240,20 @@ class ESPHomeSerial(BaseSerial):
         self._loop_thread.start()
 
     def _on_data(self, msg: SerialProxyDataReceived) -> None:
-        if msg.instance == self._instance_id:
-            self._read_buffer.extend(msg.data)
-            self._read_event.set()
+        if msg.instance != self._instance_id:
+            return
+
+        client_loop = self._client_loop
+        if client_loop is None or client_loop is self._loop:
+            self._handle_incoming_data(msg.data)
+        else:
+            assert self._loop is not None
+            self._loop.call_soon_threadsafe(self._handle_incoming_data, msg.data)
+
+    def _handle_incoming_data(self, data: bytes) -> None:
+        """Apply buffered data on `self._loop` after cross-loop marshalling."""
+        self._read_buffer.extend(data)
+        self._read_event.set()
 
     def _open(self) -> None:
         """Open the serial port."""
@@ -209,9 +307,10 @@ class ESPHomeSerial(BaseSerial):
                 password=self._password,
                 noise_psk=self._noise_psk,
             )
+            self._client_loop = self._api._loop
 
             self._disconnect_api = True
-            await self._api.connect(login=True)
+            await self._call_on_client_loop(self._api.connect(login=True))
         else:
             # Don't disconnect an externally-passed API
             self._disconnect_api = False
@@ -220,7 +319,7 @@ class ESPHomeSerial(BaseSerial):
     async def _async_list_serial_ports(self) -> list[SerialPortInfo]:
         assert self._api is not None
 
-        device_info = await self._api.device_info()
+        device_info = await self._call_on_client_loop(self._api.device_info())
         ports = []
 
         for proxy in device_info.serial_proxies:
@@ -259,11 +358,22 @@ class ESPHomeSerial(BaseSerial):
     async def _async_subscribe(self) -> None:
         assert self._api is not None
         await self._subscribe_instance()
-        self._unsub = self._api.subscribe_serial_proxy_data(self._on_data)
+        self._unsub = await self._call_on_client_loop(self._register_data_handler())
+
+    async def _register_data_handler(self) -> Callable[[], None]:
+        """Register `_on_data` on the client's loop and return the unsub."""
+        assert self._api is not None
+        unsub: Callable[[], None] = self._api.subscribe_serial_proxy_data(self._on_data)
+        return unsub
 
     @translate_esphome_errors
     async def _ping(self, *, timeout: float) -> None:
         """Ping the ESPHome API."""
+        assert self._api is not None
+        await self._call_on_client_loop(self._send_ping(timeout=timeout))
+
+    async def _send_ping(self, *, timeout: float) -> None:
+        """Issue a ping request on the client's loop."""
         assert self._api is not None
         conn = self._api._get_connection()
 
@@ -280,7 +390,7 @@ class ESPHomeSerial(BaseSerial):
         if self._api is None or self._instance_subscribed:
             return
 
-        info = await self._api.device_info()
+        info = await self._call_on_client_loop(self._api.device_info())
 
         if self._instance_id is None:
             assert self._port_name is not None
@@ -299,7 +409,9 @@ class ESPHomeSerial(BaseSerial):
             instance_id, _proxy_info = name_to_info_mapping[self._port_name]
             self._instance_id = instance_id
 
-        self._api.serial_proxy_subscribe(self._instance_id)
+        self._schedule_on_client_loop(
+            self._api.serial_proxy_subscribe, self._instance_id
+        )
 
         # Ping to ensure the daemon has processed the subscribe
         await self._ping(timeout=self._connect_timeout)
@@ -312,14 +424,17 @@ class ESPHomeSerial(BaseSerial):
             return
 
         with suppress(APIConnectionError):
-            self._api.serial_proxy_unsubscribe(self._instance_id)
+            self._schedule_on_client_loop(
+                self._api.serial_proxy_unsubscribe, self._instance_id
+            )
 
         self._instance_subscribed = False
 
     def _configure_port(self) -> None:
         """Configure the serial port settings."""
         assert self._api is not None
-        self._api.serial_proxy_configure(
+        self._schedule_on_client_loop(
+            self._api.serial_proxy_configure,
             instance=self._instance_id,
             baudrate=self._baudrate,
             flow_control=self._rtscts,
@@ -328,12 +443,8 @@ class ESPHomeSerial(BaseSerial):
             data_size=self._byte_size,
         )
 
-    def _set_modem_pins(self, modem_pins: ModemPins) -> None:
-        """Set modem control bits."""
-        self._call_on_loop(self._async_set_modem_pins(modem_pins))
-
-    @translate_esphome_errors
-    async def _async_set_modem_pins(self, modem_pins: ModemPins) -> None:
+    def _send_set_modem_pins(self, modem_pins: ModemPins) -> None:
+        """Send a signal to set modem control bits, without waiting for a response."""
         assert self._api is not None
         line_states = self._last_line_state
 
@@ -348,10 +459,32 @@ class ESPHomeSerial(BaseSerial):
             line_states &= ~LineStateFlag.DTR
 
         self._last_line_state = line_states
-        self._api.serial_proxy_set_modem_pins(
+        self._schedule_on_client_loop(
+            self._api.serial_proxy_set_modem_pins,
             instance=self._instance_id,
-            line_states=self._last_line_state,
+            line_states=line_states,
         )
+
+    def _set_modem_pins(self, modem_pins: ModemPins) -> None:
+        """Set modem control bits."""
+
+        # XXX: This is the one sync API we allow to be used from an async context, by
+        # enqueuing the operation instead of blocking.
+        if self._in_event_loop():
+            warnings.warn(
+                "Use `await transport.set_modem_pins(...)` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            self._send_set_modem_pins(modem_pins)
+            return
+
+        self._call_on_loop(self._async_set_modem_pins(modem_pins))
+
+    @translate_esphome_errors
+    async def _async_set_modem_pins(self, modem_pins: ModemPins) -> None:
+        assert self._api is not None
+        self._send_set_modem_pins(modem_pins)
 
         await self._async_get_modem_pins()
 
@@ -361,7 +494,9 @@ class ESPHomeSerial(BaseSerial):
     @translate_esphome_errors
     async def _async_get_modem_pins(self) -> ModemPins:
         assert self._api is not None
-        rsp = await self._api.serial_proxy_get_modem_pins(instance=self._instance_id)
+        rsp = await self._call_on_client_loop(
+            self._api.serial_proxy_get_modem_pins(instance=self._instance_id)
+        )
         self._last_line_state = rsp.line_states
 
         return ModemPins(
@@ -388,7 +523,9 @@ class ESPHomeSerial(BaseSerial):
     async def _async_flush(self) -> None:
         """Flush write buffers."""
         assert self._api is not None
-        await self._api.serial_proxy_flush(instance=self._instance_id)
+        await self._call_on_client_loop(
+            self._api.serial_proxy_flush(instance=self._instance_id)
+        )
 
     def _flush(self) -> None:
         """Flush write buffers."""
@@ -398,7 +535,9 @@ class ESPHomeSerial(BaseSerial):
         """Write bytes to serial port."""
         assert self._api is not None
         data = bytes(b)
-        self._api.serial_proxy_write(instance=self._instance_id, data=data)
+        self._schedule_on_client_loop(
+            self._api.serial_proxy_write, instance=self._instance_id, data=data
+        )
         return len(data)
 
     def _readinto(self, b: Buffer, *, timeout: float | None) -> int:
@@ -423,12 +562,12 @@ class ESPHomeSerial(BaseSerial):
     def _close(self) -> None:
         """Close the serial port."""
         if self._unsub is not None:
-            self._unsub()
+            self._schedule_on_client_loop(self._unsub)
             self._unsub = None
 
         if self._disconnect_api and self._api is not None:
             self._unsubscribe_instance()
-            self._call_on_loop(self._api.disconnect())
+            self._call_on_loop(self._call_on_client_loop(self._api.disconnect()))
             self._api = None
 
         if self._loop_thread is not None:
@@ -444,6 +583,7 @@ class ESPHomeSerialTransport(BaseSerialTransport):
     """Serial transport over ESPHome serial proxy API."""
 
     transport_name = "esphome"
+    _serial_cls: type[ESPHomeSerial] = ESPHomeSerial
     _serial: ESPHomeSerial | None
 
     def __init__(
@@ -456,7 +596,7 @@ class ESPHomeSerialTransport(BaseSerialTransport):
 
     @translate_esphome_errors
     async def _connect(self, **kwargs: Any) -> None:
-        self._serial = ESPHomeSerial(loop=self._loop, **kwargs)
+        self._serial = self._serial_cls(loop=self._loop, **kwargs)
         self._extra["serial"] = self._serial
 
         assert self._serial is not None
@@ -465,14 +605,33 @@ class ESPHomeSerialTransport(BaseSerialTransport):
 
         assert self._serial._api is not None
         await self._serial._subscribe_instance()
-        self._unsub = self._serial._api.subscribe_serial_proxy_data(self._on_data)
+        self._unsub = await self._serial._call_on_client_loop(
+            self._register_transport_data_handler()
+        )
 
         self._protocol.connection_made(self)
 
+    async def _register_transport_data_handler(self) -> Callable[[], None]:
+        """Register `_on_data` on the client's loop and return the unsub."""
+        assert self._serial is not None
+        assert self._serial._api is not None
+
+        # This isn't a coroutine but needs to be run in the target loop
+        unsub: Callable[[], None] = self._serial._api.subscribe_serial_proxy_data(
+            self._on_data
+        )
+        return unsub
+
     def _on_data(self, msg: SerialProxyDataReceived) -> None:
         assert self._serial is not None
-        if msg.instance == self._serial._instance_id:
+        if msg.instance != self._serial._instance_id:
+            return
+
+        client_loop = self._serial._client_loop
+        if client_loop is None or client_loop is self._loop:
             self._protocol.data_received(msg.data)
+        else:
+            self._loop.call_soon_threadsafe(self._protocol.data_received, msg.data)
 
     def write(self, data: bytes | bytearray | memoryview) -> None:
         """Write data to the serial proxy."""
@@ -489,11 +648,14 @@ class ESPHomeSerialTransport(BaseSerialTransport):
             return
         self._closing = True
 
+        serial = self._serial
         if self._unsub is not None:
-            self._unsub()
+            if serial is not None:
+                serial._schedule_on_client_loop(self._unsub)
+            else:
+                self._unsub()
             self._unsub = None
 
-        serial = self._serial
         if serial is None:
             self._call_protocol_connection_lost(None)
             return
@@ -519,8 +681,9 @@ class ESPHomeSerialTransport(BaseSerialTransport):
 
     async def _async_close(self, api: APIClient) -> None:
         """Close the API connection."""
+        assert self._serial is not None
         try:
-            await api.disconnect()
+            await self._serial._call_on_client_loop(api.disconnect())
         finally:
             self._call_protocol_connection_lost(None)
 

--- a/serialx/platforms/serial_esphome.py
+++ b/serialx/platforms/serial_esphome.py
@@ -186,8 +186,7 @@ class ESPHomeSerial(BaseSerial):
 
     def _in_event_loop(self) -> bool:
         """Check if we are currently running in the event loop."""
-        if self._loop is None:
-            return False
+        assert self._loop is not None
 
         try:
             return asyncio.get_running_loop() is self._loop
@@ -235,6 +234,7 @@ class ESPHomeSerial(BaseSerial):
         """Start a new event loop in a background thread if one isn't set."""
         if self._loop is not None:
             return
+
         self._loop = asyncio.new_event_loop()
         self._loop_thread = threading.Thread(target=self._loop.run_forever)
         self._loop_thread.start()
@@ -467,6 +467,7 @@ class ESPHomeSerial(BaseSerial):
 
     def _set_modem_pins(self, modem_pins: ModemPins) -> None:
         """Set modem control bits."""
+        assert self._loop is not None
 
         # XXX: This is the one sync API we allow to be used from an async context, by
         # enqueuing the operation instead of blocking.

--- a/tests/test_serial_esphome.py
+++ b/tests/test_serial_esphome.py
@@ -12,7 +12,7 @@ except ImportError:
 
 import asyncio
 from base64 import b64encode
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Iterator
 import contextlib
 import threading
 from typing import cast
@@ -35,7 +35,51 @@ from serialx.platforms.serial_esphome import (
     ESPHomeSerialTransport,
 )
 
-from .common import ESPHOME_HOST_BINARY, create_esphome_pair, create_socat_pair
+from .common import (
+    ESPHOME_HOST_BINARY,
+    async_create_reader_writer,
+    create_esphome_pair,
+    create_socat_pair,
+)
+
+
+@contextlib.contextmanager
+def api_client_on_thread_loop(
+    url: str,
+) -> Iterator[tuple[APIClient, asyncio.AbstractEventLoop]]:
+    """Yield an APIClient connected on a dedicated background thread's loop."""
+    parsed = urllib.parse.urlparse(url)
+
+    thread_loop = asyncio.new_event_loop()
+    ready = threading.Event()
+
+    def _run_loop() -> None:
+        asyncio.set_event_loop(thread_loop)
+        ready.set()
+        thread_loop.run_forever()
+
+    thread = threading.Thread(target=_run_loop, daemon=True)
+    thread.start()
+    ready.wait()
+
+    async def _connect() -> APIClient:
+        api = APIClient(
+            address=parsed.hostname,
+            port=parsed.port or ESPHOME_DEFAULT_PORT,
+            password=None,
+        )
+        await api.connect(login=True)
+        return api
+
+    api = asyncio.run_coroutine_threadsafe(_connect(), thread_loop).result()
+
+    try:
+        yield api, thread_loop
+    finally:
+        asyncio.run_coroutine_threadsafe(api.disconnect(), thread_loop).result()
+        thread_loop.call_soon_threadsafe(thread_loop.stop)
+        thread.join(timeout=5)
+        thread_loop.close()
 
 
 @contextlib.asynccontextmanager
@@ -45,36 +89,9 @@ async def create_cross_loop_reader_writer(
     tuple[asyncio.StreamReader, SerialStreamWriter[ESPHomeSerialTransport]]
 ]:
     """Create a reader/writer whose `APIClient` lives on its own thread loop."""
-    parsed = urllib.parse.urlparse(url)
+    port_name = urllib.parse.parse_qs(urllib.parse.urlparse(url).query)["port_name"][0]
 
-    # We need to extract the port name from the URI, since we create the client manually
-    params = urllib.parse.parse_qs(parsed.query)
-    port_name = params["port_name"][0]
-
-    thread_loop = asyncio.new_event_loop()
-    loop_ready = threading.Event()
-
-    def _run_loop() -> None:
-        asyncio.set_event_loop(thread_loop)
-        loop_ready.set()
-        thread_loop.run_forever()
-
-    thread = threading.Thread(target=_run_loop, daemon=True)
-    thread.start()
-    loop_ready.wait()
-
-    async def _connect_api() -> APIClient:
-        api = APIClient(
-            address=parsed.hostname,
-            port=parsed.port or ESPHOME_DEFAULT_PORT,
-            password=None,
-        )
-        await api.connect(login=True)
-        return api
-
-    api = asyncio.run_coroutine_threadsafe(_connect_api(), thread_loop).result()
-
-    try:
+    with api_client_on_thread_loop(url) as (api, _thread_loop):
         reader, writer = await open_serial_connection(
             url=None,
             transport_cls=ESPHomeSerialTransport,
@@ -82,18 +99,11 @@ async def create_cross_loop_reader_writer(
             port_name=port_name,
             baudrate=115200,
         )
-
         try:
             yield reader, cast(SerialStreamWriter[ESPHomeSerialTransport], writer)
         finally:
             writer.close()
             await writer.wait_closed()
-    finally:
-        asyncio.run_coroutine_threadsafe(api.disconnect(), thread_loop).result()
-
-        thread_loop.call_soon_threadsafe(thread_loop.stop)
-        thread.join(timeout=5)
-        thread_loop.close()
 
 
 def base64(key: bytes) -> str:
@@ -458,3 +468,40 @@ async def test_cross_loop_sync_modem_pins_on_loop_thread() -> None:
 
                 with pytest.raises(RuntimeError, match="sync ESPHomeSerial method"):
                     _ = serial.dtr
+
+
+@pytest.mark.skipif(not ESPHOME_HOST_BINARY, reason="esphome host binary not available")
+async def test_sync_api_with_external_api_on_different_loop() -> None:
+    """Sync API works when the `APIClient` lives on a different loop."""
+    with create_socat_pair() as (socat_left, socat_right):
+        with create_esphome_pair(socat_left, socat_right) as (left, right):
+            async with async_create_reader_writer(right, baudrate=115200) as (
+                _peer_reader,
+                peer_writer,
+            ):
+                with api_client_on_thread_loop(left) as (api, api_loop):
+
+                    def _sync_open() -> ESPHomeSerial:
+                        serial = ESPHomeSerial(
+                            api=api,
+                            port_name="Serial Proxy Left",
+                            baudrate=115200,
+                        )
+                        serial.open()
+                        return serial
+
+                    serial = await asyncio.to_thread(_sync_open)
+
+                    try:
+                        # API on thread 1, sync-dispatch loop on thread 2
+                        assert serial._client_loop is api_loop
+                        assert serial._loop is not None
+                        assert serial._loop is not api_loop
+
+                        peer_writer.write(b"peer-data")
+                        await peer_writer.drain()
+
+                        data = await asyncio.to_thread(serial.read, len(b"peer-data"))
+                        assert data == b"peer-data"
+                    finally:
+                        await asyncio.to_thread(serial.close)

--- a/tests/test_serial_esphome.py
+++ b/tests/test_serial_esphome.py
@@ -12,23 +12,88 @@ except ImportError:
 
 import asyncio
 from base64 import b64encode
+from collections.abc import AsyncIterator
+import contextlib
+import threading
+from typing import cast
 from unittest.mock import patch
 import urllib.parse
+import warnings
 
 from serialx import (
     Platform,
     SerialException,
     SerialPortInfo,
+    SerialStreamWriter,
     async_list_serial_ports,
     list_serial_ports,
     open_serial_connection,
 )
 from serialx.platforms.serial_esphome import (
     ESPHOME_DEFAULT_PORT,
+    ESPHomeSerial,
     ESPHomeSerialTransport,
 )
 
 from .common import ESPHOME_HOST_BINARY, create_esphome_pair, create_socat_pair
+
+
+@contextlib.asynccontextmanager
+async def create_cross_loop_reader_writer(
+    url: str,
+) -> AsyncIterator[
+    tuple[asyncio.StreamReader, SerialStreamWriter[ESPHomeSerialTransport]]
+]:
+    """Create a reader/writer whose `APIClient` lives on its own thread loop."""
+    parsed = urllib.parse.urlparse(url)
+
+    # We need to extract the port name from the URI, since we create the client manually
+    params = urllib.parse.parse_qs(parsed.query)
+    port_name = params["port_name"][0]
+
+    thread_loop = asyncio.new_event_loop()
+    loop_ready = threading.Event()
+
+    def _run_loop() -> None:
+        asyncio.set_event_loop(thread_loop)
+        loop_ready.set()
+        thread_loop.run_forever()
+
+    thread = threading.Thread(target=_run_loop, daemon=True)
+    thread.start()
+    loop_ready.wait()
+
+    async def _connect_api() -> APIClient:
+        api = APIClient(
+            address=parsed.hostname,
+            port=parsed.port or ESPHOME_DEFAULT_PORT,
+            password=None,
+        )
+        await api.connect(login=True)
+        return api
+
+    api = asyncio.run_coroutine_threadsafe(_connect_api(), thread_loop).result()
+
+    try:
+        reader, writer = await open_serial_connection(
+            url=None,
+            transport_cls=ESPHomeSerialTransport,
+            api=api,
+            port_name=port_name,
+            baudrate=115200,
+        )
+
+        try:
+            yield reader, cast(SerialStreamWriter[ESPHomeSerialTransport], writer)
+        finally:
+            writer.close()
+            await writer.wait_closed()
+    finally:
+        asyncio.run_coroutine_threadsafe(api.disconnect(), thread_loop).result()
+
+        thread_loop.call_soon_threadsafe(thread_loop.stop)
+        thread.join(timeout=5)
+        thread_loop.close()
 
 
 def base64(key: bytes) -> str:
@@ -331,3 +396,65 @@ async def test_sync_esphome_list_serial_ports_external_api() -> None:
             # The externally-passed API must remain connected.
             await api.device_info()
             await api.disconnect()
+
+
+@pytest.mark.skipif(not ESPHOME_HOST_BINARY, reason="esphome host binary not available")
+async def test_cross_loop_async_api() -> None:
+    """Async API works with the `APIClient` on a separate loop."""
+    with create_socat_pair() as (socat_left, socat_right):
+        with create_esphome_pair(socat_left, socat_right) as (left, right):
+            # Peer side uses the plain URL-based handler
+            peer_reader, peer_writer = await open_serial_connection(
+                url=right, baudrate=115200
+            )
+
+            try:
+                async with create_cross_loop_reader_writer(left) as (reader, writer):
+                    serial = writer.transport.get_extra_info("serial")
+                    assert isinstance(serial, ESPHomeSerial)
+                    assert serial._client_loop is not asyncio.get_running_loop()
+                    assert serial._loop is asyncio.get_running_loop()
+
+                    # Cross-loop side -> peer (write path)
+                    writer.write(b"left-to-right")
+                    await writer.drain()
+                    data = await peer_reader.readexactly(len(b"left-to-right"))
+                    assert data == b"left-to-right"
+
+                    # Peer -> cross-loop side (read path via _on_data marshalling)
+                    peer_writer.write(b"right-to-left")
+                    await peer_writer.drain()
+                    data = await reader.readexactly(len(b"right-to-left"))
+                    assert data == b"right-to-left"
+
+                    # Async modem pins + flush round-trip across loops. The
+                    # host binary does not propagate flow control between
+                    # sides, so we just assert the calls complete.
+                    await writer.transport.set_modem_pins(dtr=True, rts=False)
+                    await writer.transport.get_modem_pins()
+                    await writer.transport.flush()
+            finally:
+                peer_writer.close()
+                await peer_writer.wait_closed()
+
+
+@pytest.mark.skipif(not ESPHOME_HOST_BINARY, reason="esphome host binary not available")
+async def test_cross_loop_sync_modem_pins_on_loop_thread() -> None:
+    """Sync modem-pin access from `self._loop`'s thread must not deadlock."""
+    with create_socat_pair() as (socat_left, socat_right):
+        with create_esphome_pair(socat_left, socat_right) as (left, _right):
+            async with create_cross_loop_reader_writer(left) as (
+                _reader,
+                writer,
+            ):
+                serial = writer.transport.serial
+
+                with warnings.catch_warnings():
+                    warnings.simplefilter("always", DeprecationWarning)
+                    with pytest.warns(
+                        DeprecationWarning, match="transport.set_modem_pins"
+                    ):
+                        serial.dtr = False
+
+                with pytest.raises(RuntimeError, match="sync ESPHomeSerial method"):
+                    _ = serial.dtr

--- a/tests/test_serial_esphome.py
+++ b/tests/test_serial_esphome.py
@@ -505,3 +505,78 @@ async def test_sync_api_with_external_api_on_different_loop() -> None:
                         assert data == b"peer-data"
                     finally:
                         await asyncio.to_thread(serial.close)
+
+
+@pytest.mark.skipif(not ESPHOME_HOST_BINARY, reason="esphome host binary not available")
+async def test_single_api_multiple_async_ports() -> None:
+    """Two async transports sharing one APIClient operate independently."""
+    with create_socat_pair() as (socat_left, socat_right):
+        with create_esphome_pair(socat_left, socat_right) as (left, _right):
+            parsed = urllib.parse.urlparse(left)
+            api = APIClient(
+                address=parsed.hostname,
+                port=parsed.port or ESPHOME_DEFAULT_PORT,
+                password=None,
+            )
+            await api.connect(login=True)
+
+            try:
+                reader_left, writer_left = await open_serial_connection(
+                    url=None,
+                    transport_cls=ESPHomeSerialTransport,
+                    api=api,
+                    port_name="Serial Proxy Left",
+                    baudrate=115200,
+                )
+                reader_right, writer_right = await open_serial_connection(
+                    url=None,
+                    transport_cls=ESPHomeSerialTransport,
+                    api=api,
+                    port_name="Serial Proxy Right",
+                    baudrate=115200,
+                )
+                try:
+                    writer_left.write(b"left-to-right")
+                    await writer_left.drain()
+                    data = await asyncio.wait_for(
+                        reader_right.readexactly(len(b"left-to-right")), timeout=5
+                    )
+                    assert data == b"left-to-right"
+
+                    writer_right.write(b"right-to-left")
+                    await writer_right.drain()
+                    data = await asyncio.wait_for(
+                        reader_left.readexactly(len(b"right-to-left")), timeout=5
+                    )
+                    assert data == b"right-to-left"
+                finally:
+                    writer_left.close()
+                    writer_right.close()
+                    await writer_left.wait_closed()
+                    await writer_right.wait_closed()
+
+                # The shared externally-owned API is still connected
+                await api.device_info()
+            finally:
+                await api.disconnect()
+
+
+@pytest.mark.skipif(not ESPHOME_HOST_BINARY, reason="esphome host binary not available")
+async def test_single_api_multiple_sync_ports() -> None:
+    """Two sync ESPHomeSerials sharing one APIClient operate independently."""
+    with create_socat_pair() as (socat_left, socat_right):
+        with create_esphome_pair(socat_left, socat_right) as (left, _right):
+            with api_client_on_thread_loop(left) as (api, _api_loop):
+                with (
+                    ESPHomeSerial(
+                        api=api, port_name="Serial Proxy Left", baudrate=115200
+                    ) as serial_left,
+                    ESPHomeSerial(
+                        api=api, port_name="Serial Proxy Right", baudrate=115200
+                    ) as serial_right,
+                ):
+                    serial_left.write(b"left-to-right")
+                    assert serial_right.read(len(b"left-to-right")) == b"left-to-right"
+
+                    serial_right.write(b"right-to-left")
+                    assert serial_left.read(len(b"right-to-left")) == b"right-to-left"

--- a/tests/test_serial_esphome.py
+++ b/tests/test_serial_esphome.py
@@ -413,39 +413,34 @@ async def test_cross_loop_async_api() -> None:
     """Async API works with the `APIClient` on a separate loop."""
     with create_socat_pair() as (socat_left, socat_right):
         with create_esphome_pair(socat_left, socat_right) as (left, right):
-            # Peer side uses the plain URL-based handler
-            peer_reader, peer_writer = await open_serial_connection(
+            reader_right, writer_right = await open_serial_connection(
                 url=right, baudrate=115200
             )
 
             try:
-                async with create_cross_loop_reader_writer(left) as (reader, writer):
-                    serial = writer.transport.get_extra_info("serial")
+                async with create_cross_loop_reader_writer(left) as (
+                    reader_left,
+                    writer_left,
+                ):
+                    serial = writer_left.transport.get_extra_info("serial")
                     assert isinstance(serial, ESPHomeSerial)
                     assert serial._client_loop is not asyncio.get_running_loop()
                     assert serial._loop is asyncio.get_running_loop()
 
-                    # Cross-loop side -> peer (write path)
-                    writer.write(b"left-to-right")
-                    await writer.drain()
-                    data = await peer_reader.readexactly(len(b"left-to-right"))
-                    assert data == b"left-to-right"
+                    writer_left.write(b"left to right")
+                    data = await reader_right.readexactly(len(b"left to right"))
+                    assert data == b"left to right"
 
-                    # Peer -> cross-loop side (read path via _on_data marshalling)
-                    peer_writer.write(b"right-to-left")
-                    await peer_writer.drain()
-                    data = await reader.readexactly(len(b"right-to-left"))
-                    assert data == b"right-to-left"
+                    writer_right.write(b"right to left")
+                    data = await reader_left.readexactly(len(b"right to left"))
+                    assert data == b"right to left"
 
-                    # Async modem pins + flush round-trip across loops. The
-                    # host binary does not propagate flow control between
-                    # sides, so we just assert the calls complete.
-                    await writer.transport.set_modem_pins(dtr=True, rts=False)
-                    await writer.transport.get_modem_pins()
-                    await writer.transport.flush()
+                    await writer_left.transport.set_modem_pins(dtr=True, rts=False)
+                    await writer_left.transport.get_modem_pins()
+                    await writer_left.transport.flush()
             finally:
-                peer_writer.close()
-                await peer_writer.wait_closed()
+                writer_right.close()
+                await writer_right.wait_closed()
 
 
 @pytest.mark.skipif(not ESPHOME_HOST_BINARY, reason="esphome host binary not available")
@@ -535,20 +530,21 @@ async def test_single_api_multiple_async_ports() -> None:
                     port_name="Serial Proxy Right",
                     baudrate=115200,
                 )
+
                 try:
-                    writer_left.write(b"left-to-right")
+                    writer_left.write(b"left to right")
                     await writer_left.drain()
                     data = await asyncio.wait_for(
-                        reader_right.readexactly(len(b"left-to-right")), timeout=5
+                        reader_right.readexactly(len(b"left to right")), timeout=5
                     )
-                    assert data == b"left-to-right"
+                    assert data == b"left to right"
 
-                    writer_right.write(b"right-to-left")
+                    writer_right.write(b"right to left")
                     await writer_right.drain()
                     data = await asyncio.wait_for(
-                        reader_left.readexactly(len(b"right-to-left")), timeout=5
+                        reader_left.readexactly(len(b"right to left")), timeout=5
                     )
-                    assert data == b"right-to-left"
+                    assert data == b"right to left"
                 finally:
                     writer_left.close()
                     writer_right.close()
@@ -575,8 +571,8 @@ async def test_single_api_multiple_sync_ports() -> None:
                         api=api, port_name="Serial Proxy Right", baudrate=115200
                     ) as serial_right,
                 ):
-                    serial_left.write(b"left-to-right")
-                    assert serial_right.read(len(b"left-to-right")) == b"left-to-right"
+                    serial_left.write(b"left to right")
+                    assert serial_right.read(len(b"left to right")) == b"left to right"
 
-                    serial_right.write(b"right-to-left")
-                    assert serial_left.read(len(b"right-to-left")) == b"right-to-left"
+                    serial_right.write(b"right to left")
+                    assert serial_left.read(len(b"right to left")) == b"right to left"


### PR DESCRIPTION
On async transports, we expose a `.serial` property that references the _sync_ serial interface. This is strictly for backwards compatibility, as some packages rely on accessing modem pins or the serial port name from this sync API.

Zigpy unfortunately has two weird uses:
1. bellows runs its serial communication in a separate thread. If we pass the Home Assistant Core aioesphomeapi API client instance by reference, we start awaiting tasks across event loops, breaking everything.
2. zigpy-znp uses `transport.serial.dtr = True` to set modem lines (once we migrate zigpy to use serialx strictly, this will be transformed into `await transport.set_modem_lines(dtr=True)`). This calls a sync API from an async context, which runs an async operation _synchronously_ in the parent event loop _using_ the parent event loop. This is an instant asyncio deadlock. Worse yet, Home Assistant registers signal handlers and makes this deadlock worse by being unkillable with `CTRL-C` and logging absolutely nothing past this point.

To work around these issues, I've made some tweaks:
1. We support cross-loop and thread-safe operation by using the appropriate asyncio helper functions `asyncio.run_coroutine_threadsafe`, etc. This change has optimizations for when the API instance's loop is the same as the current loop.
2. The synchronous `set_modem_pins` can now be called from an async context but it no longer blocks at all, returning instantly. We log a deprecation warning here.
3. `get_modem_pins` throws a `RuntimeError`. There's no sensible way to implement this.