### PR TITLE
Provide a no-op default implementation of serial port listing

### DIFF
--- a/serialx/common.py
+++ b/serialx/common.py
@@ -64,14 +64,26 @@ class _RegistryEntry(NamedTuple):
 _REGISTERED_URI_HANDLERS: defaultdict[str, list[_RegistryEntry]] = defaultdict(list)
 
 
+def empty_port_list(*args: Any, **kwargs: Any) -> list[SerialPortInfo]:
+    """Return an empty list of serial ports."""
+    return []
+
+
+async def async_empty_port_list(*args: Any, **kwargs: Any) -> list[SerialPortInfo]:
+    """Return an empty list of serial ports, async."""
+    return []
+
+
 def register_uri_handler(
     *,
     scheme: str,
     unique_scheme: str,
     sync_cls: type[BaseSerial],
     async_transport_cls: type[BaseSerialTransport],
-    list_serial_ports_func: Callable[..., list[SerialPortInfo]],
-    async_list_serial_ports_func: Callable[..., Awaitable[list[SerialPortInfo]]],
+    list_serial_ports_func: Callable[..., list[SerialPortInfo]] = empty_port_list,
+    async_list_serial_ports_func: Callable[
+        ..., Awaitable[list[SerialPortInfo]]
+    ] = async_empty_port_list,
     weight: int = 1,
     strip_uri_scheme: bool = False,
 ) -> Callable[[], None]:

--- a/serialx/platforms/serial_extended_posix.py
+++ b/serialx/platforms/serial_extended_posix.py
@@ -8,12 +8,7 @@ from __future__ import annotations
 import termios
 
 from ..common import register_uri_handler
-from .serial_posix import (
-    PosixSerial,
-    PosixSerialTransport,
-    async_posix_list_serial_ports,
-    posix_list_serial_ports,
-)
+from .serial_posix import PosixSerial, PosixSerialTransport
 
 CRTSCTS = getattr(termios, "CRTSCTS", getattr(termios, "CNEW_RTSCTS", None))
 
@@ -52,8 +47,6 @@ if is_extended_posix():
         unique_scheme="extended-posix://",
         sync_cls=ExtendedPosixSerial,
         async_transport_cls=ExtendedPosixSerialTransport,
-        list_serial_ports_func=posix_list_serial_ports,
-        async_list_serial_ports_func=async_posix_list_serial_ports,
         weight=2,
         strip_uri_scheme=True,
     )

--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -25,7 +25,6 @@ from ..common import (
     ModemPins,
     Parity,
     PinState,
-    SerialPortInfo,
     StopBits,
     UnsupportedSetting,
     register_uri_handler,
@@ -525,22 +524,10 @@ class PosixSerialTransport(DescriptorTransport):
             self._reset_empty_waiter()
 
 
-def posix_list_serial_ports() -> list[SerialPortInfo]:
-    """List available serial ports on POSIX."""
-    return []
-
-
-async def async_posix_list_serial_ports() -> list[SerialPortInfo]:
-    """List available serial ports on POSIX, async."""
-    return []
-
-
 register_uri_handler(
     scheme="device://",
     unique_scheme="posix://",
     sync_cls=PosixSerial,
     async_transport_cls=PosixSerialTransport,
-    list_serial_ports_func=posix_list_serial_ports,
-    async_list_serial_ports_func=async_posix_list_serial_ports,
     strip_uri_scheme=True,
 )

--- a/serialx/platforms/serial_rfc2217/__init__.py
+++ b/serialx/platforms/serial_rfc2217/__init__.py
@@ -24,7 +24,6 @@ from ...common import (
     Parity,
     PinState,
     SerialException,
-    SerialPortInfo,
     StopBits,
     UnsupportedSetting,
     measure_time,
@@ -1041,21 +1040,9 @@ class RFC2217SerialTransport(BaseSerialTransport):
         return self._tcp_transport.can_write_eof()
 
 
-def rfc2217_list_serial_ports() -> list[SerialPortInfo]:
-    """List serial ports for RFC2217."""
-    return []
-
-
-async def async_rfc2217_list_serial_ports() -> list[SerialPortInfo]:
-    """List serial ports for RFC2217, async."""
-    return []
-
-
 register_uri_handler(
     scheme="rfc2217://",
     unique_scheme="rfc2217://",
     sync_cls=RFC2217Serial,
     async_transport_cls=RFC2217SerialTransport,
-    list_serial_ports_func=rfc2217_list_serial_ports,
-    async_list_serial_ports_func=async_rfc2217_list_serial_ports,
 )

--- a/serialx/platforms/serial_socket.py
+++ b/serialx/platforms/serial_socket.py
@@ -17,7 +17,6 @@ from serialx.common import (
     BaseSerialTransport,
     ModemPins,
     Parity,
-    SerialPortInfo,
     StopBits,
     register_uri_handler,
 )
@@ -354,29 +353,15 @@ class SocketSerialTransport(BaseSerialTransport):
         )
 
 
-def socket_list_serial_ports() -> list[SerialPortInfo]:
-    """List serial ports for sockets."""
-    return []
-
-
-async def async_socket_list_serial_ports() -> list[SerialPortInfo]:
-    """List serial ports for sockets, async."""
-    return []
-
-
 register_uri_handler(
     scheme="socket://",
     unique_scheme="socket://",
     sync_cls=SocketSerial,
     async_transport_cls=SocketSerialTransport,
-    list_serial_ports_func=socket_list_serial_ports,
-    async_list_serial_ports_func=async_socket_list_serial_ports,
 )
 register_uri_handler(
     scheme="tcp://",
     unique_scheme="tcp://",
     sync_cls=SocketSerial,
     async_transport_cls=SocketSerialTransport,
-    list_serial_ports_func=socket_list_serial_ports,
-    async_list_serial_ports_func=async_socket_list_serial_ports,
 )


### PR DESCRIPTION
The majority of platforms do not actually implement serial port listing. It's unnecessary verbosity to require them to provide an implementation of both functions that return a typed empty list.