### PR TITLE
Add a default connect timeout to async socket serial transport

### DIFF
--- a/serialx/platforms/serial_socket.py
+++ b/serialx/platforms/serial_socket.py
@@ -7,8 +7,14 @@ from collections.abc import Generator
 from contextlib import contextmanager
 import logging
 import socket
+import sys
 from typing import Any
 import urllib.parse
+
+if sys.version_info >= (3, 11):
+    from asyncio import timeout as asyncio_timeout
+else:
+    from async_timeout import timeout as asyncio_timeout
 
 from typing_extensions import Buffer
 
@@ -22,6 +28,7 @@ from serialx.common import (
 )
 
 LOGGER = logging.getLogger(__name__)
+DEFAULT_CONNECT_TIMEOUT = 10.0
 
 
 class SocketSerial(BaseSerial):
@@ -31,7 +38,7 @@ class SocketSerial(BaseSerial):
         self,
         *args: Any,
         # Socket-specific kwargs
-        connect_timeout: float | None = None,
+        connect_timeout: float | None = DEFAULT_CONNECT_TIMEOUT,
         **kwargs: Any,
     ) -> None:
         """Initialize socket serial port."""
@@ -217,6 +224,7 @@ class SocketSerialTransport(BaseSerialTransport):
         xonxoff: bool = False,
         rtscts: bool = False,
         byte_size: int = 8,
+        connect_timeout: float | None = DEFAULT_CONNECT_TIMEOUT,
         **kwargs: Any,
     ) -> None:
         self._serial = SocketSerial(
@@ -227,16 +235,18 @@ class SocketSerialTransport(BaseSerialTransport):
             xonxoff=xonxoff,
             rtscts=rtscts,
             byte_size=byte_size,
+            connect_timeout=connect_timeout,
         )
         self._extra["serial"] = self._serial
 
         self._tcp_connection_lost_waiter = self._loop.create_future()
 
-        tcp_transport, _ = await self._loop.create_connection(
-            lambda: _SocketProxyProtocol(self),
-            host=self._serial._host,
-            port=self._serial._port,
-        )
+        async with asyncio_timeout(self._serial._connect_timeout):
+            tcp_transport, _ = await self._loop.create_connection(
+                lambda: _SocketProxyProtocol(self),
+                host=self._serial._host,
+                port=self._serial._port,
+            )
         self._tcp_transport = tcp_transport
 
         if self._connection_lost_called:

--- a/tests/test_serial_socket.py
+++ b/tests/test_serial_socket.py
@@ -1,8 +1,10 @@
 """Socket serial port tests."""
 
+import asyncio
+
 import pytest
 
-from serialx import Serial
+from serialx import Serial, create_serial_connection
 from serialx.platforms.serial_socket import SocketSerial
 from tests.common import measure_time
 from tests.socket_relay import create_socket_pair
@@ -50,3 +52,20 @@ def test_socket_connect_timeout() -> None:
                 pass
 
     assert elapsed() < 1.0
+
+
+async def test_async_socket_connect_timeout() -> None:
+    """Test that connect_timeout is respected by SocketSerialTransport."""
+    url = "socket://192.0.2.1:1234"
+
+    with measure_time() as elapsed:
+        with pytest.raises((OSError, TimeoutError, asyncio.TimeoutError)):
+            await create_serial_connection(
+                asyncio.get_running_loop(),
+                asyncio.Protocol,
+                url=url,
+                baudrate=115200,
+                connect_timeout=0.2,
+            )
+
+    assert 0.2 <= elapsed() < 1.0


### PR DESCRIPTION
I've set the default timeout to 10s to match real-world usage. This technically is a breaking change but I don't think anybody is relying on OS-specific behavior for timeouts. If they are, passing `connect_timeout=None` restores it.