### PR TITLE
Include packages by default instead of excluding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ docs = [
 ]
 
 [tool.setuptools.packages.find]
-exclude = ["tests", "tests.*"]
+include = ["serialx", "serialx.*"]
 
 [tool.setuptools_scm]
 


### PR DESCRIPTION
We erroneously included `docs` as a submodule in the most recent couple of releases. `src` has been in there for a while too.

Instead of excluding folders, we instead just include the one module we expect to export.

---

The wheel itself has the expected folder structure now:

```
     serialx/__init__.py
     serialx/_serialx_rust.abi3.so
     serialx/async_serial.py
     serialx/common.py
     serialx/compat.py
     serialx/descriptor_transport.py
     serialx/py.typed
     serialx/serial.py
     serialx/serialutil.py
     serialx/platforms/__init__.py
     serialx/platforms/serial_darwin.py
     serialx/platforms/serial_esphome.py
     serialx/platforms/serial_extended_posix.py
     serialx/platforms/serial_freebsd.py
     serialx/platforms/serial_linux.py
     serialx/platforms/serial_posix.py
     serialx/platforms/serial_socket.py
     serialx/platforms/serial_win32.py
     serialx/platforms/serial_rfc2217/__init__.py
     serialx/platforms/serial_rfc2217/types.py
     serialx/tools/__init__.py
     serialx/tools/list_ports.py
     serialx/tools/list_ports_common.py
     serialx-1.4.1.dev1+g80949ea5c.dist-info/METADATA
     serialx-1.4.1.dev1+g80949ea5c.dist-info/WHEEL
     serialx-1.4.1.dev1+g80949ea5c.dist-info/top_level.txt
     serialx-1.4.1.dev1+g80949ea5c.dist-info/RECORD
```