### PR TITLE
Use public API for accessing aioesphomeapi client loop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ documentation = "https://puddly.github.io/serialx/"
 
 [project.optional-dependencies]
 esphome = [
-    "aioesphomeapi>=44.5.1; python_version >= '3.11'",
+    "aioesphomeapi>=44.17.0; python_version >= '3.11'",
 ]
 dev = [
     "ruff",
@@ -34,7 +34,7 @@ dev = [
     "pytest-timeout",
     "pytest-xdist",
     "psutil",
-    "aioesphomeapi>=44.6.0 ; python_version >= '3.11'",
+    "aioesphomeapi>=44.17.0 ; python_version >= '3.11'",
 ]
 docs = [
     "sphinx>=7,<8.2.3; python_version < '3.11'",

--- a/serialx/platforms/serial_esphome.py
+++ b/serialx/platforms/serial_esphome.py
@@ -169,7 +169,7 @@ class ESPHomeSerial(BaseSerial):
 
         self._api: APIClient | None = api
         self._client_loop: asyncio.AbstractEventLoop | None = (
-            api._loop if api is not None else None
+            api.loop if api is not None else None
         )
         self._port_name: str | None = port_name
         self._instance_id: int | None = port_instance
@@ -307,7 +307,7 @@ class ESPHomeSerial(BaseSerial):
                 password=self._password,
                 noise_psk=self._noise_psk,
             )
-            self._client_loop = self._api._loop
+            self._client_loop = self._api.loop
 
             self._disconnect_api = True
             await self._call_on_client_loop(self._api.connect(login=True))


### PR DESCRIPTION
https://github.com/esphome/aioesphomeapi/pull/1598 has been merged so we can drop the internal `_loop` access.