### PR TITLE
Add a pyserial migration guide

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,7 @@ extensions = [
     "myst_parser",
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
+    "sphinx_design",
 ]
 
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]

--- a/docs/how-to/pyserial-migration.md
+++ b/docs/how-to/pyserial-migration.md
@@ -1,0 +1,127 @@
+# Migrating from pyserial
+
+This page covers the main differences to be aware of when porting pyserial code to serialx.
+
+## Packaging
+serialx is API-compatible with both pyserial (`serial`) and pyserial-asyncio (`serial_asyncio`) at the same time.
+You may be using a fork of pyserial-asyncio like pyserial-asyncio-fast. serialx replaces all three.
+
+::::{tab-set}
+
+:::{tab-item} requirements.txt
+```diff
+-pyserial
+-pyserial-asyncio
+-pyserial-asyncio-fast
++serialx
+```
+:::
+
+:::{tab-item} pyproject.toml
+```diff
+ dependencies = [
+-    "pyserial",
+-    "pyserial-asyncio",
+-    "pyserial-asyncio-fast",
++    "serialx",
+ ]
+```
+:::
+
+:::{tab-item} setup.py
+```diff
+ install_requires=[
+-    "pyserial",
+-    "pyserial-asyncio",
+-    "pyserial-asyncio-fast",
++    "serialx",
+ ],
+```
+:::
+
+::::
+
+## Sync migration
+serialx provides compatibility properties, methods, and kwargs for almost all pyserial APIs.
+Many are legacy methods and should be migrated to use modern names. All deprecated methods and properties
+are listed in the [main API documentation](../api.md). The most common ones ones are listed below:
+
+| Old Name                    | New Name                   | Notes                                        |
+| ---                         | ---                        | ---                                          |
+| `port`                      | `path`                     |                                              |
+| `portstr`                   | `path`                     |                                              |
+| `timeout`                   | `read_timeout`             |                                              |
+| `writeTimeout`              | `write_timeout`            |                                              |
+| `bytesize`                  | `byte_size`                |                                              |
+| `data_bits`                 | `byte_size`                |                                              |
+| `stop_bits`                 | `stopbits`                 | `stopbits` returns a `StopBits` enum         |
+| `in_waiting`                | `num_unread_bytes()`       | Now a method                                 |
+| `out_waiting`               | `num_unwritten_bytes()`    | Now a method                                 |
+| `inWaiting()`               | `num_unread_bytes()`       |                                              |
+| `isOpen()`                  | `is_open`                  | Now a property                               |
+| `flushInput()`              | `reset_read_buffer()`      |                                              |
+| `flushOutput()`             | `reset_write_buffer()`     |                                              |
+| `reset_input_buffer()`      | `reset_read_buffer()`      |                                              |
+| `reset_output_buffer()`     | `reset_write_buffer()`     |                                              |
+| `Serial(port=...)`          | `serial_for_url(url, ...)` | Constructor kwarg                            |
+| `Serial(timeout=...)`       | `read_timeout=...`         | Constructor kwarg                            |
+| `Serial(writeTimeout=...)`  | `write_timeout=...`        | Constructor kwarg                            |
+| `Serial(bytesize=...)`      | `byte_size=...`            | Constructor kwarg                            |
+| `Serial(do_not_open=False)` | —                          | Not supported; open explicitly via `open()`  |
+| `SerialPortInfo[i]`         | attribute access           | Slicing `SerialPortInfo` is deprecated       |
+| `SerialPortInfo.description`| `SerialPortInfo.product`   |                                              |
+
+### Connecting to a serial port
+Use `serialx.serial_for_url(url, ...)` instead of `serial.Serial(port, ...)`.
+
+`serial_for_url` automatically dispatches to native serial devices, `socket://`, `rfc2217://`, `esphome://`, all future platform handlers, allowing your code to work with serial ports of any type without any modification. `serial.Serial`, on the other hand, only connects to a single type of device. Its direct construction is deprecated.
+
+```python
+import serialx
+
+with serialx.serial_for_url("/dev/ttyUSB0", baudrate=115200) as serial:
+    serial.write(b"ping")
+```
+
+There is no equivalent for async code because the default `create_serial_connection` and `open_serial_connection` functions already transparently accept URIs.
+
+## Exceptions
+pyserial re-raises all errors as `serial.SerialException`, including OS-level failures and timeouts. serialx raises native exceptions directly so callers can handle them granularly:
+
+| Condition                    | pyserial                        | serialx                                   |
+| ---                          | ---                             | ---                                       |
+| Device missing               | `SerialException`               | `FileNotFoundError` or another `OSError`  |
+| I/O error                    | `SerialException`               | `OSError`                                 |
+| Protocol/backend failure     | `SerialException`               | `serialx.SerialException` (subclass)      |
+| Read/write timeout           | `SerialTimeoutException`        | `TimeoutError`                            |
+| Unsupported setting          | `ValueError` / `SerialException`| `serialx.UnsupportedSetting`              |
+| Unknown URL scheme           | —                               | `serialx.UnknownUriScheme`                |
+
+## Async migration
+Existing packages like pyserial-asyncio and pyserial-asyncio-fast have a straightforward public API: `create_serial_connection` and `open_serial_connection` allow you to interact with a `SerialTransport`. serialx has the same public API and exposes the same functions, just replace the imports.
+
+### Reading and writing modem pins
+If your async code accesses `transport.serial` to interact with modem pins, it is performing blocking IO on the event loop.
+
+:::{danger} ❌ Don't do blocking IO in the event loop
+```python
+transport.serial.dtr = True
+
+if transport.serial.cts:
+    ...
+```
+:::
+
+Instead, use the new async APIs to read and write pins:
+
+:::{tip} ✅ Use async APIs instead
+```python
+await transport.set_modem_pins(dtr=True, rts=False)
+
+pins = await transport.get_modem_pins()
+if pins.cts is serialx.PinState.HIGH:
+    ...
+```
+:::
+
+`set_modem_pins` accepts individual pin kwargs or a full `ModemPins` dataclass. Pins omitted from the call are left unchanged. `get_modem_pins` returns a `ModemPins` dataclass of `PinState` enum values, call `.to_bool()` on a pin for a `bool | None`.

--- a/docs/how-to/pyserial-migration.md
+++ b/docs/how-to/pyserial-migration.md
@@ -44,7 +44,7 @@ You may be using a fork of pyserial-asyncio like pyserial-asyncio-fast. serialx 
 ## Sync migration
 serialx provides compatibility properties, methods, and kwargs for almost all pyserial APIs.
 Many are legacy methods and should be migrated to use modern names. All deprecated methods and properties
-are listed in the [main API documentation](../api.md). The most common ones ones are listed below:
+are listed in the [main API documentation](../api.md). The most common ones are listed below:
 
 | Old Name                    | New Name                   | Notes                                        |
 | ---                         | ---                        | ---                                          |

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,7 @@ api
 
 how-to/esphome
 how-to/pyodide
+how-to/pyserial-migration
 ```
 
 ```{toctree}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,8 @@ docs = [
     "myst-parser>=4.0.1,<5; python_version < '3.11'",
     "myst-parser>=5; python_version >= '3.11'",
     "sphinx-design>=0.6",
-    "sphinx-autobuild>=2025.08.25",
+    "sphinx-autobuild>=2024.10.3; python_version < '3.11'",
+    "sphinx-autobuild>=2025.08.25; python_version >= '3.11'",
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,8 @@ docs = [
     "furo>=2025.7.19",
     "myst-parser>=4.0.1,<5; python_version < '3.11'",
     "myst-parser>=5; python_version >= '3.11'",
+    "sphinx-design>=0.6",
+    "sphinx-autobuild>=2025.08.25",
 ]
 
 [tool.setuptools.packages.find]

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -658,8 +658,9 @@ class BaseSerial(io.RawIOBase):
     def port(self) -> str | None:
         """Deprecated alias for `path`.
 
-        Warning: Deprecated
-            Use `path` instead.
+        Warning:
+            Deprecated, use `path` instead.
+
         """
         return str(self.path) if self.path is not None else None
 
@@ -667,8 +668,9 @@ class BaseSerial(io.RawIOBase):
     def portstr(self) -> str | None:
         """Deprecated alias for `path`.
 
-        Warning: Deprecated
-            Use `path` instead.
+        Warning:
+            Deprecated, use `path` instead.
+
         """
         return str(self.path) if self.path is not None else None
 
@@ -676,8 +678,9 @@ class BaseSerial(io.RawIOBase):
     def timeout(self) -> float | None:
         """Deprecated alias for `read_timeout`.
 
-        Warning: Deprecated
-            Use `read_timeout` instead.
+        Warning:
+            Deprecated, use `read_timeout` instead.
+
         """
         return self.read_timeout
 
@@ -689,8 +692,9 @@ class BaseSerial(io.RawIOBase):
     def bytesize(self) -> int:
         """Deprecated alias for `byte_size`.
 
-        Warning: Deprecated
-            Use `byte_size` instead.
+        Warning:
+            Deprecated, use `byte_size` instead.
+
         """
         return self.byte_size
 
@@ -698,8 +702,9 @@ class BaseSerial(io.RawIOBase):
     def data_bits(self) -> int:
         """Deprecated alias for `byte_size`.
 
-        Warning: Deprecated
-            Use `byte_size` instead.
+        Warning:
+            Deprecated, use `byte_size` instead.
+
         """
         return self.byte_size
 
@@ -712,8 +717,9 @@ class BaseSerial(io.RawIOBase):
     def stop_bits(self) -> int | float:
         """Deprecated alias for `stopbits`.
 
-        Warning: Deprecated
-            Use `stopbits` instead.
+        Warning:
+            Deprecated, use `stopbits` instead.
+
         """
         return cast(int | float, self._stopbits.value)
 
@@ -726,40 +732,45 @@ class BaseSerial(io.RawIOBase):
     def writeTimeout(self) -> float | None:
         """Deprecated alias for `write_timeout`.
 
-        Warning: Deprecated
-            Use `write_timeout` instead.
+        Warning:
+            Deprecated, use `write_timeout` instead.
+
         """
         return self.write_timeout
 
     def reset_input_buffer(self) -> None:
         """Reset the read buffer.
 
-        Warning: Deprecated
-            Use `reset_read_buffer` instead.
+        Warning:
+            Deprecated, use `reset_read_buffer` instead.
+
         """
         self.reset_read_buffer()
 
     def reset_output_buffer(self) -> None:
         """Reset the write buffer.
 
-        Warning: Deprecated
-            Use `reset_write_buffer` instead.
+        Warning:
+            Deprecated, use `reset_write_buffer` instead.
+
         """
         self.reset_write_buffer()
 
     def flushInput(self) -> None:
         """Reset the read buffer.
 
-        Warning: Deprecated
-            Use `reset_read_buffer` instead.
+        Warning:
+            Deprecated, use `reset_read_buffer` instead.
+
         """
         self.reset_read_buffer()
 
     def flushOutput(self) -> None:
         """Reset the write buffer.
 
-        Warning: Deprecated
-            Use `reset_write_buffer` instead.
+        Warning:
+            Deprecated, use `reset_write_buffer` instead.
+
         """
         self.reset_write_buffer()
 
@@ -767,8 +778,9 @@ class BaseSerial(io.RawIOBase):
     def in_waiting(self) -> int:
         """Deprecated alias for `num_unread_bytes`.
 
-        Warning: Deprecated
-            Use `num_unread_bytes` instead.
+        Warning:
+            Deprecated, use `num_unread_bytes` instead.
+
         """
         return self.num_unread_bytes()
 
@@ -776,8 +788,9 @@ class BaseSerial(io.RawIOBase):
     def out_waiting(self) -> int:
         """Deprecated alias for `num_unwritten_bytes`.
 
-        Warning: Deprecated
-            Use `num_unwritten_bytes` instead.
+        Warning:
+            Deprecated, use `num_unwritten_bytes` instead.
+
         """
         return self.num_unwritten_bytes()
 
@@ -785,16 +798,18 @@ class BaseSerial(io.RawIOBase):
     def inWaiting(self) -> int:
         """Deprecated alias for `num_unread_bytes`.
 
-        Warning: Deprecated
-            Use `num_unread_bytes` instead.
+        Warning:
+            Deprecated, use `num_unread_bytes` instead.
+
         """
         return self.in_waiting
 
     def isOpen(self) -> bool:
         """Return whether the serial port is open.
 
-        Warning: Deprecated
-            Use `is_open` instead.
+        Warning:
+            Deprecated, use `is_open` instead.
+
         """
         return self.is_open
 
@@ -1052,8 +1067,9 @@ class SerialPortInfo:
     def description(self) -> str | None:
         """Deprecated alias for `product`.
 
-        Warning: Deprecated
-            Use `product` instead.
+        Warning:
+            Deprecated, use `product` instead.
+
         """
         warnings.warn(
             "`description` is deprecated, use `product` instead",


### PR DESCRIPTION
A small guide to cover 99% of migration cases. If you're not subclassing anything and just use public APIs, this will be more than enough to migrate an existing project.