### PR TITLE
Make Parity a string enum

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,3 @@
-ci:
-  autofix_commit_msg: "Apply pre-commit auto fixes"
-  autoupdate_commit_msg: "Auto-update pre-commit hooks"
-  skip: [mypy]
-
 repos:
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 
 [tool.mypy]
+python_version = "3.10"
 strict = true
 check_untyped_defs = true
 show_error_codes = true

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 from collections.abc import Awaitable, Callable, Iterator
 from contextlib import contextmanager
 import dataclasses
-from enum import Enum
+from enum import Enum, StrEnum
 import functools
 import io
 from pathlib import Path
@@ -184,14 +184,14 @@ class StopBits(Enum):
     TWO = 2
 
 
-class Parity(Enum):
+class Parity(StrEnum):
     """Parity configuration."""
 
-    NONE = None
-    ODD = 1
-    EVEN = 2
-    MARK = 3
-    SPACE = 4
+    NONE = "N"
+    ODD = "O"
+    EVEN = "E"
+    MARK = "M"
+    SPACE = "S"
 
 
 class PinState(Enum):
@@ -300,7 +300,7 @@ class BaseSerial(io.RawIOBase):
         path: str | Path | None = None,
         baudrate: int = 9600,
         *,
-        parity: Parity | None = Parity.NONE,
+        parity: Parity | str | None = Parity.NONE,
         stopbits: StopBits | int | float = StopBits.ONE,
         xonxoff: bool = False,
         rtscts: bool = False,
@@ -327,7 +327,9 @@ class BaseSerial(io.RawIOBase):
         if not isinstance(stopbits, StopBits):
             stopbits = StopBits(stopbits)
 
-        if not isinstance(parity, Parity):
+        if parity is None:
+            parity = Parity.NONE
+        elif not isinstance(parity, Parity):
             parity = Parity(parity)
 
         self._path = path

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 from collections.abc import Awaitable, Callable, Iterator
 from contextlib import contextmanager
 import dataclasses
-from enum import Enum, StrEnum
+from enum import Enum
 import functools
 import io
 from pathlib import Path
@@ -184,7 +184,7 @@ class StopBits(Enum):
     TWO = 2
 
 
-class Parity(StrEnum):
+class Parity(str, Enum):
     """Parity configuration."""
 
     NONE = "N"

--- a/tests/test_pyserial_compat.py
+++ b/tests/test_pyserial_compat.py
@@ -11,7 +11,7 @@ if sys.platform == "emscripten":
         allow_module_level=True,
     )
 
-from serialx import Serial, SerialPortInfo
+from serialx import Parity, Serial, SerialPortInfo
 from serialx.tools.list_ports import comports, grep
 from serialx.tools.list_ports_common import ListPortInfo
 from tests.common import SerialPair
@@ -80,6 +80,12 @@ def test_compat_timeout_setter(serial_pair: SerialPair) -> None:
 
         s.timeout = 0.5
         assert s.read_timeout == 0.5
+
+
+def test_compat_parity_none(serial_pair: SerialPair) -> None:
+    """Test that `parity=None` is accepted and maps to `Parity.NONE`."""
+    with Serial.from_url(serial_pair.left, baudrate=115200, parity=None) as s:
+        assert s.parity is Parity.NONE
 
 
 def test_compat_baudrate_setter(serial_pair: SerialPair) -> None:


### PR DESCRIPTION
For better compatibility with pyserial, I've made `Parity` a string enum matching the existing constants.