### PR TITLE
Partially implement `flush` for RFC2217

### DIFF
--- a/serialx/platforms/serial_rfc2217/__init__.py
+++ b/serialx/platforms/serial_rfc2217/__init__.py
@@ -52,7 +52,6 @@ from .types import (
     SetModemstateMaskCmd,
     SetParityCmd,
     SetStopsizeCmd,
-    SignatureCmd,
     TelnetCmdId,
     TelnetCommand,
     TelnetOption,
@@ -671,7 +670,7 @@ class RFC2217Serial(SocketSerial):
             return
 
         # RFC2217 has no flush. Instead, we "flush" the pipe with a req/rsp sequence.
-        self._send_and_wait(SignatureCmd())
+        self._send_and_wait(SetBaudrateCmd(baudrate=self._baudrate))
 
 
 class _RFC2217ProxyProtocol(asyncio.Protocol):
@@ -1019,7 +1018,7 @@ class RFC2217SerialTransport(BaseSerialTransport):
             return
 
         # RFC2217 has no flush. Instead, we "flush" the pipe with a req/rsp sequence.
-        await self._send_and_wait(SignatureCmd())
+        await self._send_and_wait(SetBaudrateCmd(baudrate=self._serial._baudrate))
 
     def get_write_buffer_size(self) -> int:
         """Get the number of bytes currently in the write buffer."""

--- a/serialx/platforms/serial_rfc2217/__init__.py
+++ b/serialx/platforms/serial_rfc2217/__init__.py
@@ -52,6 +52,7 @@ from .types import (
     SetModemstateMaskCmd,
     SetParityCmd,
     SetStopsizeCmd,
+    SignatureCmd,
     TelnetCmdId,
     TelnetCommand,
     TelnetOption,
@@ -665,7 +666,12 @@ class RFC2217Serial(SocketSerial):
         return self._engine.get_modem_pins()
 
     def _flush(self) -> None:
-        """Flush write buffers (no-op, TCP handles buffering)."""
+        """Wait for the server to acknowledge all preceding writes."""
+        if not self._engine.negotiated:
+            return
+
+        # RFC2217 has no flush. Instead, we "flush" the pipe with a req/rsp sequence.
+        self._send_and_wait(SignatureCmd())
 
 
 class _RFC2217ProxyProtocol(asyncio.Protocol):
@@ -1007,7 +1013,13 @@ class RFC2217SerialTransport(BaseSerialTransport):
             self._tcp_connection_lost(None)
 
     async def flush(self) -> None:
-        """Flush write buffers (no-op, TCP transport handles buffering)."""
+        """Wait for the server to acknowledge all preceding writes."""
+        assert self._serial is not None
+        if not self._serial._engine.negotiated:
+            return
+
+        # RFC2217 has no flush. Instead, we "flush" the pipe with a req/rsp sequence.
+        await self._send_and_wait(SignatureCmd())
 
     def get_write_buffer_size(self) -> int:
         """Get the number of bytes currently in the write buffer."""

--- a/tests/test_sync_transports.py
+++ b/tests/test_sync_transports.py
@@ -869,6 +869,11 @@ def test_fast_open_close(serial_pair: SerialPair) -> None:
     with Serial.from_url(serial_pair.left, baudrate=115200) as left:
         with Serial.from_url(serial_pair.right, baudrate=115200) as right:
             right.write(message)
+            right.flush()
+
+            # Some backends (notably complex chained RFC2217) lose data on close, making
+            # this test flaky without a tiny delay
+            time.sleep(0.01)
 
         assert left.readexactly(len(message)) == message
 


### PR DESCRIPTION
RFC2217 doesn't have a way to "flush". We instead "flush" the TCP socket by sending a no-op request and receiving a response.

`test_fast_open_close` as a test relies on behavior that not all backends technically have: enqueuing data to send and then closing the port only works on some backends.