### PR TITLE
Don't run `no-commit-to-branch` check for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,8 @@ jobs:
           path: ~/.cache/prek
           key: ${{ steps.cache-prek.outputs.cache-primary-key }}
       - name: Lint and static analysis
+        env:
+          SKIP: no-commit-to-branch
         run: |
           . venv/bin/activate
           prek run --show-diff-on-failure --color=always --all-files


### PR DESCRIPTION
Merging PRs causes CI failures because the check runs even when we _want_ to merge to `dev`: https://github.com/puddly/serialx/actions/runs/25325510481