### PR TITLE
Move warning for missing Rust extension into function body

### DIFF
--- a/serialx/serialx_rust.py
+++ b/serialx/serialx_rust.py
@@ -15,11 +15,12 @@ __all__ = ["list_serial_ports_impl"]
 try:
     from serialx._serialx_rust import list_serial_ports_impl
 except ImportError:
-    LOGGER.warning(
-        "serialx Rust extension failed to load; serial port enumeration will "
-        "not be available"
-    )
 
     def list_serial_ports_impl() -> list[RustSerialPortInfo]:
         """Return an empty list when the Rust extension is unavailable."""
+        LOGGER.warning(
+            "serialx Rust extension failed to load; serial port enumeration will "
+            "not be available"
+        )
+
         return []


### PR DESCRIPTION
I've noticed the warning logs a bit more often than necessary. We currently do not rely on the Rust module for anything other than listing serial ports so this can be made into a loud runtime warning.