### PR TITLE
Drop runtime `termios2` NCCS detection

### DIFF
--- a/serialx/platforms/serial_linux.py
+++ b/serialx/platforms/serial_linux.py
@@ -42,24 +42,22 @@ CBAUDEX = getattr(termios, "CBAUDEX", 0o00010000)
 NON_POSIX_FALLBACK_BAUDRATE = 115200
 NON_POSIX_FALLBACK_BAUDRATE_CONST = termios.B115200
 
+# `NCCS` is 19 on every Linux architecture and the `struct termios2` layout has been
+# stable since 2007
+NCCS = 19
 
-class TermiosStruct(ctypes.Structure):
-    """The `termios` struct."""
 
+class Termios2Struct(ctypes.Structure):
+    """The `termios2` struct."""
+
+    _pack_ = 1
     _fields_ = (
         ("c_iflag", ctypes.c_uint32),
         ("c_oflag", ctypes.c_uint32),
         ("c_cflag", ctypes.c_uint32),
         ("c_lflag", ctypes.c_uint32),
         ("c_line", ctypes.c_uint8),
-        ("c_cc", ctypes.c_uint8 * 64),  # NCCS is usually 19 bytes, let's be safe
-    )
-
-
-class Termios2SpeedStruct(ctypes.Structure):
-    """The extra `c_ispeed` and `c_ospeed` members at the end of `struct termios2`."""
-
-    _fields_ = (
+        ("c_cc", ctypes.c_uint8 * NCCS),
         ("c_ispeed", ctypes.c_uint32),
         ("c_ospeed", ctypes.c_uint32),
     )
@@ -82,43 +80,24 @@ class LinuxSerial(ExtendedPosixSerial):
         """Set the baudrate of the serial port, must be called after `tcsetattr`."""
         assert self._fileno is not None
 
-        # The termios2 struct is going to be smaller than the sum of these two objects
-        buffer = bytearray(
-            ctypes.sizeof(TermiosStruct) + ctypes.sizeof(Termios2SpeedStruct)
-        )
+        buffer = bytearray(ctypes.sizeof(Termios2Struct))
         fcntl.ioctl(self._fileno, TCGETS2, buffer)
 
+        termios2 = Termios2Struct.from_buffer(buffer)
+
+        # Sanity check that our struct layout matches the kernel's
+        if termios2.c_ispeed == 0 or termios2.c_ospeed == 0:
+            raise RuntimeError(f"termios2 speed fields are zero: {buffer.hex()}")
+
         # The POSIX baudrates are stored in the lower bits of `c_cflag`. We clear them.
-        termios_struct = TermiosStruct.from_buffer(buffer)
-        termios_struct.c_cflag &= ~CBAUD
-        termios_struct.c_cflag |= CBAUDEX
+        termios2.c_cflag &= ~CBAUD
+        termios2.c_cflag |= CBAUDEX
 
-        # `termios2` extends `termios` with two extra fields. The problem is that these
-        # fields appear *after* the `c_cc` array, which has a length defined by `NCCS`,
-        # a constant that we do not have access to. We overcome this by searching for
-        # the speed fields directly, since we set them to a known value earlier.
-        try:
-            temp_speed_buffer = bytearray(ctypes.sizeof(Termios2SpeedStruct))
-            temp_speed_struct = Termios2SpeedStruct.from_buffer(temp_speed_buffer)
-            temp_speed_struct.c_ispeed = NON_POSIX_FALLBACK_BAUDRATE
-            temp_speed_struct.c_ospeed = NON_POSIX_FALLBACK_BAUDRATE
+        termios2.c_ispeed = baudrate
+        termios2.c_ospeed = baudrate
 
-            offset = buffer.index(temp_speed_buffer)
-        except ValueError as exc:
-            raise RuntimeError(
-                f"Could not determine offset of termios2 speed fields: {buffer.hex()}"
-            ) from exc
-
-        termios2_speed_struct = Termios2SpeedStruct.from_buffer(buffer, offset)
-        termios2_speed_struct.c_ispeed = baudrate
-        termios2_speed_struct.c_ospeed = baudrate
-
-        # The ctypes structures mutate the buffer in place
-        LOGGER.debug(
-            "Writing termios2 struct (c_ispeed offset %d bytes): %r",
-            offset,
-            buffer.hex(),
-        )
+        # The ctypes structure mutates the buffer in place
+        LOGGER.debug("Writing termios2 struct: %r", buffer.hex())
         fcntl.ioctl(self._fileno, TCSETS2, buffer)
 
     def _build_parity_flags(self) -> int:

--- a/serialx/platforms/serial_linux.py
+++ b/serialx/platforms/serial_linux.py
@@ -51,6 +51,7 @@ class Termios2Struct(ctypes.Structure):
     """The `termios2` struct."""
 
     _pack_ = 1
+    _layout_ = "ms"
     _fields_ = (
         ("c_iflag", ctypes.c_uint32),
         ("c_oflag", ctypes.c_uint32),

--- a/tests/test_serial_linux.py
+++ b/tests/test_serial_linux.py
@@ -13,11 +13,10 @@ import ctypes
 import errno
 import fcntl
 import os
+import termios
 import threading
 from typing import Any
 from unittest.mock import ANY, call, patch
-
-import pytest
 
 from serialx.platforms.serial_linux import (
     CBAUD,
@@ -52,29 +51,25 @@ def _make_ioctl_mock(initial_buffer: bytes, captured_writes: list[bytes]) -> Any
 
 def test_set_non_posix_baudrate_handles_actual_hardware_rate() -> None:
     """Regression for issue #83: cp210x writes back the actual hardware rate."""
-    captured: list[bytes] = []
 
+    # `struct termios2` after `tcsetattr(B115200)` on a typical Linux pty, but with
+    # c_ispeed/c_ospeed reporting the cp210x actual hardware rate (115384) instead of
+    # the requested 115200.
+    initial = Termios2Struct(
+        c_cflag=(
+            termios.CS8 | termios.CREAD | termios.HUPCL | termios.CLOCAL | CBAUDEX
+        ),
+        c_ispeed=115384,
+        c_ospeed=115384,
+    )
+    initial_buffer = bytes(initial)
+
+    captured: list[bytes] = []
     with create_socat_pair() as (left, _right):
         with LinuxSerial(left, baudrate=115200) as serial:
             with patch(
                 "serialx.platforms.serial_linux.fcntl.ioctl",
-                side_effect=_make_ioctl_mock(
-                    # `struct termios2` after `tcsetattr(B115200)` on a typical Linux
-                    # pty, but with c_ispeed/c_ospeed reporting the cp210x actual
-                    # hardware rate (115384) instead of the requested 115200. See
-                    # issue #83.
-                    bytes.fromhex(
-                        "00000000"
-                        "00000000"
-                        "b01c0000"
-                        "00000000"
-                        "00"
-                        "031c7f150400000011131a00120f1716000000"
-                        "b8c20100"
-                        "b8c20100"
-                    ),
-                    captured,
-                ),
+                side_effect=_make_ioctl_mock(initial_buffer, captured),
             ):
                 serial._set_non_posix_baudrate(250000)
 

--- a/tests/test_serial_linux.py
+++ b/tests/test_serial_linux.py
@@ -9,6 +9,7 @@ if sys.platform != "linux":
 
 import asyncio
 import contextlib
+import ctypes
 import errno
 import fcntl
 import os
@@ -16,11 +17,92 @@ import threading
 from typing import Any
 from unittest.mock import ANY, call, patch
 
-from serialx.platforms.serial_linux import LinuxSerial, LinuxSerialTransport
+import pytest
+
+from serialx.platforms.serial_linux import (
+    CBAUD,
+    CBAUDEX,
+    TCGETS2,
+    TCSETS2,
+    LinuxSerial,
+    LinuxSerialTransport,
+    Termios2Struct,
+)
 from tests.common import async_create_socat_pair, create_socat_pair
 
 TIOCSSERIAL = 0x0000541F
 TIOCGSERIAL = 0x0000541E
+
+
+def _make_ioctl_mock(initial_buffer: bytes, captured_writes: list[bytes]) -> Any:
+    """Build an ioctl side_effect that fakes TCGETS2 and captures TCSETS2."""
+    ioctl_orig = fcntl.ioctl
+
+    def ioctl(fd: int, request: int, arg: Any = 0, mutate_flag: bool = True) -> Any:
+        if request == TCGETS2:
+            arg[: len(initial_buffer)] = initial_buffer
+            return 0
+        if request == TCSETS2:
+            captured_writes.append(bytes(arg))
+            return 0
+        return ioctl_orig(fd, request, arg, mutate_flag)
+
+    return ioctl
+
+
+def test_set_non_posix_baudrate_handles_actual_hardware_rate() -> None:
+    """Regression for issue #83: cp210x writes back the actual hardware rate."""
+    captured: list[bytes] = []
+
+    with create_socat_pair() as (left, _right):
+        with LinuxSerial(left, baudrate=115200) as serial:
+            with patch(
+                "serialx.platforms.serial_linux.fcntl.ioctl",
+                side_effect=_make_ioctl_mock(
+                    # `struct termios2` after `tcsetattr(B115200)` on a typical Linux
+                    # pty, but with c_ispeed/c_ospeed reporting the cp210x actual
+                    # hardware rate (115384) instead of the requested 115200. See
+                    # issue #83.
+                    bytes.fromhex(
+                        "00000000"
+                        "00000000"
+                        "b01c0000"
+                        "00000000"
+                        "00"
+                        "031c7f150400000011131a00120f1716000000"
+                        "b8c20100"
+                        "b8c20100"
+                    ),
+                    captured,
+                ),
+            ):
+                serial._set_non_posix_baudrate(250000)
+
+    assert len(captured) == 1
+    written = Termios2Struct.from_buffer_copy(captured[0])
+    assert written.c_ispeed == 250000
+    assert written.c_ospeed == 250000
+    assert written.c_cflag & CBAUDEX
+    assert written.c_cflag & CBAUD == 0
+
+
+def test_set_non_posix_baudrate_zero_speed_raises() -> None:
+    """A zero-filled readback indicates the struct layout is wrong."""
+    zeros = bytes(ctypes.sizeof(Termios2Struct))
+    captured: list[bytes] = []
+
+    with create_socat_pair() as (left, _right):
+        with LinuxSerial(left, baudrate=115200) as serial:
+            with patch(
+                "serialx.platforms.serial_linux.fcntl.ioctl",
+                side_effect=_make_ioctl_mock(zeros, captured),
+            ):
+                with pytest.raises(
+                    RuntimeError, match="termios2 speed fields are zero"
+                ):
+                    serial._set_non_posix_baudrate(250000)
+
+    assert captured == []
 
 
 @patch("serialx.platforms.serial_linux.TIOCGSERIAL", TIOCGSERIAL)

--- a/tests/test_serial_linux.py
+++ b/tests/test_serial_linux.py
@@ -82,8 +82,8 @@ def test_set_non_posix_baudrate_handles_actual_hardware_rate() -> None:
     written = Termios2Struct.from_buffer_copy(captured[0])
     assert written.c_ispeed == 250000
     assert written.c_ospeed == 250000
-    assert written.c_cflag & CBAUDEX
-    assert written.c_cflag & CBAUD == 0
+    # CBAUDEX should be the only CBAUD bit set, signalling "use ispeed/ospeed"
+    assert written.c_cflag & CBAUD == CBAUDEX
 
 
 def test_set_non_posix_baudrate_zero_speed_raises() -> None:


### PR DESCRIPTION
When using a non-POSIX baudrate, we end up checking `c_ispeed` and `c_ospeed` to validate some struct offsets. On the CP2102N, the Linux driver replaces these with the "real" baudrates and breaks our assumption that the set baudrate can be read back again. We didn't run into this in the past (despite testing on tons of CP2102N devices...) because this is only triggered when setting a non-POSIX baudrate.

This breaks our runtime detection of the `NCCS` constant. Realistically, this value hasn't changed in almost two decades and we don't really need to perform the runtime detection to begin with. My original assumption to future-proof lead to more issues than benefits 😄.

I've swapped back to hardcoding `NCCS = 19` and have confirmed the fix on a CP2102N.

---

Fixes #83.