### PR TITLE
Treat `read()` returning no bytes as a permanent failure

### DIFF
--- a/serialx/common.py
+++ b/serialx/common.py
@@ -1008,20 +1008,17 @@ class BaseSerialTransport(asyncio.Transport):
     async def get_modem_pins(self) -> ModemPins:
         """Get modem control bits."""
         self._check_broken()
-        assert self._serial is not None
-        return await self._loop.run_in_executor(None, self._serial.get_modem_pins)
+        return await self._get_modem_pins()
 
+    @abstractmethod
+    async def _get_modem_pins(self) -> ModemPins:
+        """Get modem control bits, internal."""
+        raise NotImplementedError
+
+    @abstractmethod
     async def _set_modem_pins(self, modem_pins: ModemPins) -> None:
         """Set modem control bits, internal."""
-        self._check_broken()
-        await self._loop.run_in_executor(
-            None,
-            lambda: (
-                self._serial._set_modem_pins(modem_pins)
-                if self._serial is not None
-                else None
-            ),
-        )
+        raise NotImplementedError
 
     async def set_modem_pins(
         self,

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -405,9 +405,8 @@ class BaseSerial(io.RawIOBase):
     def open(self) -> None:
         """Open the serial port."""
         self._broken = None
-        self._open()
-
         try:
+            self._open()
             self._configure_port()
         except BaseException:
             self.close()

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -382,6 +382,17 @@ class BaseSerial(io.RawIOBase):
 
         self._wrap_exceptions = _wrap_exceptions
 
+        # Enter a "broken" state so that an error condition can persist
+        self._broken: OSError | None = None
+
+    def _mark_broken(self, exc: OSError) -> None:
+        if self._broken is None:
+            self._broken = exc
+
+    def _check_broken(self) -> None:
+        if self._broken is not None:
+            raise self._broken
+
     @classmethod
     def from_url(cls, url: str, *args: Any, **kwargs: Any) -> BaseSerial:
         """Create the appropriate serial port subclass for the given URL."""
@@ -393,6 +404,7 @@ class BaseSerial(io.RawIOBase):
     @maybe_wrap_exceptions
     def open(self) -> None:
         """Open the serial port."""
+        self._broken = None
         self._open()
 
         try:
@@ -436,8 +448,10 @@ class BaseSerial(io.RawIOBase):
         """Get the write timeout in seconds."""
         return self._write_timeout
 
+    @maybe_wrap_exceptions
     def get_modem_pins(self) -> ModemPins:
         """Get modem control bits."""
+        self._check_broken()
         return self._get_modem_pins()
 
     @maybe_wrap_exceptions
@@ -456,6 +470,8 @@ class BaseSerial(io.RawIOBase):
         dsr: PinState | bool | None = PinState.UNDEFINED,
     ) -> None:
         """Set modem control bits."""
+        self._check_broken()
+
         if modem_pins is None:
             modem_pins = ModemPins(
                 le=PinState.convert(le),
@@ -484,6 +500,7 @@ class BaseSerial(io.RawIOBase):
     @maybe_wrap_exceptions
     def readinto(self, b: Buffer, *, timeout: float | None = None) -> int:
         """Read bytes from serial port into buffer."""
+        self._check_broken()
         timeout = self._read_timeout if timeout is None else timeout
         return self._readinto(b, timeout=timeout)
 
@@ -495,6 +512,7 @@ class BaseSerial(io.RawIOBase):
     @maybe_wrap_exceptions
     def write(self, data: Buffer, *, timeout: float | None = None) -> int:
         """Write bytes to serial port."""
+        self._check_broken()
         timeout = self._write_timeout if timeout is None else timeout
         return self._write(data, timeout=timeout)
 
@@ -879,6 +897,14 @@ class BaseSerialTransport(asyncio.Transport):
         self._closing: bool = False
         self._closed_waiter: asyncio.Future[None] = loop.create_future()
 
+    def _mark_broken(self, exc: OSError) -> None:
+        if self._serial is not None:
+            self._serial._mark_broken(exc)
+
+    def _check_broken(self) -> None:
+        if self._serial is not None:
+            self._serial._check_broken()
+
     def is_closing(self) -> bool:
         """Return whether the transport is closing."""
         return self._closing
@@ -981,11 +1007,13 @@ class BaseSerialTransport(asyncio.Transport):
 
     async def get_modem_pins(self) -> ModemPins:
         """Get modem control bits."""
+        self._check_broken()
         assert self._serial is not None
         return await self._loop.run_in_executor(None, self._serial.get_modem_pins)
 
     async def _set_modem_pins(self, modem_pins: ModemPins) -> None:
         """Set modem control bits, internal."""
+        self._check_broken()
         await self._loop.run_in_executor(
             None,
             lambda: (
@@ -1010,6 +1038,8 @@ class BaseSerialTransport(asyncio.Transport):
         dsr: PinState | bool | None = PinState.UNDEFINED,
     ) -> None:
         """Set modem control bits."""
+        self._check_broken()
+
         if modem_pins is None:
             modem_pins = ModemPins(
                 le=PinState.convert(le),

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -1054,6 +1054,12 @@ class BaseSerialTransport(asyncio.Transport):
 
     async def flush(self) -> None:
         """Flush write buffers, waiting until all data is written."""
+        self._check_broken()
+        await self._flush()
+
+    @abstractmethod
+    async def _flush(self) -> None:
+        """Flush write buffers, waiting until all data is written, internal."""
         raise NotImplementedError
 
     async def wait_closed(self) -> None:

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -383,9 +383,9 @@ class BaseSerial(io.RawIOBase):
         self._wrap_exceptions = _wrap_exceptions
 
         # Enter a "broken" state so that an error condition can persist
-        self._broken: OSError | None = None
+        self._broken: Exception | None = None
 
-    def _mark_broken(self, exc: OSError) -> None:
+    def _mark_broken(self, exc: Exception) -> None:
         if self._broken is None:
             self._broken = exc
 
@@ -897,7 +897,7 @@ class BaseSerialTransport(asyncio.Transport):
         self._closing: bool = False
         self._closed_waiter: asyncio.Future[None] = loop.create_future()
 
-    def _mark_broken(self, exc: OSError) -> None:
+    def _mark_broken(self, exc: Exception) -> None:
         if self._serial is not None:
             self._serial._mark_broken(exc)
 

--- a/serialx/descriptor_transport.py
+++ b/serialx/descriptor_transport.py
@@ -136,11 +136,14 @@ class DescriptorTransport(BaseSerialTransport):
             if data:
                 self._protocol.data_received(data)
             else:
-                LOGGER.info("%r was closed by peer", self)
-                self._closing = True
-                self._loop.remove_reader(self._fileno)
-                self._loop.call_soon(self._protocol.eof_received)
-                self._maybe_background_close(None)
+                # Linux's hung_up_tty_read returns 0 (drivers/tty/tty_io.c); surface
+                # this as -EIO to match what write/ioctl already get from the kernel,
+                # so consumers don't busy-loop on b''.
+                disconnect = OSError(
+                    errno.EIO, "device disconnected or in use by another process"
+                )
+                self._mark_broken(disconnect)
+                self._close(disconnect)
 
     def pause_reading(self) -> None:
         """Pause reading from the file descriptor."""

--- a/serialx/platforms/serial_esphome.py
+++ b/serialx/platforms/serial_esphome.py
@@ -691,8 +691,8 @@ class ESPHomeSerialTransport(BaseSerialTransport):
         finally:
             self._call_protocol_connection_lost(None)
 
-    async def flush(self) -> None:
-        """Flush write buffers."""
+    async def _flush(self) -> None:
+        """Flush write buffers, waiting until all data is written, internal."""
         assert self._serial is not None
         await self._serial._async_flush()
 

--- a/serialx/platforms/serial_esphome.py
+++ b/serialx/platforms/serial_esphome.py
@@ -696,10 +696,15 @@ class ESPHomeSerialTransport(BaseSerialTransport):
         assert self._serial is not None
         await self._serial._async_flush()
 
-    async def get_modem_pins(self) -> ModemPins:
-        """Get modem control bits."""
+    async def _get_modem_pins(self) -> ModemPins:
+        """Get modem control bits, internal."""
         assert self._serial is not None
         return await self._serial._async_get_modem_pins()
+
+    async def _set_modem_pins(self, modem_pins: ModemPins) -> None:
+        """Set modem control bits, internal."""
+        assert self._serial is not None
+        await self._serial._async_set_modem_pins(modem_pins)
 
     def get_write_buffer_size(self) -> int:
         """Get the number of bytes currently in the write buffer."""

--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -525,8 +525,8 @@ class PosixSerialTransport(DescriptorTransport):
 
         self._protocol.connection_made(self)
 
-    async def flush(self) -> None:
-        """Flush write buffers, waiting until all data is written."""
+    async def _flush(self) -> None:
+        """Flush write buffers, waiting until all data is written, internal."""
         assert self._serial is not None
 
         try:

--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -539,6 +539,16 @@ class PosixSerialTransport(DescriptorTransport):
         finally:
             self._reset_empty_waiter()
 
+    async def _get_modem_pins(self) -> ModemPins:
+        """Get modem control bits, internal."""
+        assert self._serial is not None
+        return await self._loop.run_in_executor(None, self._serial.get_modem_pins)
+
+    async def _set_modem_pins(self, modem_pins: ModemPins) -> None:
+        """Set modem control bits, internal."""
+        assert self._serial is not None
+        await self._loop.run_in_executor(None, self._serial._set_modem_pins, modem_pins)
+
 
 register_uri_handler(
     scheme="device://",

--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -405,6 +405,14 @@ class PosixSerial(BaseSerial):
             n = os.readinto(self._fileno, b)
             LOGGER.debug("Read %d bytes", n)
 
+            if n == 0:
+                self._mark_broken(
+                    OSError(
+                        errno.EIO, "device disconnected or in use by another process"
+                    )
+                )
+                self._check_broken()
+
             return n
 
     else:
@@ -427,6 +435,14 @@ class PosixSerial(BaseSerial):
             n = len(chunk)
             m[:n] = chunk
             LOGGER.debug("Read %d bytes: %r", n, chunk)
+
+            if n == 0:
+                self._mark_broken(
+                    OSError(
+                        errno.EIO, "device disconnected or in use by another process"
+                    )
+                )
+                self._check_broken()
 
             return n
 

--- a/serialx/platforms/serial_pyodide/__init__.py
+++ b/serialx/platforms/serial_pyodide/__init__.py
@@ -282,8 +282,8 @@ class PyodideSerialTransport(BaseSerialTransport):
             assert self._protocol is not None
             self._protocol.data_received(bytes(result.value))
 
-    async def get_modem_pins(self) -> ModemPins:
-        """Get modem control bits."""
+    async def _get_modem_pins(self) -> ModemPins:
+        """Get modem control bits, internal."""
         assert self._js_port is not None
         result = await self._js_port.getSignals()
 

--- a/serialx/platforms/serial_pyodide/__init__.py
+++ b/serialx/platforms/serial_pyodide/__init__.py
@@ -315,8 +315,8 @@ class PyodideSerialTransport(BaseSerialTransport):
         """Return the number of bytes currently queued for writing."""
         return self._write_buffer_size
 
-    async def flush(self) -> None:
-        """Flush write buffers, waiting until all data is written."""
+    async def _flush(self) -> None:
+        """Flush write buffers, waiting until all data is written, internal."""
         await self._write_queue.join()
 
     def abort(self) -> None:

--- a/serialx/platforms/serial_rfc2217/__init__.py
+++ b/serialx/platforms/serial_rfc2217/__init__.py
@@ -968,19 +968,19 @@ class RFC2217SerialTransport(BaseSerialTransport):
         self._closing = True
         self._tcp_transport = None
 
-        self._mark_broken(OSError(errno.EIO, "RFC 2217 connection closed by server"))
+        if exc is None:
+            exc = OSError(errno.EIO, "RFC 2217 connection closed by server")
+        self._mark_broken(exc)
 
         # Fail any pending waiters
-        waiter_exc = exc or SerialException("RFC 2217 connection closed by server")
-
         for _expected, telnet_waiter in self._telnet_waiters:
             if not telnet_waiter.done():
-                telnet_waiter.set_exception(waiter_exc)
+                telnet_waiter.set_exception(exc)
         self._telnet_waiters.clear()
 
         for rfc2217_waiter in self._rfc2217_waiters.values():
             if not rfc2217_waiter.done():
-                rfc2217_waiter.set_exception(waiter_exc)
+                rfc2217_waiter.set_exception(exc)
         self._rfc2217_waiters.clear()
 
         if self._serial is not None:

--- a/serialx/platforms/serial_rfc2217/__init__.py
+++ b/serialx/platforms/serial_rfc2217/__init__.py
@@ -6,6 +6,7 @@ import asyncio
 from collections.abc import Generator
 from contextlib import suppress
 from enum import IntEnum
+import errno
 import logging
 import sys
 
@@ -537,7 +538,10 @@ class RFC2217Serial(SocketSerial):
         n = self._socket.recv_into(buf)
 
         if n == 0:
-            raise SerialException("RFC 2217 connection closed by server")
+            self._mark_broken(
+                OSError(errno.EIO, "RFC 2217 connection closed by server")
+            )
+            self._check_broken()
 
         raw = bytes(buf[:n])
         LOGGER.debug("RX raw: %d bytes  [%s]", n, raw.hex(" "))
@@ -963,6 +967,8 @@ class RFC2217SerialTransport(BaseSerialTransport):
         self._connection_lost_called = True
         self._closing = True
         self._tcp_transport = None
+
+        self._mark_broken(OSError(errno.EIO, "RFC 2217 connection closed by server"))
 
         # Fail any pending waiters
         waiter_exc = exc or SerialException("RFC 2217 connection closed by server")

--- a/serialx/platforms/serial_rfc2217/__init__.py
+++ b/serialx/platforms/serial_rfc2217/__init__.py
@@ -909,12 +909,13 @@ class RFC2217SerialTransport(BaseSerialTransport):
 
     def write(self, data: bytes | bytearray | memoryview) -> None:
         """Write data to the serial port, escaping IAC bytes."""
-        assert self._tcp_transport is not None
+        if self._tcp_transport is None:
+            return
         escaped = iac_escape(bytes(data))
         LOGGER.debug("TX data: %d bytes (%d on wire)", len(data), len(escaped))
         self._tcp_transport.write(escaped)
 
-    async def get_modem_pins(self) -> ModemPins:
+    async def _get_modem_pins(self) -> ModemPins:
         """Return modem pin state from the last NOTIFY-MODEMSTATE."""
         assert self._serial is not None
         return self._serial._engine.get_modem_pins()

--- a/serialx/platforms/serial_rfc2217/__init__.py
+++ b/serialx/platforms/serial_rfc2217/__init__.py
@@ -1024,8 +1024,8 @@ class RFC2217SerialTransport(BaseSerialTransport):
         else:
             self._tcp_connection_lost(None)
 
-    async def flush(self) -> None:
-        """Wait for the server to acknowledge all preceding writes."""
+    async def _flush(self) -> None:
+        """Flush write buffers, waiting until all data is written, internal."""
         assert self._serial is not None
         if not self._serial._engine.negotiated:
             return

--- a/serialx/platforms/serial_rfc2217/__init__.py
+++ b/serialx/platforms/serial_rfc2217/__init__.py
@@ -637,7 +637,10 @@ class RFC2217Serial(SocketSerial):
                 timeout -= get_elapsed()
 
             if n == 0:
-                return 0
+                self._mark_broken(
+                    OSError(errno.EIO, "RFC 2217 connection closed by server")
+                )
+                self._check_broken()
 
             raw = bytes(buf[:n])
             LOGGER.debug("RX raw (readinto): %d bytes  [%s]", n, raw.hex(" "))

--- a/serialx/platforms/serial_socket.py
+++ b/serialx/platforms/serial_socket.py
@@ -343,6 +343,13 @@ class SocketSerialTransport(BaseSerialTransport):
     async def flush(self) -> None:
         """Flush write buffers (no-op, TCP transport handles buffering)."""
 
+    async def _get_modem_pins(self) -> ModemPins:
+        """Get modem control bits, internal."""
+        return ModemPins()
+
+    async def _set_modem_pins(self, modem_pins: ModemPins) -> None:
+        """Set modem control bits, internal."""
+
     def get_write_buffer_size(self) -> int:
         """Get the number of bytes currently in the write buffer."""
         if self._tcp_transport is not None:

--- a/serialx/platforms/serial_socket.py
+++ b/serialx/platforms/serial_socket.py
@@ -340,8 +340,8 @@ class SocketSerialTransport(BaseSerialTransport):
         else:
             self._connection_lost(None)
 
-    async def flush(self) -> None:
-        """Flush write buffers (no-op, TCP transport handles buffering)."""
+    async def _flush(self) -> None:
+        """Flush write buffers, waiting until all data is written, internal."""
 
     async def _get_modem_pins(self) -> ModemPins:
         """Get modem control bits, internal."""

--- a/serialx/platforms/serial_socket.py
+++ b/serialx/platforms/serial_socket.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Generator
 from contextlib import contextmanager
+import errno
 import logging
 import socket
 import sys
@@ -169,9 +170,15 @@ class SocketSerial(BaseSerial):
         m = memoryview(b).cast("B")
         try:
             with self._socket_timeout(timeout):
-                return self._socket.recv_into(m)
+                n = self._socket.recv_into(m)
         except TimeoutError:
             return 0
+
+        if n == 0:
+            self._mark_broken(OSError(errno.EIO, "socket closed by peer"))
+            self._check_broken()
+
+        return n
 
     def _close(self) -> None:
         """Close the socket."""
@@ -278,6 +285,9 @@ class SocketSerialTransport(BaseSerialTransport):
         self._connection_lost_called = True
         self._closing = True
         self._tcp_transport = None
+        if exc is None:
+            exc = OSError(errno.EIO, "socket closed by peer")
+        self._mark_broken(exc)
         self._call_protocol_connection_lost(exc)
 
     def _tcp_connection_lost(self) -> None:
@@ -290,7 +300,8 @@ class SocketSerialTransport(BaseSerialTransport):
 
     def write(self, data: bytes | bytearray | memoryview) -> None:
         """Write data to the socket."""
-        assert self._tcp_transport is not None
+        if self._tcp_transport is None:
+            return
         self._tcp_transport.write(data)
 
     def pause_reading(self) -> None:

--- a/serialx/platforms/serial_win32.py
+++ b/serialx/platforms/serial_win32.py
@@ -709,8 +709,8 @@ class Win32SerialTransport(BaseSerialTransport):
         if self._internal_transport is not None:
             self._internal_transport.set_protocol(protocol)
 
-    async def flush(self) -> None:
-        """Flush write buffers, waiting until all data is written."""
+    async def _flush(self) -> None:
+        """Flush write buffers, waiting until all data is written, internal."""
         assert self._serial is not None
         assert self._internal_transport is not None
         try:

--- a/serialx/platforms/serial_win32.py
+++ b/serialx/platforms/serial_win32.py
@@ -722,6 +722,16 @@ class Win32SerialTransport(BaseSerialTransport):
         finally:
             self._internal_transport._reset_empty_waiter()  # type:ignore[attr-defined]
 
+    async def _get_modem_pins(self) -> ModemPins:
+        """Get modem control bits, internal."""
+        assert self._serial is not None
+        return await self._loop.run_in_executor(None, self._serial.get_modem_pins)
+
+    async def _set_modem_pins(self, modem_pins: ModemPins) -> None:
+        """Set modem control bits, internal."""
+        assert self._serial is not None
+        await self._loop.run_in_executor(None, self._serial.set_modem_pins, modem_pins)
+
 
 def win32_list_serial_ports() -> list[SerialPortInfo]:
     """List available serial ports on Windows."""

--- a/tests/common.py
+++ b/tests/common.py
@@ -95,7 +95,6 @@ SERIAL_PAIR_DEFAULT_QUIRKS: dict[SerialBackend, frozenset[SerialQuirk]] = {
             SerialQuirk.NO_NUM_UNREAD_BYTES,
             SerialQuirk.NO_PAUSE_WRITING_CALLBACKS,
             SerialQuirk.NO_EXCLUSIVITY,
-            SerialQuirk.NO_UNPLUG,
         }
     ),
     SerialBackend.ESPHOME: frozenset(

--- a/tests/common.py
+++ b/tests/common.py
@@ -126,6 +126,7 @@ SERIAL_PAIR_DEFAULT_QUIRKS: dict[SerialBackend, frozenset[SerialQuirk]] = {
             SerialQuirk.NO_WRITE_TIMEOUT,
             SerialQuirk.NO_PAUSE_WRITING_CALLBACKS,
             SerialQuirk.NO_EXCLUSIVITY,
+            SerialQuirk.NO_UNPLUG,
         }
     ),
     SerialBackend.SER2NET: frozenset({}),
@@ -200,6 +201,9 @@ class SerialPair(UnresolvedSerialPair):
     original_right: str
 
     uri_scheme: str
+
+    unplug_left: Callable[[], None] | None = None
+    unplug_right: Callable[[], None] | None = None
 
 
 def _get_listening_ports(pid: int) -> list[int]:
@@ -352,7 +356,9 @@ def create_esphome_pair(
 
 
 @contextlib.contextmanager
-def create_socat_pair() -> Iterator[tuple[str, str]]:
+def create_socat_pair() -> Iterator[
+    tuple[str, str, Callable[[], None], Callable[[], None]]
+]:
     """Create a bridged pair of virtual PTYs using two socat processes.
 
     Each PTY is managed by its own socat process, linked via a UNIX socket.
@@ -402,8 +408,17 @@ def create_socat_pair() -> Iterator[tuple[str, str]]:
             name="socat(left)",
         )
 
+        def _kill(proc: subprocess.Popen[Any]) -> None:
+            proc.kill()
+            proc.wait()
+
         try:
-            yield (left_tty, right_tty)
+            yield (
+                left_tty,
+                right_tty,
+                lambda: _kill(left_proc),
+                lambda: _kill(right_proc),
+            )
         finally:
             for proc in (left_proc, right_proc):
                 if proc.returncode is None:

--- a/tests/common.py
+++ b/tests/common.py
@@ -426,6 +426,10 @@ def create_socat_pair() -> Iterator[
                     proc.terminate()
                     proc.wait()
 
+                # The unplug callables hold references to the Popen objects
+                if proc.stderr is not None:
+                    proc.stderr.close()
+
 
 @contextlib.contextmanager
 def create_pyodide_pair() -> Iterator[tuple[str, str]]:

--- a/tests/common.py
+++ b/tests/common.py
@@ -149,6 +149,7 @@ SERIAL_PAIR_DEFAULT_QUIRKS: dict[SerialBackend, frozenset[SerialQuirk]] = {
             SerialQuirk.NO_BUFFER_CONTROL,
             SerialQuirk.NO_WRITE_LIMITS,
             SerialQuirk.NO_EXCLUSIVITY,
+            SerialQuirk.NO_UNPLUG,
         }
     ),
 }

--- a/tests/common.py
+++ b/tests/common.py
@@ -18,6 +18,7 @@ import time
 from typing import IO, Any
 
 import psutil
+import pytest
 from typing_extensions import Self
 
 import serialx
@@ -203,6 +204,31 @@ class SerialPair(UnresolvedSerialPair):
 
     unplug_left: Callable[[], None] | None = None
     unplug_right: Callable[[], None] | None = None
+
+
+def _snapshot_fds() -> set[int]:
+    """Return the set of open fd numbers for this process."""
+    if sys.platform == "linux":
+        with contextlib.suppress(FileNotFoundError):
+            return {int(e) for e in os.listdir(f"/proc/{os.getpid()}/fd")}
+
+    proc = psutil.Process()
+    fds: set[int] = {f.fd for f in proc.open_files() if f.fd >= 0}
+    fds |= {c.fd for c in proc.net_connections(kind="all") if c.fd >= 0}
+    return fds
+
+
+@contextlib.contextmanager
+def check_fd_leaks() -> Iterator[None]:
+    """Fail if any file descriptor is opened in this block without being closed."""
+    before = _snapshot_fds()
+
+    try:
+        yield
+    finally:
+        leaked = _snapshot_fds() - before
+        if leaked:
+            pytest.fail(f"Leaked file descriptors: {sorted(leaked)}")
 
 
 def _get_listening_ports(pid: int) -> list[int]:

--- a/tests/common.py
+++ b/tests/common.py
@@ -125,7 +125,6 @@ SERIAL_PAIR_DEFAULT_QUIRKS: dict[SerialBackend, frozenset[SerialQuirk]] = {
             SerialQuirk.NO_WRITE_TIMEOUT,
             SerialQuirk.NO_PAUSE_WRITING_CALLBACKS,
             SerialQuirk.NO_EXCLUSIVITY,
-            SerialQuirk.NO_UNPLUG,
         }
     ),
     SerialBackend.SER2NET: frozenset({}),
@@ -483,7 +482,7 @@ async def async_create_socat_pair() -> AsyncIterator[tuple[str, str]]:
 @contextlib.contextmanager
 def create_ser2net_pair(
     left_adapter: str, right_adapter: str
-) -> Iterator[tuple[str, str]]:
+) -> Iterator[tuple[str, str, Callable[[], None], Callable[[], None]]]:
     """Create a pair of independent RFC2217 sockets using ser2net."""
 
     # fmt: off
@@ -513,6 +512,10 @@ def create_ser2net_pair(
     )
     # fmt: on
 
+    def _kill() -> None:
+        proc.kill()
+        proc.wait()
+
     try:
         _wait_for_ready(
             proc,
@@ -523,14 +526,21 @@ def create_ser2net_pair(
 
         left, right = _get_listening_ports(proc.pid)
 
+        # ser2net serves both adapters from one process
         yield (
             f"rfc2217://127.0.0.1:{left}",
             f"rfc2217://127.0.0.1:{right}",
+            _kill,
+            _kill,
         )
     finally:
         if proc.returncode is None:
             proc.terminate()
             proc.wait()
+        if proc.stdout is not None:
+            proc.stdout.close()
+        if proc.stderr is not None:
+            proc.stderr.close()
 
 
 @contextlib.contextmanager

--- a/tests/common.py
+++ b/tests/common.py
@@ -209,8 +209,10 @@ class SerialPair(UnresolvedSerialPair):
 def _snapshot_fds() -> set[int]:
     """Return the set of open fd numbers for this process."""
     if sys.platform == "linux":
-        with contextlib.suppress(FileNotFoundError):
-            return {int(e) for e in os.listdir(f"/proc/{os.getpid()}/fd")}
+        return {int(e) for e in os.listdir(f"/proc/{os.getpid()}/fd")}
+
+    if sys.platform == "emscripten":
+        return set()
 
     proc = psutil.Process()
     fds: set[int] = {f.fd for f in proc.open_files() if f.fd >= 0}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -283,7 +283,9 @@ def serial_pair(request: pytest.FixtureRequest) -> Generator[SerialPair]:
 
             case SerialBackend.SER2NET:
                 assert left is not None and right is not None
-                left, right = stack.enter_context(create_ser2net_pair(left, right))
+                left, right, unplug_left, unplug_right = stack.enter_context(
+                    create_ser2net_pair(left, right)
+                )
 
             case SerialBackend.HUB4COM:
                 assert left is not None and right is not None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -268,7 +268,9 @@ def serial_pair(request: pytest.FixtureRequest) -> Generator[SerialPair]:
 
             case SerialBackend.SOCKET:
                 assert left is None and right is None
-                left, right = stack.enter_context(create_socket_pair())
+                left, right, unplug_left, unplug_right = stack.enter_context(
+                    create_socket_pair()
+                )
 
             case SerialBackend.PYODIDE:
                 assert left is None and right is None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncGenerator, Generator
+from collections.abc import AsyncGenerator, Callable, Generator
 import contextlib
 import dataclasses
 import os
@@ -254,13 +254,17 @@ def serial_pair(request: pytest.FixtureRequest) -> Generator[SerialPair]:
     stack = contextlib.ExitStack()
     left = spec.left
     right = spec.right
+    unplug_left: Callable[[], None] | None = None
+    unplug_right: Callable[[], None] | None = None
 
     for backend in spec.backends[::-1]:
         match backend:
             # Synthetic backends don't have an underlying serial port
             case SerialBackend.SOCAT:
                 assert left is None and right is None
-                left, right = stack.enter_context(create_socat_pair())
+                left, right, unplug_left, unplug_right = stack.enter_context(
+                    create_socat_pair()
+                )
 
             case SerialBackend.SOCKET:
                 assert left is None and right is None
@@ -325,6 +329,8 @@ def serial_pair(request: pytest.FixtureRequest) -> Generator[SerialPair]:
             backends=spec.backends,
             quirks=spec.quirks,
             uri_scheme=effective_scheme,
+            unplug_left=unplug_left,
+            unplug_right=unplug_right,
         )
     finally:
         stack.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import AsyncGenerator, Callable, Generator
 import contextlib
 import dataclasses
-import os
 import sys
 import urllib.parse
 
@@ -22,6 +21,7 @@ from tests.common import (
     SerialPair,
     SerialQuirk,
     UnresolvedSerialPair,
+    check_fd_leaks,
     create_adapter_pair,
     create_esphome_pair,
     create_hub4com_pair,
@@ -340,35 +340,8 @@ def serial_pair(request: pytest.FixtureRequest) -> Generator[SerialPair]:
         stack.close()
 
 
-def _snapshot_fds() -> dict[int, str]:
-    """Return a mapping of open fd -> target path for this process."""
-    pid = os.getpid()
-    result = {}
-
-    try:
-        for entry in os.listdir(f"/proc/{pid}/fd"):
-            with contextlib.suppress(OSError):
-                result[int(entry)] = os.readlink(f"/proc/{pid}/fd/{entry}")
-    except FileNotFoundError:
-        pass
-
-    return result
-
-
 @pytest.fixture(autouse=True)
-async def check_fd_leaks(request: pytest.FixtureRequest) -> AsyncGenerator[None]:
-    """Detect leaked file descriptors between tests."""
-    if sys.platform != "linux":
+async def _check_fd_leaks_autouse() -> AsyncGenerator[None]:
+    """Run every test inside `check_fd_leaks` to catch unintended fd leaks."""
+    with check_fd_leaks():
         yield
-        return
-
-    before = _snapshot_fds()
-
-    try:
-        yield
-    finally:
-        after = _snapshot_fds()
-
-        leaked = {fd: path for fd, path in after.items() if fd not in before}
-        if leaked:
-            pytest.fail(f"Leaked file descriptors: {leaked}")

--- a/tests/socket_relay.py
+++ b/tests/socket_relay.py
@@ -2,7 +2,7 @@
 
 # Async imports
 import asyncio
-from collections.abc import AsyncIterator, Iterator
+from collections.abc import AsyncIterator, Callable, Iterator
 import contextlib
 import logging
 import queue
@@ -188,6 +188,13 @@ class _SocketPairRelay:
         for relay_thread in self.relay_threads:
             relay_thread.start()
 
+    def disconnect_side(self, side: str) -> None:
+        with self.active_lock:
+            conn = self.active_connections[side]
+            self.active_connections[side] = None
+        if conn is not None:
+            self._close_socket(conn)
+
     def close(self) -> None:
         self.stop_event.set()
         self._close_socket(self.left_server)
@@ -237,12 +244,55 @@ def create_silent_server() -> Iterator[str]:
 
 
 @contextlib.contextmanager
-def create_socket_pair() -> Iterator[tuple[str, str]]:
+def create_accept_then_close_server() -> Iterator[str]:
+    """Create a TCP server that accepts and immediately closes each connection."""
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind(("127.0.0.1", 0))
+    server.listen(1)
+    server.settimeout(0.1)
+
+    stop = threading.Event()
+
+    def accept_loop() -> None:
+        while not stop.is_set():
+            try:
+                client, _ = server.accept()
+            except (TimeoutError, OSError):
+                continue
+            # Drain so close() produces FIN; with unread data macOS sends RST,
+            # which surfaces as ECONNRESET rather than the 0-byte recv we want.
+            client.settimeout(0.1)
+            with contextlib.suppress(OSError):
+                while client.recv(4096):
+                    pass
+            client.close()
+
+    thread = threading.Thread(target=accept_loop, daemon=True)
+    thread.start()
+
+    try:
+        yield f"127.0.0.1:{server.getsockname()[1]}"
+    finally:
+        stop.set()
+        server.close()
+        thread.join(timeout=1)
+
+
+@contextlib.contextmanager
+def create_socket_pair() -> Iterator[
+    tuple[str, str, Callable[[], None], Callable[[], None]]
+]:
     """Create two socket:// endpoints backed by a bidirectional relay."""
     relay = _SocketPairRelay()
     relay.start()
     try:
-        yield (relay.left_url, relay.right_url)
+        yield (
+            relay.left_url,
+            relay.right_url,
+            lambda: relay.disconnect_side("left"),
+            lambda: relay.disconnect_side("right"),
+        )
     finally:
         relay.close()
 

--- a/tests/test_async_transports.py
+++ b/tests/test_async_transports.py
@@ -1332,10 +1332,17 @@ async def test_async_unplug_raises_on_streamreader_readline(
 
     reader, writer = await open_serial_connection(serial_pair.left, baudrate=115200)
     try:
-        serial_pair.unplug_left()
+        async with serialx.async_serial_for_url(
+            serial_pair.right, baudrate=115200
+        ) as right:
+            right.write(b"ping\n")
+            await right.drain()
+            assert await reader.readline() == b"ping\n"
 
-        with pytest.raises(OSError):
-            await reader.readline()
+            serial_pair.unplug_left()
+
+            with pytest.raises(OSError):
+                await reader.readline()
     finally:
         writer.close()
         with contextlib.suppress(OSError):

--- a/tests/test_async_transports.py
+++ b/tests/test_async_transports.py
@@ -23,6 +23,7 @@ from serialx import (
     StopBits,
     create_serial_connection,
     get_serial_classes,
+    open_serial_connection,
 )
 from tests.common import (
     SerialBackend,
@@ -1292,3 +1293,50 @@ async def test_async_wait_closed_multiple_waiters_abort(
     await asyncio.wait_for(connection_lost_event.wait(), timeout=5.0)
     await asyncio.wait_for(asyncio.gather(wait_closed_1, wait_closed_2), timeout=5.0)
     assert transport.is_closing()
+
+
+@pytest.mark.skip_quirks(SerialQuirk.NO_UNPLUG)
+async def test_async_unplug_raises(serial_pair: SerialPair) -> None:
+    """Each operation on an unplugged port raises rather than silently EOFing."""
+    assert serial_pair.unplug_left is not None
+
+    async with async_create_serial_pair(
+        serial_pair.left, serial_pair.right, baudrate=115200
+    ) as (left, right):
+        right.write(b"ping\n")
+        await right.drain()
+        assert await left.readline() == b"ping\n"
+
+        serial_pair.unplug_left()
+
+        with pytest.raises(OSError):
+            await left.read(1)
+
+        with pytest.raises(OSError):
+            left.write(b"x")
+            await left.drain()
+
+        with pytest.raises(OSError):
+            await left.get_modem_pins()
+
+        with pytest.raises(OSError):
+            await left.set_modem_pins(rts=True)
+
+
+@pytest.mark.skip_quirks(SerialQuirk.NO_UNPLUG)
+async def test_async_unplug_raises_on_streamreader_readline(
+    serial_pair: SerialPair,
+) -> None:
+    """`reader.readline()` after unplug must raise, not silently return b''."""
+    assert serial_pair.unplug_left is not None
+
+    reader, writer = await open_serial_connection(serial_pair.left, baudrate=115200)
+    try:
+        serial_pair.unplug_left()
+
+        with pytest.raises(OSError):
+            await reader.readline()
+    finally:
+        writer.close()
+        with contextlib.suppress(OSError):
+            await writer.wait_closed()

--- a/tests/test_serial_esphome.py
+++ b/tests/test_serial_esphome.py
@@ -102,7 +102,7 @@ def base64(key: bytes) -> str:
 @pytest.mark.skipif(not ESPHOME_HOST_BINARY, reason="esphome host binary not available")
 async def test_externally_passed_api() -> None:
     """Test passing an ESPHome API instance externally."""
-    with create_socat_pair() as (socat_left, socat_right):
+    with create_socat_pair() as (socat_left, socat_right, _, _):
         with create_esphome_pair(socat_left, socat_right) as (left, _right):
             # Connect to the ESPHome API externally
             parsed = urllib.parse.urlparse(left)
@@ -131,7 +131,7 @@ async def test_externally_passed_api() -> None:
 @pytest.mark.skipif(not ESPHOME_HOST_BINARY, reason="esphome host binary not available")
 async def test_externally_passed_api_close_after_disconnect() -> None:
     """Test closing the transport after the API has been disconnected."""
-    with create_socat_pair() as (socat_left, socat_right):
+    with create_socat_pair() as (socat_left, socat_right, _, _):
         with create_esphome_pair(socat_left, socat_right) as (left, _right):
             parsed = urllib.parse.urlparse(left)
             api = APIClient(
@@ -159,7 +159,7 @@ async def test_externally_passed_api_close_after_disconnect() -> None:
 @pytest.mark.skipif(not ESPHOME_HOST_BINARY, reason="esphome host binary not available")
 async def test_connect_by_instance_id() -> None:
     """Test connecting to an ESPHome serial proxy by instance ID."""
-    with create_socat_pair() as (socat_left, socat_right):
+    with create_socat_pair() as (socat_left, socat_right, _, _):
         with create_esphome_pair(socat_left, socat_right) as (left, _right):
             parsed = urllib.parse.urlparse(left)
 
@@ -174,7 +174,7 @@ async def test_connect_by_instance_id() -> None:
 @pytest.mark.skipif(not ESPHOME_HOST_BINARY, reason="esphome host binary not available")
 async def test_connect_by_invalid_name() -> None:
     """Test that connecting with an invalid port name raises ValueError."""
-    with create_socat_pair() as (socat_left, socat_right):
+    with create_socat_pair() as (socat_left, socat_right, _, _):
         with create_esphome_pair(socat_left, socat_right) as (left, _right):
             parsed = urllib.parse.urlparse(left)
             url = f"esphome://{parsed.hostname}:{parsed.port}?port_name=Nonexistent"
@@ -187,7 +187,7 @@ async def test_connect_by_invalid_name() -> None:
 @pytest.mark.skipif(not ESPHOME_HOST_BINARY, reason="esphome host binary not available")
 async def test_connect_plaintext_to_encrypted_server() -> None:
     """Test that connecting without encryption to an encrypted server raises."""
-    with create_socat_pair() as (socat_left, socat_right):
+    with create_socat_pair() as (socat_left, socat_right, _, _):
         with create_esphome_pair(
             socat_left,
             socat_right,
@@ -206,7 +206,7 @@ async def test_connect_plaintext_to_encrypted_server() -> None:
 @pytest.mark.skipif(not ESPHOME_HOST_BINARY, reason="esphome host binary not available")
 async def test_connect_encrypted_plaintext_to_server() -> None:
     """Test that connecting with encryption to an unencrypted server raises."""
-    with create_socat_pair() as (socat_left, socat_right):
+    with create_socat_pair() as (socat_left, socat_right, _, _):
         with create_esphome_pair(
             socat_left,
             socat_right,
@@ -244,7 +244,7 @@ async def test_noise_psk_key_alias() -> None:
     """Test that connecting without encryption to an encrypted server raises."""
     key = base64(b"A noise PSK 32 bytes in length..")
 
-    with create_socat_pair() as (socat_left, socat_right):
+    with create_socat_pair() as (socat_left, socat_right, _, _):
         with create_esphome_pair(
             socat_left,
             socat_right,
@@ -317,7 +317,7 @@ async def test_esphome_list_serial_ports() -> None:
     assert list_serial_ports(Platform.ESPHOME) == []
     assert await async_list_serial_ports(Platform.ESPHOME) == []
 
-    with create_socat_pair() as (socat_left, socat_right):
+    with create_socat_pair() as (socat_left, socat_right, _, _):
         with create_esphome_pair(socat_left, socat_right) as (left, _right):
             parsed = urllib.parse.urlparse(left)
             api = APIClient(
@@ -334,7 +334,7 @@ async def test_esphome_list_serial_ports() -> None:
 @pytest.mark.skipif(not ESPHOME_HOST_BINARY, reason="esphome host binary not available")
 async def test_async_esphome_list_serial_ports_via_uri() -> None:
     """Test listing ESPHome serial ports asynchronously via a URI."""
-    with create_socat_pair() as (socat_left, socat_right):
+    with create_socat_pair() as (socat_left, socat_right, _, _):
         with create_esphome_pair(socat_left, socat_right) as (left, _right):
             parsed = urllib.parse.urlparse(left)
 
@@ -347,7 +347,7 @@ def test_sync_esphome_list_serial_ports_via_uri() -> None:
     """Test listing ESPHome serial ports synchronously via a URI."""
     assert list_serial_ports(Platform.ESPHOME) == []
 
-    with create_socat_pair() as (socat_left, socat_right):
+    with create_socat_pair() as (socat_left, socat_right, _, _):
         with create_esphome_pair(socat_left, socat_right) as (left, _right):
             parsed = urllib.parse.urlparse(left)
 
@@ -360,7 +360,7 @@ async def test_sync_esphome_list_serial_ports_external_api() -> None:
     """Test sync listing of ESPHome serial ports with an externally-passed API."""
     test_loop = asyncio.get_running_loop()
 
-    with create_socat_pair() as (socat_left, socat_right):
+    with create_socat_pair() as (socat_left, socat_right, _, _):
         with create_esphome_pair(socat_left, socat_right) as (left, _right):
             parsed = urllib.parse.urlparse(left)
             api = APIClient(
@@ -383,7 +383,7 @@ async def test_sync_esphome_list_serial_ports_external_api() -> None:
 @pytest.mark.skipif(not ESPHOME_HOST_BINARY, reason="esphome host binary not available")
 async def test_cross_loop_async_api() -> None:
     """Async API works with the `APIClient` on a separate loop."""
-    with create_socat_pair() as (socat_left, socat_right):
+    with create_socat_pair() as (socat_left, socat_right, _, _):
         with create_esphome_pair(socat_left, socat_right) as (left, right):
             async with async_serial_for_url(url=right, baudrate=115200) as ser_right:
                 async with cross_loop_async_serial(left) as ser_left:
@@ -408,7 +408,7 @@ async def test_cross_loop_async_api() -> None:
 @pytest.mark.skipif(not ESPHOME_HOST_BINARY, reason="esphome host binary not available")
 async def test_cross_loop_sync_modem_pins_on_loop_thread() -> None:
     """Sync modem-pin access from `self._loop`'s thread must not deadlock."""
-    with create_socat_pair() as (socat_left, socat_right):
+    with create_socat_pair() as (socat_left, socat_right, _, _):
         with create_esphome_pair(socat_left, socat_right) as (left, _right):
             async with cross_loop_async_serial(left) as serial:
                 esphome_serial = serial.transport.serial
@@ -427,7 +427,7 @@ async def test_cross_loop_sync_modem_pins_on_loop_thread() -> None:
 @pytest.mark.skipif(not ESPHOME_HOST_BINARY, reason="esphome host binary not available")
 async def test_sync_api_with_external_api_on_different_loop() -> None:
     """Sync API works when the `APIClient` lives on a different loop."""
-    with create_socat_pair() as (socat_left, socat_right):
+    with create_socat_pair() as (socat_left, socat_right, _, _):
         with create_esphome_pair(socat_left, socat_right) as (left, right):
             async with async_serial_for_url(url=right, baudrate=115200) as peer:
                 with api_client_on_thread_loop(left) as (api, api_loop):
@@ -461,7 +461,7 @@ async def test_sync_api_with_external_api_on_different_loop() -> None:
 @pytest.mark.skipif(not ESPHOME_HOST_BINARY, reason="esphome host binary not available")
 async def test_single_api_multiple_async_ports() -> None:
     """Two async transports sharing one APIClient operate independently."""
-    with create_socat_pair() as (socat_left, socat_right):
+    with create_socat_pair() as (socat_left, socat_right, _, _):
         with create_esphome_pair(socat_left, socat_right) as (left, _right):
             parsed = urllib.parse.urlparse(left)
             api = APIClient(
@@ -511,7 +511,7 @@ async def test_single_api_multiple_async_ports() -> None:
 @pytest.mark.skipif(not ESPHOME_HOST_BINARY, reason="esphome host binary not available")
 async def test_single_api_multiple_sync_ports() -> None:
     """Two sync ESPHomeSerials sharing one APIClient operate independently."""
-    with create_socat_pair() as (socat_left, socat_right):
+    with create_socat_pair() as (socat_left, socat_right, _, _):
         with create_esphome_pair(socat_left, socat_right) as (left, _right):
             with api_client_on_thread_loop(left) as (api, _api_loop):
                 with (

--- a/tests/test_serial_linux.py
+++ b/tests/test_serial_linux.py
@@ -65,7 +65,7 @@ def test_set_non_posix_baudrate_handles_actual_hardware_rate() -> None:
     initial_buffer = bytes(initial)
 
     captured: list[bytes] = []
-    with create_socat_pair() as (left, _right):
+    with create_socat_pair() as (left, _right, _, _):
         with LinuxSerial(left, baudrate=115200) as serial:
             with patch(
                 "serialx.platforms.serial_linux.fcntl.ioctl",
@@ -86,7 +86,7 @@ def test_set_non_posix_baudrate_zero_speed_raises() -> None:
     zeros = bytes(ctypes.sizeof(Termios2Struct))
     captured: list[bytes] = []
 
-    with create_socat_pair() as (left, _right):
+    with create_socat_pair() as (left, _right, _, _):
         with LinuxSerial(left, baudrate=115200) as serial:
             with patch(
                 "serialx.platforms.serial_linux.fcntl.ioctl",
@@ -115,7 +115,7 @@ def test_tiocgserial_ioctl_not_supported() -> None:
     with patch(
         "serialx.platforms.serial_linux.fcntl.ioctl", side_effect=ioctl
     ) as mock_ioctl:
-        with create_socat_pair() as (left, _right):
+        with create_socat_pair() as (left, _right, _, _):
             with LinuxSerial(left, baudrate=115200):
                 # The serial port still opens
                 pass
@@ -138,7 +138,7 @@ def test_tiocgserial_ioctl_unexpected() -> None:
     with patch(
         "serialx.platforms.serial_linux.fcntl.ioctl", side_effect=ioctl
     ) as mock_ioctl:
-        with create_socat_pair() as (left, _right):
+        with create_socat_pair() as (left, _right, _, _):
             with pytest.raises(OSError, match="Invalid argument"):
                 with LinuxSerial(left, baudrate=115200):
                     # The serial port will fail to open

--- a/tests/test_serial_rfc2217.py
+++ b/tests/test_serial_rfc2217.py
@@ -26,7 +26,7 @@ from serialx.platforms.serial_rfc2217.types import (
 )
 
 from .common import HUB4COM_BINARY, SerialBackend, SerialPair, create_hub4com_pair
-from .socket_relay import create_silent_server
+from .socket_relay import create_accept_then_close_server, create_silent_server
 
 
 def test_unknown_telnet_option() -> None:
@@ -102,6 +102,16 @@ async def test_async_negotiate_timeout_silent_server() -> None:
                 )
 
         assert 0.1 <= elapsed() < 1.0
+
+
+def test_sync_peer_close_during_negotiation_raises() -> None:
+    """Peer-side TCP close surfaces as OSError, not a silent 0-byte read."""
+    with create_accept_then_close_server() as addr:
+        with pytest.raises(OSError, match="RFC 2217 connection closed by server"):
+            with Serial.from_url(
+                f"rfc2217://{addr}", baudrate=115200, connect_timeout=2.0
+            ):
+                pass
 
 
 @pytest.mark.skipif(not HUB4COM_BINARY, reason="hub4com not available")

--- a/tests/test_serial_socket.py
+++ b/tests/test_serial_socket.py
@@ -29,7 +29,7 @@ def test_socket_connect_timeout_property() -> None:
 
 def test_socket_effective_timeout_mismatched() -> None:
     """Test that mismatched read/write timeouts use min for socket timeout."""
-    with create_socket_pair() as (left_url, _right_url):
+    with create_socket_pair() as (left_url, _right_url, _, _):
         serial = Serial.from_url(
             left_url, baudrate=115200, read_timeout=2.0, write_timeout=1.0
         )

--- a/tests/test_sync_transports.py
+++ b/tests/test_sync_transports.py
@@ -15,7 +15,13 @@ if sys.platform == "emscripten":
     )
 
 from serialx import ModemPins, Parity, PinState, Serial, StopBits, serial_for_url
-from tests.common import SerialBackend, SerialPair, SerialQuirk, measure_time
+from tests.common import (
+    SerialBackend,
+    SerialPair,
+    SerialQuirk,
+    check_fd_leaks,
+    measure_time,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -436,6 +442,17 @@ def test_sync_exclusive(serial_pair: SerialPair) -> None:
         with pytest.raises(OSError):
             with Serial.from_url(serial_pair.left, baudrate=115200, exclusive=True):
                 pass
+
+
+@pytest.mark.skip_quirks(SerialQuirk.NO_EXCLUSIVITY)
+def test_sync_exclusive_open_failure_does_not_leak(serial_pair: SerialPair) -> None:
+    """A failed exclusive open must not leak the fd it acquired before locking."""
+    with Serial.from_url(serial_pair.left, baudrate=115200, exclusive=True):
+        # We check explicitly to ensure the gc doesn't hide a leak
+        with check_fd_leaks():
+            blocked = Serial.from_url(serial_pair.left, baudrate=115200, exclusive=True)
+            with pytest.raises(OSError):
+                blocked.open()
 
 
 def test_sync_exclusive_disabled(serial_pair: SerialPair) -> None:

--- a/tests/test_sync_transports.py
+++ b/tests/test_sync_transports.py
@@ -1074,6 +1074,34 @@ def test_deassert_on_open_with_rtscts(
             assert left.get_modem_pins().cts is expected_state
 
 
+@pytest.mark.skip_quirks(SerialQuirk.NO_UNPLUG)
+def test_sync_unplug_raises(serial_pair: SerialPair) -> None:
+    """Each operation on an unplugged port raises rather than silently EOFing."""
+    assert serial_pair.unplug_left is not None
+
+    with (
+        Serial.from_url(serial_pair.left, baudrate=115200, timeout=2.0) as left,
+        Serial.from_url(serial_pair.right, baudrate=115200) as right,
+    ):
+        right.write(b"ping\n")
+        right.flush()
+        assert left.readline() == b"ping\n"
+
+        serial_pair.unplug_left()
+
+        with pytest.raises(OSError):
+            left.read(1)
+
+        with pytest.raises(OSError):
+            left.write(b"x")
+
+        with pytest.raises(OSError):
+            left.get_modem_pins()
+
+        with pytest.raises(OSError):
+            left.set_modem_pins(rts=True)
+
+
 @pytest.mark.skip_quirks(SerialQuirk.NO_RTS_CTS, SerialQuirk.NO_WRITE_TIMEOUT)
 def test_write_timeout_cts_held(serial_pair: SerialPair) -> None:
     """Test that write timeout fires when CTS is deasserted (flow control hold)."""


### PR DESCRIPTION
Serial ports on POSIX enter a strange state on device disconnect: `select` will return that `n` bytes can be read but `read(n)` returns no bytes. We should enter an instance-wide failure state if this is a case (not just on read) because writes and pin state changes should fail.

Related: https://github.com/home-assistant/core/issues/170257