### PR TITLE
Propagate failure state for `write` and `flush` on all platforms

### DIFF
--- a/serialx/common.py
+++ b/serialx/common.py
@@ -522,6 +522,7 @@ class BaseSerial(io.RawIOBase):
 
     def flush(self) -> None:
         """Flush write buffers."""
+        self._check_broken()
         self._flush()
 
     @abstractmethod

--- a/serialx/descriptor_transport.py
+++ b/serialx/descriptor_transport.py
@@ -252,6 +252,8 @@ class DescriptorTransport(BaseSerialTransport):
         assert isinstance(data, (bytes, bytearray, memoryview)), repr(data)
         LOGGER.debug("Immediately writing %r", data)
 
+        self._check_broken()
+
         if isinstance(data, bytearray):
             data = memoryview(data)
         if not data:

--- a/serialx/platforms/serial_rfc2217/__init__.py
+++ b/serialx/platforms/serial_rfc2217/__init__.py
@@ -909,8 +909,8 @@ class RFC2217SerialTransport(BaseSerialTransport):
 
     def write(self, data: bytes | bytearray | memoryview) -> None:
         """Write data to the serial port, escaping IAC bytes."""
-        if self._tcp_transport is None:
-            return
+        self._check_broken()
+        assert self._tcp_transport is not None
         escaped = iac_escape(bytes(data))
         LOGGER.debug("TX data: %d bytes (%d on wire)", len(data), len(escaped))
         self._tcp_transport.write(escaped)

--- a/serialx/platforms/serial_socket.py
+++ b/serialx/platforms/serial_socket.py
@@ -300,8 +300,8 @@ class SocketSerialTransport(BaseSerialTransport):
 
     def write(self, data: bytes | bytearray | memoryview) -> None:
         """Write data to the socket."""
-        if self._tcp_transport is None:
-            return
+        self._check_broken()
+        assert self._tcp_transport is not None
         self._tcp_transport.write(data)
 
     def pause_reading(self) -> None:

--- a/tests/test_async_transports.py
+++ b/tests/test_async_transports.py
@@ -1314,6 +1314,8 @@ async def test_async_unplug_raises(serial_pair: SerialPair) -> None:
 
         with pytest.raises(OSError):
             left.write(b"x")
+
+        with pytest.raises(OSError):
             await left.drain()
 
         with pytest.raises(OSError):

--- a/tests/test_sync_transports.py
+++ b/tests/test_sync_transports.py
@@ -1113,6 +1113,9 @@ def test_sync_unplug_raises(serial_pair: SerialPair) -> None:
             left.write(b"x")
 
         with pytest.raises(OSError):
+            left.flush()
+
+        with pytest.raises(OSError):
             left.get_modem_pins()
 
         with pytest.raises(OSError):


### PR DESCRIPTION
Fixes #88.

To align the network protocols with others, we should always raise an error when `write` and other methods (for both the sync and async APIs) are used after the connection is lost.