### PR TITLE
Make `write` async in the unified async API

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,7 @@ async def main():
         "/dev/serial/by-id/port", baudrate=115200,
     ) as serial:
         data = await serial.readexactly(5)
-        serial.write(b"test")
-        await serial.flush()
+        await serial.write(b"test")
 
         await serial.set_modem_pins(rts=True, dtr=True)
         pins = await serial.get_modem_pins()

--- a/docs/how-to/async-serial.md
+++ b/docs/how-to/async-serial.md
@@ -11,7 +11,7 @@ import serialx
 async with serialx.async_serial_for_url(
     "/dev/serial/by-id/port", baudrate=115200,
 ) as serial:
-    serial.write(b"ping")
+    await serial.write(b"ping")
     data = await serial.readexactly(4)
 ```
 
@@ -27,8 +27,7 @@ async with serialx.async_serial_for_url(
     async with asyncio.TaskGroup() as tg:
         async def ping() -> None:
             while True:
-                serial.write(b"ping")
-                await serial.flush()
+                await serial.write(b"ping")
                 await asyncio.sleep(1)
 
         tg.create_task(ping())
@@ -55,8 +54,8 @@ finally:
 ```
 
 ### Reading and writing
-Reads are coroutines, writes are synchronous (data is buffered and drained on
-demand):
+Reads and writes are coroutines. `write()` queues the data and waits until it
+has been handed to the OS, so write errors surface at the call site:
 
 ```python
 data = await serial.read(64)              # up to 64 bytes
@@ -64,9 +63,16 @@ chunk = await serial.readexactly(32)      # exactly 32 bytes
 line = await serial.readline()            # through the next \n
 header = await serial.readuntil(b"\r\n")  # through a custom delimiter
 
-serial.write(b"hello ")
-serial.write(b"world\n")
-await serial.flush()                      # wait until the data has been written
+await serial.write(b"hello ")
+await serial.write(b"world\n")
+```
+
+To batch several writes before yielding, use the `_nowait` variants and `drain()`:
+
+```python
+serial.write_nowait(b"hello ")
+serial.write_nowait(b"world\n")
+await serial.drain()
 ```
 
 ### Modem pins

--- a/docs/how-to/pyserial-migration.md
+++ b/docs/how-to/pyserial-migration.md
@@ -154,6 +154,6 @@ If you have existing sync code using `serial_for_url` and want to make it async,
 -    serial.write(b"ping")
 -    data = serial.readexactly(4)
 +async with serialx.async_serial_for_url("/dev/ttyUSB0", baudrate=115200) as serial:
-+    serial.write(b"ping")
++    await serial.write(b"ping")
 +    data = await serial.readexactly(4)
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -23,7 +23,7 @@ import serialx
 async with serialx.async_serial_for_url(
     "/dev/serial/by-id/port", baudrate=115200,
 ) as serial:
-    serial.write(b"ping")
+    await serial.write(b"ping")
     data = await serial.readexactly(4)
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -23,8 +23,7 @@ import serialx
 
 async with serialx.async_serial_for_url("/dev/serial/by-id/port", baudrate=115200) as serial:
     data = await serial.readexactly(5)
-    serial.write(b"test")
-    await serial.flush()
+    await serial.write(b"test")
 ```
 
 All functions, including `open` and `close`, are async and work exactly as they do with

--- a/serialx/async_serial.py
+++ b/serialx/async_serial.py
@@ -153,12 +153,24 @@ class AsyncSerial:
 
     # ---- Writes ----
 
-    def write(self, data: bytes | bytearray | memoryview) -> None:
-        """Queue data for writing."""
+    async def write(self, data: bytes | bytearray | memoryview) -> None:
+        """Queue data for writing and wait for the application buffer to drain."""
+        writer = self._require_writer()
+        writer.write(data)
+        await writer.drain()
+
+    async def writelines(self, data: Iterable[bytes | bytearray | memoryview]) -> None:
+        """Queue buffers for writing and wait for the application buffer to drain."""
+        writer = self._require_writer()
+        writer.writelines(data)
+        await writer.drain()
+
+    def write_nowait(self, data: bytes | bytearray | memoryview) -> None:
+        """Queue data for writing without waiting; pair with `drain()` to batch."""
         self._require_writer().write(data)
 
-    def writelines(self, data: Iterable[bytes | bytearray | memoryview]) -> None:
-        """Queue an iterable of buffers for writing."""
+    def writelines_nowait(self, data: Iterable[bytes | bytearray | memoryview]) -> None:
+        """Queue buffers for writing without waiting; pair with `drain()` to batch."""
         self._require_writer().writelines(data)
 
     async def drain(self) -> None:

--- a/tests/test_async_serial.py
+++ b/tests/test_async_serial.py
@@ -3,7 +3,7 @@
 import pytest
 
 from serialx import SerialException, async_serial_for_url
-from tests.common import SerialPair
+from tests.common import SerialPair, async_create_serial_pair
 
 
 async def test_unopened_state() -> None:
@@ -96,3 +96,29 @@ async def test_read_when_unopened_raises() -> None:
 
     with pytest.raises(SerialException, match="not open"):
         serial.write_nowait(b"x")
+
+    with pytest.raises(SerialException, match="not open"):
+        await serial.writelines([b"x"])
+
+    with pytest.raises(SerialException, match="not open"):
+        serial.writelines_nowait([b"x"])
+
+
+async def test_write_then_close_preserves_data(serial_pair: SerialPair) -> None:
+    """`await write` drains before returning so close() doesn't lose bytes."""
+    async with async_create_serial_pair(
+        serial_pair.left, serial_pair.right, baudrate=115200
+    ) as (left, right):
+        await left.write(b"hello world")
+        await left.close()
+        assert await right.readexactly(11) == b"hello world"
+
+
+async def test_writelines_then_close_preserves_data(serial_pair: SerialPair) -> None:
+    """`await writelines` drains before returning so close() doesn't lose bytes."""
+    async with async_create_serial_pair(
+        serial_pair.left, serial_pair.right, baudrate=115200
+    ) as (left, right):
+        await left.writelines([b"foo", b"bar", b"baz"])
+        await left.close()
+        assert await right.readexactly(9) == b"foobarbaz"

--- a/tests/test_async_serial.py
+++ b/tests/test_async_serial.py
@@ -79,7 +79,7 @@ async def test_abort(serial_pair: SerialPair) -> None:
     """abort() drops pending writes and triggers close immediately."""
     serial = async_serial_for_url(serial_pair.left, baudrate=115200)
     await serial.open()
-    serial.write(b"this may be dropped")
+    serial.write_nowait(b"this may be dropped")
     serial.abort()
     await serial.wait_closed()
     assert serial.is_open is False
@@ -92,4 +92,7 @@ async def test_read_when_unopened_raises() -> None:
         await serial.read(1)
 
     with pytest.raises(SerialException, match="not open"):
-        serial.write(b"x")
+        await serial.write(b"x")
+
+    with pytest.raises(SerialException, match="not open"):
+        serial.write_nowait(b"x")

--- a/tests/test_async_transports.py
+++ b/tests/test_async_transports.py
@@ -44,7 +44,7 @@ async def test_async_all_bytes(serial_pair: SerialPair) -> None:
         serial_pair.left, serial_pair.right, baudrate=115200
     ) as (left, right):
         data = bytes(range(256))
-        left.write(data)
+        left.write_nowait(data)
         result = await right.readexactly(len(data))
         assert result == data
 
@@ -59,7 +59,7 @@ async def test_async_segmented_binary_data(serial_pair: SerialPair) -> None:
 
         for i in range(0, 256, segment_size):
             segment = data[i : i + segment_size]
-            left.write(segment)
+            left.write_nowait(segment)
             result = await right.readexactly(len(segment))
             assert result == segment
 
@@ -71,7 +71,7 @@ async def test_async_binary_payload_sizes(serial_pair: SerialPair, size: int) ->
         serial_pair.left, serial_pair.right, baudrate=115200
     ) as (left, right):
         data = bytes([i % 256 for i in range(size)])
-        left.write(data)
+        left.write_nowait(data)
         result = await right.readexactly(len(data))
         assert result == data
 
@@ -82,7 +82,7 @@ async def test_async_null_bytes(serial_pair: SerialPair) -> None:
         serial_pair.left, serial_pair.right, baudrate=115200
     ) as (left, right):
         null_data = b"\x00" * 64
-        left.write(null_data)
+        left.write_nowait(null_data)
         result = await right.readexactly(len(null_data))
         assert result == null_data
 
@@ -92,7 +92,7 @@ async def test_async_readuntil(serial_pair: SerialPair) -> None:
     async with async_create_serial_pair(
         serial_pair.left, serial_pair.right, baudrate=115200
     ) as (left, right):
-        left.write(b"hello\nworld\n")
+        left.write_nowait(b"hello\nworld\n")
         assert await right.readuntil() == b"hello\n"
         assert await right.readuntil(b"\n") == b"world\n"
 
@@ -102,7 +102,7 @@ async def test_async_readuntil_custom_separator(serial_pair: SerialPair) -> None
     async with async_create_serial_pair(
         serial_pair.left, serial_pair.right, baudrate=115200
     ) as (left, right):
-        left.write(b"first||second||tail")
+        left.write_nowait(b"first||second||tail")
         assert await right.readuntil(b"||") == b"first||"
         assert await right.readuntil(b"||") == b"second||"
 
@@ -112,7 +112,7 @@ async def test_async_readuntil_repeated_separator(serial_pair: SerialPair) -> No
     async with async_create_serial_pair(
         serial_pair.left, serial_pair.right, baudrate=115200
     ) as (left, right):
-        left.write(b"foo|||||bar||tail||")
+        left.write_nowait(b"foo|||||bar||tail||")
         assert await right.readuntil(b"||") == b"foo||"
         assert await right.readuntil(b"||") == b"||"
         assert await right.readuntil(b"||") == b"|bar||"
@@ -124,7 +124,7 @@ async def test_async_readline(serial_pair: SerialPair) -> None:
     async with async_create_serial_pair(
         serial_pair.left, serial_pair.right, baudrate=115200
     ) as (left, right):
-        left.write(b"alpha\nbeta\ngamma\n")
+        left.write_nowait(b"alpha\nbeta\ngamma\n")
         assert await right.readline() == b"alpha\n"
         assert await right.readline() == b"beta\n"
         assert await right.readline() == b"gamma\n"
@@ -135,7 +135,7 @@ async def test_async_writelines(serial_pair: SerialPair) -> None:
     async with async_create_serial_pair(
         serial_pair.left, serial_pair.right, baudrate=115200
     ) as (left, right):
-        left.writelines([b"foo", b"bar", b"baz"])
+        left.writelines_nowait([b"foo", b"bar", b"baz"])
         assert await right.readexactly(9) == b"foobarbaz"
 
 
@@ -147,11 +147,11 @@ async def test_async_overlapping_read_write(serial_pair: SerialPair) -> None:
         data = bytes(range(256))
         read = b""
 
-        left.write(data[:100])
+        left.write_nowait(data[:100])
         read += await right.readexactly(10)
-        left.write(data[100:150])
+        left.write_nowait(data[100:150])
         read += await right.readexactly(10)
-        left.write(data[150:])
+        left.write_nowait(data[150:])
         read += await right.readexactly(10)
         read += await right.readexactly(256 - 30)
 
@@ -190,7 +190,7 @@ async def test_async_random_large(
         serial_pair.left, serial_pair.right, baudrate=baudrate
     ) as (left, right):
         data = os.urandom(chunk_size)
-        left.write(data)
+        left.write_nowait(data)
         read_data = await right.readexactly(chunk_size)
         assert read_data == data
 
@@ -206,7 +206,7 @@ async def test_async_repeated_write_read_cycles(
         data = bytes(range(256))
 
         for _ in range(iterations):
-            left.write(data)
+            left.write_nowait(data)
             result = await right.readexactly(len(data))
             assert result == data
 
@@ -220,7 +220,7 @@ async def test_async_buffered_writes_then_read(serial_pair: SerialPair) -> None:
         iterations = 4
 
         for _ in range(iterations):
-            left.write(chunk)
+            left.write_nowait(chunk)
 
         total_size = len(chunk) * iterations
         result = await right.readexactly(total_size)
@@ -241,7 +241,7 @@ async def test_async_large_payload(serial_pair: SerialPair, payload_size: int) -
         serial_pair.left, serial_pair.right, baudrate=921600
     ) as (left, right):
         data = bytes([i % 256 for i in range(payload_size)])
-        left.write(data)
+        left.write_nowait(data)
         result = await right.readexactly(len(data))
         assert result == data
 
@@ -256,7 +256,7 @@ async def test_async_rapid_small_writes(serial_pair: SerialPair) -> None:
 
         for i in range(iterations):
             data = bytes([i % 256])
-            left.write(data)
+            left.write_nowait(data)
             result = await right.readexactly(1)
             received.extend(result)
 
@@ -284,7 +284,7 @@ async def test_async_sustained_throughput(
     ) as (left, right):
         chunk = os.urandom(1024)
         for _ in range(iterations):
-            left.write(chunk)
+            left.write_nowait(chunk)
             result = await right.readexactly(len(chunk))
             assert result == chunk
 
@@ -311,7 +311,7 @@ async def test_async_valid_baudrates(serial_pair: SerialPair, baudrate: int) -> 
         serial_pair.left, baudrate=baudrate
     ) as left:
         assert left.baudrate == baudrate
-        left.write(b"test")
+        left.write_nowait(b"test")
 
 
 async def test_async_nonstandard_baudrate(serial_pair: SerialPair) -> None:
@@ -326,7 +326,7 @@ async def test_async_nonstandard_baudrate(serial_pair: SerialPair) -> None:
         serial_pair.left, serial_pair.right, baudrate=200000
     ) as (left, right):
         assert left.baudrate == 200000
-        left.write(b"test")
+        left.write_nowait(b"test")
         assert await right.readexactly(4) == b"test"
 
 
@@ -354,7 +354,7 @@ async def test_async_valid_parity(serial_pair: SerialPair, parity: Parity) -> No
         serial_pair.left, baudrate=115200, parity=parity
     ) as left:
         assert left.parity == parity
-        left.write(b"test")
+        left.write_nowait(b"test")
 
 
 @pytest.mark.parametrize(
@@ -390,7 +390,7 @@ async def test_async_valid_stopbits(
         serial_pair.left, baudrate=115200, stopbits=stopbits
     ) as left:
         assert left.stopbits == expected
-        left.write(b"test")
+        left.write_nowait(b"test")
 
 
 @pytest.mark.parametrize("byte_size", [5, 6, 7, 8])
@@ -403,7 +403,7 @@ async def test_async_valid_byte_size(serial_pair: SerialPair, byte_size: int) ->
         serial_pair.left, baudrate=115200, byte_size=byte_size
     ) as left:
         assert left.byte_size == byte_size
-        left.write(b"test")
+        left.write_nowait(b"test")
 
 
 async def test_async_invalid_byte_size(serial_pair: SerialPair) -> None:
@@ -424,7 +424,7 @@ async def test_async_xonxoff_setting(serial_pair: SerialPair, xonxoff: bool) -> 
     async with serialx.async_serial_for_url(
         serial_pair.left, baudrate=115200, xonxoff=xonxoff
     ) as left:
-        left.write(b"test")
+        left.write_nowait(b"test")
 
 
 @pytest.mark.parametrize("rtscts", [True, False])
@@ -437,7 +437,7 @@ async def test_async_rtscts_setting(serial_pair: SerialPair, rtscts: bool) -> No
         async with serialx.async_serial_for_url(
             serial_pair.left, baudrate=115200, rtscts=rtscts
         ) as left:
-            left.write(b"test")
+            left.write_nowait(b"test")
 
 
 # --- Lifecycle ---
@@ -450,7 +450,7 @@ async def test_async_concurrent_writes(serial_pair: SerialPair) -> None:
     ) as (left, right):
 
         async def write_data(data: bytes) -> None:
-            left.write(data)
+            left.write_nowait(data)
 
         data1 = b"A" * 100
         data2 = b"B" * 100
@@ -471,7 +471,7 @@ async def test_async_read_with_timeout(serial_pair: SerialPair) -> None:
     async with async_create_serial_pair(
         serial_pair.left, serial_pair.right, baudrate=115200
     ) as (left, right):
-        left.write(b"test")
+        left.write_nowait(b"test")
 
         result = await asyncio.wait_for(right.readexactly(4), timeout=1.0)
         assert result == b"test"
@@ -499,7 +499,7 @@ async def test_async_pause_resume(serial_pair: SerialPair) -> None:
     ) as (left, right):
         left.transport.pause_reading()
 
-        right.write(b"A long message")
+        right.write_nowait(b"A long message")
         await right.drain()
 
         # Nothing can be read
@@ -592,7 +592,7 @@ async def test_async_write_bytearray(serial_pair: SerialPair) -> None:
         serial_pair.left, serial_pair.right, baudrate=115200
     ) as (left, right):
         data = bytearray(b"hello bytearray")
-        left.write(data)
+        left.write_nowait(data)
         result = await right.readexactly(len(data))
         assert result == b"hello bytearray"
 
@@ -602,8 +602,8 @@ async def test_async_write_empty(serial_pair: SerialPair) -> None:
     async with async_create_serial_pair(
         serial_pair.left, serial_pair.right, baudrate=115200
     ) as (left, right):
-        left.write(b"")
-        left.write(b"after_empty")
+        left.write_nowait(b"")
+        left.write_nowait(b"after_empty")
         result = await right.readexactly(len(b"after_empty"))
         assert result == b"after_empty"
 
@@ -644,7 +644,7 @@ async def test_async_flush(serial_pair: SerialPair) -> None:
     async with async_create_serial_pair(
         serial_pair.left, serial_pair.right, baudrate=115200
     ) as (left, right):
-        left.write(b"flush test data")
+        left.write_nowait(b"flush test data")
         await left.flush()
 
         result = await right.readexactly(len(b"flush test data"))
@@ -1153,8 +1153,8 @@ async def test_async_exclusive_disabled(serial_pair: SerialPair) -> None:
         ) as left2:
             assert left2.exclusive is False
 
-            left1.write(b"hello")
-            left2.write(b"world")
+            left1.write_nowait(b"hello")
+            left2.write_nowait(b"world")
 
 
 async def test_async_connect_nonexistent_port() -> None:
@@ -1303,7 +1303,7 @@ async def test_async_unplug_raises(serial_pair: SerialPair) -> None:
     async with async_create_serial_pair(
         serial_pair.left, serial_pair.right, baudrate=115200
     ) as (left, right):
-        right.write(b"ping\n")
+        right.write_nowait(b"ping\n")
         await right.drain()
         assert await left.readline() == b"ping\n"
 
@@ -1313,7 +1313,7 @@ async def test_async_unplug_raises(serial_pair: SerialPair) -> None:
             await left.read(1)
 
         with pytest.raises(OSError):
-            left.write(b"x")
+            left.write_nowait(b"x")
 
         with pytest.raises(OSError):
             await left.drain()
@@ -1337,7 +1337,7 @@ async def test_async_unplug_raises_on_streamreader_readline(
         async with serialx.async_serial_for_url(
             serial_pair.right, baudrate=115200
         ) as right:
-            right.write(b"ping\n")
+            right.write_nowait(b"ping\n")
             await right.drain()
             assert await reader.readline() == b"ping\n"
 

--- a/tests/test_serial_esphome.py
+++ b/tests/test_serial_esphome.py
@@ -121,7 +121,7 @@ async def test_externally_passed_api() -> None:
                     port_name="Serial Proxy Left",
                     baudrate=115200,
                 ) as serial:
-                    serial.write(b"test")
+                    serial.write_nowait(b"test")
                     await serial.drain()
 
             # The API is still connected
@@ -167,7 +167,7 @@ async def test_connect_by_instance_id() -> None:
             url = f"esphome://{parsed.hostname}:{parsed.port}/0?password=unused"
 
             async with async_serial_for_url(url=url, baudrate=115200) as serial:
-                serial.write(b"test")
+                serial.write_nowait(b"test")
                 await serial.drain()
 
 
@@ -392,11 +392,11 @@ async def test_cross_loop_async_api() -> None:
                     assert serial._client_loop is not asyncio.get_running_loop()
                     assert serial._loop is asyncio.get_running_loop()
 
-                    ser_left.write(b"left to right")
+                    ser_left.write_nowait(b"left to right")
                     data = await ser_right.readexactly(len(b"left to right"))
                     assert data == b"left to right"
 
-                    ser_right.write(b"right to left")
+                    ser_right.write_nowait(b"right to left")
                     data = await ser_left.readexactly(len(b"right to left"))
                     assert data == b"right to left"
 
@@ -449,7 +449,7 @@ async def test_sync_api_with_external_api_on_different_loop() -> None:
                         assert serial._loop is not None
                         assert serial._loop is not api_loop
 
-                        peer.write(b"peer-data")
+                        peer.write_nowait(b"peer-data")
                         await peer.drain()
 
                         data = await asyncio.to_thread(serial.read, len(b"peer-data"))
@@ -488,14 +488,14 @@ async def test_single_api_multiple_async_ports() -> None:
                         baudrate=115200,
                     ) as ser_right,
                 ):
-                    ser_left.write(b"left to right")
+                    ser_left.write_nowait(b"left to right")
                     await ser_left.drain()
                     data = await asyncio.wait_for(
                         ser_right.readexactly(len(b"left to right")), timeout=5
                     )
                     assert data == b"left to right"
 
-                    ser_right.write(b"right to left")
+                    ser_right.write_nowait(b"right to left")
                     await ser_right.drain()
                     data = await asyncio.wait_for(
                         ser_left.readexactly(len(b"right to left")), timeout=5


### PR DESCRIPTION
See https://github.com/puddly/serialx/issues/88 for context.

`write`, as a proxy to `StreamWriter.write`, just enqueues data and will not necessarily throw an error if there is an issue. This also glosses over the important `drain` semantics `StreamWriter` allows you to accidentally skip. To work around this, the simple API will make `write` async and will provide the old behavior via `write_nowait`.

---

This is technically a breaking change but I wasn't able to find anybody using `async_serial_for_url` yet. I think we're safe to quickly swap it out.