### PR TITLE
Fix ESPHome protobuf `instance_id=None` conversion bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,11 +67,11 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         id: python
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           check-latest: true
       - name: Restore base Python virtual environment
         id: cache-venv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -499,7 +499,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          bun-version: 1.3.13
       - name: Cache Pyodide package wheels
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:

--- a/prek.toml
+++ b/prek.toml
@@ -19,14 +19,6 @@ additional_dependencies = ["tomli"]
 args = ["--toml", "pyproject.toml"]
 
 [[repos]]
-repo = "https://github.com/pre-commit/mirrors-mypy"
-rev = "v1.20.2"
-
-[[repos.hooks]]
-id = "mypy"
-additional_dependencies = ["types-pywin32"]
-
-[[repos]]
 repo = "https://github.com/astral-sh/ruff-pre-commit"
 rev = "v0.15.12"
 
@@ -62,6 +54,15 @@ id = "taplo-format"
 
 [[repos]]
 repo = "local"
+
+[[repos.hooks]]
+id = "mypy"
+name = "mypy"
+entry = "mypy"
+language = "system"
+types_or = ["python", "pyi"]
+exclude = '^tests/esphome/external_components/'
+require_serial = true
 
 [[repos.hooks]]
 id = "cargo-fmt"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,12 +24,17 @@ documentation = "https://puddly.github.io/serialx/"
 esphome = ["aioesphomeapi>=44.17.0; python_version >= '3.11'"]
 dev = [
   "ruff",
+  "mypy",
   "pytest",
   "prek",
   "pytest-asyncio",
   "pytest-timeout",
   "pytest-xdist",
   "psutil",
+  "async-timeout",
+  "types-psutil",
+  "types-pywin32",
+  "types-setuptools",
   "aioesphomeapi>=44.17.0 ; python_version >= '3.11'",
 ]
 docs = [
@@ -164,6 +169,7 @@ disable_error_code = [
   "unreachable",
   "untyped-decorator",
 ]
+
 
 [tool.coverage.run]
 source = ["serialx"]

--- a/serialx/platforms/serial_esphome.py
+++ b/serialx/platforms/serial_esphome.py
@@ -617,10 +617,10 @@ class ESPHomeSerialTransport(BaseSerialTransport):
 
         assert self._serial is not None
         await self._serial._async_open()
-        self._serial.configure_port()
 
         assert self._serial._api is not None
         await self._serial._subscribe_instance()
+        self._serial.configure_port()
         self._unsub = await self._serial._call_on_client_loop(
             self._register_transport_data_handler()
         )

--- a/serialx/platforms/serial_esphome.py
+++ b/serialx/platforms/serial_esphome.py
@@ -33,14 +33,14 @@ from typing import Any, ParamSpec, TypeVar, cast
 import urllib.parse
 import warnings
 
-import aioesphomeapi
-from aioesphomeapi import APIClient, SerialProxyDataReceived, SerialProxyParity
-from aioesphomeapi.core import (
+from aioesphomeapi.client import APIClient
+from aioesphomeapi.core import (  # type: ignore[attr-defined]
     APIConnectionError,
     PingRequest,
     PingResponse,
     TimeoutAPIError,
 )
+from aioesphomeapi.model import SerialProxyDataReceived, SerialProxyParity
 from typing_extensions import Buffer, Unpack
 
 from serialx import SerialException, UnsupportedSetting
@@ -221,7 +221,10 @@ class ESPHomeSerial(BaseSerial):
         )
 
     def _schedule_on_client_loop(
-        self, fn: Callable[..., Any], *args: Any, **kwargs: Any
+        self,
+        fn: Callable[_P, Any],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> None:
         """Invoke a synchronous `APIClient` method on the client's loop."""
         client_loop = self._client_loop
@@ -302,7 +305,10 @@ class ESPHomeSerial(BaseSerial):
             elif "key" in params:
                 self._noise_psk = params["key"][0]
 
-            self._api = aioesphomeapi.APIClient(
+            if parsed.hostname is None:
+                raise InvalidSettingsError(f"URI {self._path!r} is missing a hostname")
+
+            self._api = APIClient(
                 address=parsed.hostname,
                 port=parsed.port or ESPHOME_DEFAULT_PORT,
                 password=self._password,
@@ -424,6 +430,7 @@ class ESPHomeSerial(BaseSerial):
         if self._api is None or not self._instance_subscribed:
             return
 
+        assert self._instance_id is not None
         with suppress(APIConnectionError):
             self._schedule_on_client_loop(
                 self._api.serial_proxy_unsubscribe, self._instance_id
@@ -434,6 +441,7 @@ class ESPHomeSerial(BaseSerial):
     def _configure_port(self) -> None:
         """Configure the serial port settings."""
         assert self._api is not None
+        assert self._instance_id is not None
         self._schedule_on_client_loop(
             self._api.serial_proxy_configure,
             instance=self._instance_id,
@@ -447,6 +455,7 @@ class ESPHomeSerial(BaseSerial):
     def _send_set_modem_pins(self, modem_pins: ModemPins) -> None:
         """Send a signal to set modem control bits, without waiting for a response."""
         assert self._api is not None
+        assert self._instance_id is not None
         line_states = self._last_line_state
 
         if modem_pins.rts is PinState.HIGH:
@@ -496,14 +505,15 @@ class ESPHomeSerial(BaseSerial):
     @translate_esphome_errors
     async def _async_get_modem_pins(self) -> ModemPins:
         assert self._api is not None
+        assert self._instance_id is not None
         rsp = await self._call_on_client_loop(
             self._api.serial_proxy_get_modem_pins(instance=self._instance_id)
         )
-        self._last_line_state = rsp.line_states
+        self._last_line_state = LineStateFlag(rsp.line_states)
 
         return ModemPins(
-            dtr=PinState.convert(rsp.line_states & LineStateFlag.DTR),
-            rts=PinState.convert(rsp.line_states & LineStateFlag.RTS),
+            dtr=PinState.convert(bool(rsp.line_states & LineStateFlag.DTR)),
+            rts=PinState.convert(bool(rsp.line_states & LineStateFlag.RTS)),
         )
 
     def num_unread_bytes(self) -> int:
@@ -525,6 +535,7 @@ class ESPHomeSerial(BaseSerial):
     async def _async_flush(self) -> None:
         """Flush write buffers."""
         assert self._api is not None
+        assert self._instance_id is not None
         await self._call_on_client_loop(
             self._api.serial_proxy_flush(instance=self._instance_id)
         )
@@ -536,6 +547,7 @@ class ESPHomeSerial(BaseSerial):
     def _write(self, b: Buffer, *, timeout: float | None) -> int:
         """Write bytes to serial port."""
         assert self._api is not None
+        assert self._instance_id is not None
         data = bytes(b)
         self._schedule_on_client_loop(
             self._api.serial_proxy_write, instance=self._instance_id, data=data

--- a/serialx/platforms/serial_pyodide/__init__.py
+++ b/serialx/platforms/serial_pyodide/__init__.py
@@ -25,7 +25,7 @@ import contextlib
 import logging
 from typing import Any, final
 
-import js
+import js  # type: ignore[import-not-found]
 from typing_extensions import Buffer
 
 from ...common import (

--- a/tests/common.py
+++ b/tests/common.py
@@ -460,7 +460,7 @@ def create_socat_pair() -> Iterator[
 @contextlib.contextmanager
 def create_pyodide_pair() -> Iterator[tuple[str, str]]:
     """Create a fake Web Serial pair and register each side at a unique URL."""
-    import js  # noqa: PLC0415
+    import js  # type: ignore[import-not-found]  # noqa: PLC0415
 
     from serialx.platforms.serial_pyodide import (  # noqa: PLC0415
         register_js_port,

--- a/tests/test_pyserial_compat.py
+++ b/tests/test_pyserial_compat.py
@@ -174,7 +174,7 @@ def test_compat_constants() -> None:
 
     assert STOPBITS_ONE == 1  # type: ignore[comparison-overlap]
     assert STOPBITS_ONE_POINT_FIVE == 1.5
-    assert STOPBITS_TWO == 2
+    assert STOPBITS_TWO == 2  # type: ignore[comparison-overlap]
 
 
 def test_compat_tools_module() -> None:

--- a/tests/test_serial_esphome.py
+++ b/tests/test_serial_esphome.py
@@ -3,7 +3,7 @@
 import pytest
 
 try:
-    from aioesphomeapi import APIClient
+    from aioesphomeapi.client import APIClient
 except ImportError:
     pytest.skip(
         "aioesphomeapi is required to run esphome transport tests",
@@ -43,6 +43,9 @@ def api_client_on_thread_loop(
 ) -> Iterator[tuple[APIClient, asyncio.AbstractEventLoop]]:
     """Yield an APIClient connected on a dedicated background thread's loop."""
     parsed = urllib.parse.urlparse(url)
+    assert parsed.hostname is not None
+    hostname = parsed.hostname
+    port = parsed.port or ESPHOME_DEFAULT_PORT
 
     thread_loop = asyncio.new_event_loop()
     ready = threading.Event()
@@ -58,8 +61,8 @@ def api_client_on_thread_loop(
 
     async def _connect() -> APIClient:
         api = APIClient(
-            address=parsed.hostname,
-            port=parsed.port or ESPHOME_DEFAULT_PORT,
+            address=hostname,
+            port=port,
             password=None,
         )
         await api.connect(login=True)
@@ -106,6 +109,8 @@ async def test_externally_passed_api() -> None:
         with create_esphome_pair(socat_left, socat_right) as (left, _right):
             # Connect to the ESPHome API externally
             parsed = urllib.parse.urlparse(left)
+            assert parsed.hostname is not None
+
             api = APIClient(
                 address=parsed.hostname,
                 port=parsed.port or ESPHOME_DEFAULT_PORT,
@@ -134,6 +139,8 @@ async def test_externally_passed_api_close_after_disconnect() -> None:
     with create_socat_pair() as (socat_left, socat_right, _, _):
         with create_esphome_pair(socat_left, socat_right) as (left, _right):
             parsed = urllib.parse.urlparse(left)
+            assert parsed.hostname is not None
+
             api = APIClient(
                 address=parsed.hostname,
                 port=parsed.port or ESPHOME_DEFAULT_PORT,
@@ -320,6 +327,8 @@ async def test_esphome_list_serial_ports() -> None:
     with create_socat_pair() as (socat_left, socat_right, _, _):
         with create_esphome_pair(socat_left, socat_right) as (left, _right):
             parsed = urllib.parse.urlparse(left)
+            assert parsed.hostname is not None
+
             api = APIClient(
                 address=parsed.hostname,
                 port=parsed.port or ESPHOME_DEFAULT_PORT,
@@ -363,6 +372,8 @@ async def test_sync_esphome_list_serial_ports_external_api() -> None:
     with create_socat_pair() as (socat_left, socat_right, _, _):
         with create_esphome_pair(socat_left, socat_right) as (left, _right):
             parsed = urllib.parse.urlparse(left)
+            assert parsed.hostname is not None
+
             api = APIClient(
                 address=parsed.hostname,
                 port=parsed.port or ESPHOME_DEFAULT_PORT,
@@ -464,6 +475,8 @@ async def test_single_api_multiple_async_ports() -> None:
     with create_socat_pair() as (socat_left, socat_right, _, _):
         with create_esphome_pair(socat_left, socat_right) as (left, _right):
             parsed = urllib.parse.urlparse(left)
+            assert parsed.hostname is not None
+
             api = APIClient(
                 address=parsed.hostname,
                 port=parsed.port or ESPHOME_DEFAULT_PORT,


### PR DESCRIPTION
Fixes an `instance_id` protobuf type conversion bug caused by us subscribing to the ESPHome serial port instance before we configure the port (and parse the `port_name` param). `instance_id=None` was converted into` instance_id=0` automatically by protobuf.

I've tightened typing to catch this with mypy and added a few asserts to ensure tests catch this in the future.