### PR TITLE
fix: handle missing USB string descriptors in linux_list_serial_ports

### DIFF
--- a/serialx/platforms/serial_linux.py
+++ b/serialx/platforms/serial_linux.py
@@ -222,7 +222,6 @@ def linux_list_serial_ports() -> list[SerialPortInfo]:
             # USB-serial chips
             usb_interface = resolved.parent
             usb_device = usb_interface.parent
-            interface_file = usb_interface / "interface"
 
             try:
                 vid = int((usb_device / "idVendor").read_text(), 16)
@@ -246,18 +245,13 @@ def linux_list_serial_ports() -> list[SerialPortInfo]:
                 manufacturer=_read_optional_sysfs(usb_device / "manufacturer"),
                 product=_read_optional_sysfs(usb_device / "product"),
                 bcd_device=bcd_device,
-                interface_description=(
-                    interface_file.read_text()[:-1]
-                    if interface_file.exists()
-                    else None
-                ),
+                interface_description=_read_optional_sysfs(usb_interface / "interface"),
                 interface_num=interface_num,
             )
         elif subsystem == "usb":
             # CDC ACM devices
             usb_interface = resolved
             usb_device = usb_interface.parent
-            interface_file = usb_interface / "interface"
 
             try:
                 vid = int((usb_device / "idVendor").read_text(), 16)
@@ -279,11 +273,7 @@ def linux_list_serial_ports() -> list[SerialPortInfo]:
                 manufacturer=_read_optional_sysfs(usb_device / "manufacturer"),
                 product=_read_optional_sysfs(usb_device / "product"),
                 bcd_device=bcd_device,
-                interface_description=(
-                    interface_file.read_text()[:-1]
-                    if interface_file.exists()
-                    else None
-                ),
+                interface_description=_read_optional_sysfs(usb_interface / "interface"),
                 interface_num=interface_num,
             )
         elif subsystem in ("serial-base", "platform", "pnp", "amba"):

--- a/serialx/platforms/serial_linux.py
+++ b/serialx/platforms/serial_linux.py
@@ -180,6 +180,14 @@ def iterdir_safe(path: Path) -> Iterator[Path]:
         yield from path.iterdir()
 
 
+def _read_optional_sysfs(path: Path) -> str | None:
+    """Read a sysfs string file, returning None if it does not exist."""
+    try:
+        return path.read_text()[:-1]
+    except OSError:
+        return None
+
+
 def linux_list_serial_ports() -> list[SerialPortInfo]:
     """List serial ports on Linux."""
     by_id_symlinks = {}
@@ -217,29 +225,34 @@ def linux_list_serial_ports() -> list[SerialPortInfo]:
             interface_file = usb_interface / "interface"
 
             try:
-                info = SerialPortInfo(
-                    device=str(unique_device),
-                    resolved_device=str(device),
-                    vid=int((usb_device / "idVendor").read_text(), 16),
-                    pid=int((usb_device / "idProduct").read_text(), 16),
-                    serial_number=(usb_device / "serial").read_text()[:-1],
-                    manufacturer=(usb_device / "manufacturer").read_text()[:-1],
-                    product=(usb_device / "product").read_text()[:-1],
-                    bcd_device=int((usb_device / "bcdDevice").read_text(), 16),
-                    interface_description=(
-                        interface_file.read_text()[:-1]
-                        if interface_file.exists()
-                        else None
-                    ),
-                    interface_num=int(
-                        (usb_interface / "bInterfaceNumber").read_text(), 16
-                    ),
+                vid = int((usb_device / "idVendor").read_text(), 16)
+                pid = int((usb_device / "idProduct").read_text(), 16)
+                bcd_device = int((usb_device / "bcdDevice").read_text(), 16)
+                interface_num = int(
+                    (usb_interface / "bInterfaceNumber").read_text(), 16
                 )
             except OSError:
                 LOGGER.debug(
                     "Serial device %r disappeared during iteration", usb_device
                 )
                 continue
+
+            info = SerialPortInfo(
+                device=str(unique_device),
+                resolved_device=str(device),
+                vid=vid,
+                pid=pid,
+                serial_number=_read_optional_sysfs(usb_device / "serial"),
+                manufacturer=_read_optional_sysfs(usb_device / "manufacturer"),
+                product=_read_optional_sysfs(usb_device / "product"),
+                bcd_device=bcd_device,
+                interface_description=(
+                    interface_file.read_text()[:-1]
+                    if interface_file.exists()
+                    else None
+                ),
+                interface_num=interface_num,
+            )
         elif subsystem == "usb":
             # CDC ACM devices
             usb_interface = resolved
@@ -247,27 +260,32 @@ def linux_list_serial_ports() -> list[SerialPortInfo]:
             interface_file = usb_interface / "interface"
 
             try:
-                info = SerialPortInfo(
-                    device=str(unique_device),
-                    resolved_device=str(device),
-                    vid=int((usb_device / "idVendor").read_text(), 16),
-                    pid=int((usb_device / "idProduct").read_text(), 16),
-                    serial_number=(usb_device / "serial").read_text()[:-1],
-                    manufacturer=(usb_device / "manufacturer").read_text()[:-1],
-                    product=(usb_device / "product").read_text()[:-1],
-                    bcd_device=int((usb_device / "bcdDevice").read_text(), 16),
-                    interface_description=(
-                        interface_file.read_text()[:-1]
-                        if interface_file.exists()
-                        else None
-                    ),
-                    interface_num=int(
-                        (usb_interface / "bInterfaceNumber").read_text(), 16
-                    ),
+                vid = int((usb_device / "idVendor").read_text(), 16)
+                pid = int((usb_device / "idProduct").read_text(), 16)
+                bcd_device = int((usb_device / "bcdDevice").read_text(), 16)
+                interface_num = int(
+                    (usb_interface / "bInterfaceNumber").read_text(), 16
                 )
             except OSError:
                 LOGGER.debug("USB device %r disappeared during iteration", usb_device)
                 continue
+
+            info = SerialPortInfo(
+                device=str(unique_device),
+                resolved_device=str(device),
+                vid=vid,
+                pid=pid,
+                serial_number=_read_optional_sysfs(usb_device / "serial"),
+                manufacturer=_read_optional_sysfs(usb_device / "manufacturer"),
+                product=_read_optional_sysfs(usb_device / "product"),
+                bcd_device=bcd_device,
+                interface_description=(
+                    interface_file.read_text()[:-1]
+                    if interface_file.exists()
+                    else None
+                ),
+                interface_num=interface_num,
+            )
         elif subsystem in ("serial-base", "platform", "pnp", "amba"):
             # `serial-base` is the per-port subsystem introduced in Linux 6.10.
             # Older kernels expose native ports through their bus directly:


### PR DESCRIPTION
## Problem

USB devices are not required to provide manufacturer, product, or serial number string descriptors (indicated by index 0 in the USB device descriptor). When these descriptors are absent, the corresponding sysfs files (`serial`, `manufacturer`, `product`) do not exist under `/sys/bus/usb/devices/<device>/`.

Previously, these fields were read directly with `.read_text()` inside the `SerialPortInfo(...)` constructor call, outside the `try/except OSError` block. A missing sysfs file raises `FileNotFoundError` (a subclass of `OSError`), which was caught by the outer `except OSError: continue`, causing the **entire device to be silently skipped**.

### Affected device

**Velleman VMB1USB** (VID: `10cf`, PID: `0b1b`) — a CDC-ACM USB serial interface without a USB serial number descriptor. The device appears correctly in `/dev/serial/by-id/`, `/sys/class/tty/`, and is detected by pyserial, but was invisible to `serialx.list_serial_ports()`.

This caused the device to not appear in the Home Assistant Velbus integration USB port selector, which uses `serialx` via `homeassistant.components.usb.async_scan_serial_ports()`.

## Fix

Add a `_read_optional_sysfs()` helper that returns `None` on `OSError` instead of raising. Use it for the three optional USB string descriptor fields (`serial_number`, `manufacturer`, `product`) in both the `usb-serial` and `usb` (CDC-ACM) subsystem branches.

Mandatory fields (`idVendor`, `idProduct`, `bcdDevice`, `bInterfaceNumber`) remain in the existing `try/except` block that handles devices disappearing during iteration.

This mirrors the existing pattern already used for `interface_description`, which was already handled with an explicit `.exists()` check.