### PR TITLE
Add minimum versions for dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,9 @@
 [build-system]
-requires = ["setuptools>=80", "setuptools-scm[simple]>=8", "setuptools-rust"]
+requires = [
+  "setuptools>=80",
+  "setuptools-scm[simple]>=8",
+  "setuptools-rust>=1.7.0",
+]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -11,8 +15,8 @@ readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
-  "typing-extensions",
-  "async-timeout; python_version < '3.12'",
+  "typing-extensions>=4.13.0",
+  "async-timeout>=3.0.0; python_version < '3.11'",
   "pywin32; platform_system == 'Windows'",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1303,7 +1303,7 @@ wheels = [
 name = "serialx"
 source = { editable = "." }
 dependencies = [
-    { name = "async-timeout", marker = "python_full_version < '3.12'" },
+    { name = "async-timeout", marker = "python_full_version < '3.11'" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "typing-extensions" },
 ]
@@ -1347,7 +1347,7 @@ esphome = [
 requires-dist = [
     { name = "aioesphomeapi", marker = "python_full_version >= '3.11' and extra == 'dev'", specifier = ">=44.17.0" },
     { name = "aioesphomeapi", marker = "python_full_version >= '3.11' and extra == 'esphome'", specifier = ">=44.17.0" },
-    { name = "async-timeout", marker = "python_full_version < '3.12'" },
+    { name = "async-timeout", marker = "python_full_version < '3.11'", specifier = ">=3.0.0" },
     { name = "async-timeout", marker = "extra == 'dev'", specifier = ">=5.0.1" },
     { name = "codespell", marker = "extra == 'dev'", specifier = ">=2.4.2" },
     { name = "furo", marker = "extra == 'docs'", specifier = ">=2025.7.19" },
@@ -1371,7 +1371,7 @@ requires-dist = [
     { name = "types-psutil", marker = "extra == 'dev'", specifier = ">=7.2.2.20260508" },
     { name = "types-pywin32", marker = "extra == 'dev'", specifier = ">=311.0.0.20260508" },
     { name = "types-setuptools", marker = "extra == 'dev'", specifier = ">=82.0.0.20260508" },
-    { name = "typing-extensions" },
+    { name = "typing-extensions", specifier = ">=4.13.0" },
     { name = "uv", marker = "extra == 'dev'", specifier = ">=0.11.14" },
 ]
 provides-extras = ["esphome", "dev", "docs"]


### PR DESCRIPTION
## Proposed change

This PR specifies the minimum required version for several dependencies in `pyproject.toml`:
- `typing-extensions>=4.13.0`: required for `TypedDict(extra_items=...)` (PEP 728) used by `ConnectKwargs` in `common.py`; also covers `typing_extensions.Buffer`
- `async-timeout>=3.0.0`: only the bare context manager is used, but `<=2.0.0` call `asyncio.Task.current_task()` (removed in 3.9) and crash on the 3.10 install path; also tighten marker to `python_version < '3.11'` to match the import guard (3.11+ uses `asyncio.timeout` from the `stdlib`)
- `setuptools-rust>=1.7.0`: ext-modules are declared in `pyproject.toml` via `[[tool.setuptools-rust.ext-modules]]`, which requires 1.7.0+

## Additional information

I installed zigpy into an older venv and noticed that Serialx had an issue with the installed version of `typing-extensions` being too old for `extra_items`, so this PR sets a minimum version where it's actually availabe.

Whilst doing that, it was also noticed that the Python version cap in `pyproject.toml` for `async-timeout` installs it on Python 3.12, even though it's no longer needed there. It's also not used: https://github.com/puddly/serialx/blob/f9f1bf215baf3fb05e4a6f06056c12a5b9941e05/serialx/platforms/serial_socket.py#L15-L18

A minimum version was also added there for consistency – anything 2.0.0 and below breaks. 2.0.1 does seem to work, but I think it's fine to require 3.0.0 that was released two months later in 2018. (4.0.0 and newer is very much recommended anyways due to significant rewrites apparently.)

A minimum version for `setuptools-rust` was also set to make sure support for `tool.setuptools-rust` is available.

Note: Prek reformatted `pyproject.toml` due to line length. `uv.lock` was regenerated without updating the dependencies, only fixing the version constraints.

Of course, any of these changes can be removed if they're deemed unnecessary.

### AI summary

<details><summary>Verbose AI summary (click to expand)</summary>
<p>

## Summary

Several dependencies in `pyproject.toml` were unpinned even though the code relies on features that are only available above a certain version. This adds the minimum-version floors that the source actually requires, plus tightens one environment marker that was installing a dependency where it's never used.

## Changes

### Runtime dependencies

- **`typing-extensions>=4.13.0`** — `ConnectKwargs` in `common.py` defines a `TypedDict` with `extra_items=Any` (PEP 728), which is only supported since typing-extensions 4.13.0. This is the newest feature used and the binding constraint; the codebase also relies on `typing_extensions.Buffer` (PEP 688, 4.6.0+) and `Self`/`Unpack`/`NotRequired`, all of which 4.13.0 covers.

- **`async-timeout>=3.0.0`** and marker tightened to **`python_version < '3.11'`** — `async_timeout.timeout` is only imported on the Python 3.10 path; the import guard is `if sys.version_info >= (3, 11): from asyncio import timeout … else: from async_timeout import timeout`. The previous marker (`python_version < '3.12'`) installed `async-timeout` on Python 3.11 too, where it is never imported. The new marker matches the actual import guard. The floor matters: versions ≤ 2.0.0 raise `AttributeError` on Python 3.10 because they call the `asyncio.Task.current_task()` API that was removed in Python 3.9; 2.0.1 added the compat shim. `>=3.0.0` is a clean floor above that hard minimum (only the bare `async with timeout(...)` context manager is used, so no newer API is required).

### Build dependencies

- **`setuptools-rust>=1.7.0`** — `setup.py` is a bare `setuptools.setup()` stub, and the Rust extension is declared entirely via `[[tool.setuptools-rust.ext-modules]]` in `pyproject.toml`. Declaring ext-modules in `pyproject.toml` (instead of passing `RustExtension(...)` in `setup.py`) is only supported since setuptools-rust 1.7.0.

### Lockfile

- Regenerated `uv.lock` to reflect the updated specifiers. No resolved versions changed — the already-locked versions (typing-extensions 4.15.0, async-timeout 5.0.1) satisfy the new floors. `setuptools-rust` is a build-only requirement and is correctly absent from the locked runtime graph.

</p>
</details> 
