### PR TITLE
Split up `on_close` and `on_open` kwargs and fix Windows

### DIFF
--- a/docs/how-to/pyserial-migration.md
+++ b/docs/how-to/pyserial-migration.md
@@ -68,6 +68,8 @@ are listed in the [main API documentation](../api.md). The most common ones are 
 | `Serial(writeTimeout=...)`  | `write_timeout=...`        | Constructor kwarg                            |
 | `Serial(bytesize=...)`      | `byte_size=...`            | Constructor kwarg                            |
 | `Serial(do_not_open=False)` | —                          | Not supported; open explicitly via `open()`  |
+| `Serial(rtsdtr_on_open=X)`  | `dtr_on_open=X, rts_on_open=X`   | Now controlled per-pin                  |
+| `Serial(rtsdtr_on_close=X)` | `dtr_on_close=X, rts_on_close=X` | Now controlled per-pin                  |
 | `SerialPortInfo[i]`         | attribute access           | Slicing `SerialPortInfo` is deprecated       |
 | `SerialPortInfo.description`| `SerialPortInfo.product`   |                                              |
 

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -437,6 +437,9 @@ class BaseSerial(io.RawIOBase):
         do_not_open: bool | None = None,
         writeTimeout: float | None = None,
         inter_byte_timeout: int | None = None,
+        # Legacy kwargs
+        rtsdtr_on_open: PinState = PinState.UNDEFINED,
+        rtsdtr_on_close: PinState = PinState.UNDEFINED,
         # Internal pyserial compatibility signal
         _wrap_exceptions: bool = False,
     ) -> None:
@@ -466,10 +469,18 @@ class BaseSerial(io.RawIOBase):
         self._read_timeout = read_timeout
         self._write_timeout = write_timeout
 
-        self._dtr_on_open = dtr_on_open
-        self._rts_on_open = rts_on_open
-        self._dtr_on_close = dtr_on_close
-        self._rts_on_close = rts_on_close
+        self._rts_on_open: PinState = (
+            rts_on_open if rtsdtr_on_open is PinState.UNDEFINED else rtsdtr_on_open
+        )
+        self._rts_on_close: PinState = (
+            rts_on_close if rtsdtr_on_close is PinState.UNDEFINED else rtsdtr_on_close
+        )
+        self._dtr_on_open: PinState = (
+            dtr_on_open if rtsdtr_on_open is PinState.UNDEFINED else rtsdtr_on_open
+        )
+        self._dtr_on_close: PinState = (
+            dtr_on_close if rtsdtr_on_close is PinState.UNDEFINED else rtsdtr_on_close
+        )
 
         # Last-written DTR/RTS output state, for readback on backends that can't
         # report output lines from hardware

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -977,21 +977,31 @@ class BaseSerial(io.RawIOBase):
     @property
     def dtr(self) -> bool | None:
         """Get DTR modem bit."""
+        if not self.is_open:
+            return self._dtr_on_open.to_bool()
         return self.get_modem_pins().dtr.to_bool()
 
     @dtr.setter
     def dtr(self, value: bool) -> None:
         """Set DTR modem bit."""
+        if not self.is_open:
+            self._dtr_on_open = PinState.convert(value)
+            return
         self.set_modem_pins(dtr=bool(value))
 
     @property
     def rts(self) -> bool | None:
         """Get RTS modem bit."""
+        if not self.is_open:
+            return self._rts_on_open.to_bool()
         return self.get_modem_pins().rts.to_bool()
 
     @rts.setter
     def rts(self, value: bool) -> None:
         """Set RTS modem bit."""
+        if not self.is_open:
+            self._rts_on_open = PinState.convert(value)
+            return
         self.set_modem_pins(rts=bool(value))
 
     @property

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -410,7 +410,13 @@ def maybe_wrap_exceptions(
 
 
 class BaseSerial(io.RawIOBase):
-    """Base class for serial port communication."""
+    """Base class for serial port communication.
+
+    .. deprecated:: 1.9.0
+        The ``rtsdtr_on_open`` and ``rtsdtr_on_close`` constructor kwargs are
+        deprecated; use the per-pin ``dtr_on_open``, ``rts_on_open``,
+        ``dtr_on_close``, and ``rts_on_close`` instead.
+    """
 
     def __init__(
         self,
@@ -468,6 +474,17 @@ class BaseSerial(io.RawIOBase):
         self._exclusive = exclusive
         self._read_timeout = read_timeout
         self._write_timeout = write_timeout
+
+        if (
+            rtsdtr_on_open is not PinState.UNDEFINED
+            or rtsdtr_on_close is not PinState.UNDEFINED
+        ):
+            warnings.warn(
+                "`rtsdtr_on_open`/`rtsdtr_on_close` are deprecated; use the per-pin"
+                " `dtr_on_open`/`rts_on_open`/`dtr_on_close`/`rts_on_close` instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         self._rts_on_open: PinState = (
             rts_on_open if rtsdtr_on_open is PinState.UNDEFINED else rtsdtr_on_open

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -425,8 +425,10 @@ class BaseSerial(io.RawIOBase):
         byte_size: int = 8,
         read_timeout: float | None = None,
         write_timeout: float | None = None,
-        rtsdtr_on_open: PinState = PinState.HIGH,
-        rtsdtr_on_close: PinState = PinState.LOW,
+        dtr_on_open: PinState = PinState.HIGH,
+        rts_on_open: PinState = PinState.HIGH,
+        dtr_on_close: PinState = PinState.LOW,
+        rts_on_close: PinState = PinState.LOW,
         exclusive: bool = True,
         # pyserial compatibility kwargs
         port: str | None = None,
@@ -464,8 +466,10 @@ class BaseSerial(io.RawIOBase):
         self._read_timeout = read_timeout
         self._write_timeout = write_timeout
 
-        self._rtsdtr_on_open = rtsdtr_on_open
-        self._rtsdtr_on_close = rtsdtr_on_close
+        self._dtr_on_open = dtr_on_open
+        self._rts_on_open = rts_on_open
+        self._dtr_on_close = dtr_on_close
+        self._rts_on_close = rts_on_close
 
         self._auto_close = False
 
@@ -674,14 +678,24 @@ class BaseSerial(io.RawIOBase):
         return self._stopbits
 
     @property
-    def rtsdtr_on_open(self) -> PinState:
-        """Get the RTS/DTR pin state (on open) setting."""
-        return self._rtsdtr_on_open
+    def dtr_on_open(self) -> PinState:
+        """Get the DTR pin state (on open) setting."""
+        return self._dtr_on_open
 
     @property
-    def rtsdtr_on_close(self) -> PinState:
-        """Get the RTS/DTR pin state (on close) setting."""
-        return self._rtsdtr_on_close
+    def rts_on_open(self) -> PinState:
+        """Get the RTS pin state (on open) setting."""
+        return self._rts_on_open
+
+    @property
+    def dtr_on_close(self) -> PinState:
+        """Get the DTR pin state (on close) setting."""
+        return self._dtr_on_close
+
+    @property
+    def rts_on_close(self) -> PinState:
+        """Get the RTS pin state (on close) setting."""
+        return self._rts_on_close
 
     @property
     def exclusive(self) -> bool:

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -247,9 +247,15 @@ class _CommonConnectKwargs(TypedDict, total=False):
     byte_size: int
     read_timeout: float | None
     write_timeout: float | None
+    dtr_on_open: PinState
+    rts_on_open: PinState
+    dtr_on_close: PinState
+    rts_on_close: PinState
+    exclusive: bool
+
+    # backwards compatibility kwargs
     rtsdtr_on_open: PinState
     rtsdtr_on_close: PinState
-    exclusive: bool
 
     # pyserial compatibility kwargs
     port: str | None

--- a/serialx/common.py
+++ b/serialx/common.py
@@ -471,6 +471,11 @@ class BaseSerial(io.RawIOBase):
         self._dtr_on_close = dtr_on_close
         self._rts_on_close = rts_on_close
 
+        # Last-written DTR/RTS output state, for readback on backends that can't
+        # report output lines from hardware
+        self._dtr_state = PinState.UNDEFINED
+        self._rts_state = PinState.UNDEFINED
+
         self._auto_close = False
 
         # Compatibility kwargs
@@ -566,7 +571,26 @@ class BaseSerial(io.RawIOBase):
     def get_modem_pins(self) -> ModemPins:
         """Get modem control bits."""
         self._check_broken()
-        return self._get_modem_pins()
+        pins = self._get_modem_pins()
+        return dataclasses.replace(
+            pins,
+            dtr=pins.dtr if pins.dtr is not PinState.UNDEFINED else self._dtr_state,
+            rts=pins.rts if pins.rts is not PinState.UNDEFINED else self._rts_state,
+        )
+
+    def _modem_pins_on_open(self) -> ModemPins:
+        """DTR/RTS to apply on open."""
+        return ModemPins(
+            dtr=self._dtr_on_open if not self._dsrdtr else PinState.UNDEFINED,
+            rts=self._rts_on_open if not self._rtscts else PinState.UNDEFINED,
+        )
+
+    def _modem_pins_on_close(self) -> ModemPins:
+        """DTR/RTS to apply on close."""
+        return ModemPins(
+            dtr=self._dtr_on_close if not self._dsrdtr else PinState.UNDEFINED,
+            rts=self._rts_on_close if not self._rtscts else PinState.UNDEFINED,
+        )
 
     @maybe_wrap_exceptions
     def set_modem_pins(
@@ -600,7 +624,13 @@ class BaseSerial(io.RawIOBase):
                 dsr=PinState.convert(dsr),
             )
 
-        return self._set_modem_pins(pins)
+        self._set_modem_pins(pins)
+
+        if pins.dtr is not PinState.UNDEFINED:
+            self._dtr_state = pins.dtr
+
+        if pins.rts is not PinState.UNDEFINED:
+            self._rts_state = pins.rts
 
     @abstractmethod
     def _get_modem_pins(self) -> ModemPins:

--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -220,15 +220,21 @@ class PosixSerial(BaseSerial):
         # Ignore modem control lines
         cflag |= termios.CLOCAL
 
-        # Lower modem control lines after last process closes the device (hang up)
-        if self._rtsdtr_on_close is PinState.UNDEFINED:
+        # Lower modem control lines after last process closes the device (hang up).
+        # HUPCL is all-or-nothing: it lowers both DTR and RTS together, so POSIX can
+        # only honor uniform close states.
+        if (
+            self._dtr_on_close is PinState.UNDEFINED
+            and self._rts_on_close is PinState.UNDEFINED
+        ):
             pass
-        elif self._rtsdtr_on_close is PinState.HIGH:
-            raise UnsupportedSetting(
-                "POSIX only supports setting RTS/DTR to LOW on close"
-            )
-        else:
+        elif self._dtr_on_close is PinState.LOW and self._rts_on_close is PinState.LOW:
             cflag |= termios.HUPCL
+        else:
+            raise UnsupportedSetting(
+                "POSIX only supports lowering both DTR and RTS together on close"
+                " (dtr_on_close=rts_on_close=LOW) or leaving both untouched"
+            )
 
         cflag |= self._build_character_size_flags()
         cflag |= self._build_parity_flags()
@@ -312,7 +318,7 @@ class PosixSerial(BaseSerial):
 
         self._after_configure_port()
 
-        self.set_modem_pins(dtr=self._rtsdtr_on_open, rts=self._rtsdtr_on_open)
+        self.set_modem_pins(dtr=self._dtr_on_open, rts=self._rts_on_open)
 
         # Flush input and output buffers to discard stale data
         termios.tcflush(self._fileno, termios.TCIOFLUSH)

--- a/serialx/platforms/serial_posix.py
+++ b/serialx/platforms/serial_posix.py
@@ -318,7 +318,7 @@ class PosixSerial(BaseSerial):
 
         self._after_configure_port()
 
-        self.set_modem_pins(dtr=self._dtr_on_open, rts=self._rts_on_open)
+        self.set_modem_pins(self._modem_pins_on_open())
 
         # Flush input and output buffers to discard stale data
         termios.tcflush(self._fileno, termios.TCIOFLUSH)
@@ -553,7 +553,7 @@ class PosixSerialTransport(DescriptorTransport):
     async def _set_modem_pins(self, modem_pins: ModemPins) -> None:
         """Set modem control bits, internal."""
         assert self._serial is not None
-        await self._loop.run_in_executor(None, self._serial._set_modem_pins, modem_pins)
+        await self._loop.run_in_executor(None, self._serial.set_modem_pins, modem_pins)
 
 
 register_uri_handler(

--- a/serialx/platforms/serial_pyodide/__init__.py
+++ b/serialx/platforms/serial_pyodide/__init__.py
@@ -233,11 +233,10 @@ class PyodideSerialTransport(BaseSerialTransport):
         self._js_port = port
         assert self._js_port is not None
 
-        if self._serial.rtsdtr_on_open is not PinState.UNDEFINED:
-            await self.set_modem_pins(
-                rts=self._serial.rtsdtr_on_open,
-                dtr=self._serial.rtsdtr_on_open,
-            )
+        await self.set_modem_pins(
+            rts=self._serial.rts_on_open,
+            dtr=self._serial.dtr_on_open,
+        )
 
         readable = self._js_port.readable
         assert readable is not None
@@ -356,12 +355,11 @@ class PyodideSerialTransport(BaseSerialTransport):
             self._js_writer = None
 
         if self._js_port is not None:
-            if self._serial.rtsdtr_on_close is not PinState.UNDEFINED:
-                with contextlib.suppress(Exception):
-                    await self.set_modem_pins(
-                        rts=self._serial.rtsdtr_on_close,
-                        dtr=self._serial.rtsdtr_on_close,
-                    )
+            with contextlib.suppress(Exception):
+                await self.set_modem_pins(
+                    rts=self._serial.rts_on_close,
+                    dtr=self._serial.dtr_on_close,
+                )
             await self._js_port.close()
             self._js_port = None
 

--- a/serialx/platforms/serial_pyodide/__init__.py
+++ b/serialx/platforms/serial_pyodide/__init__.py
@@ -164,6 +164,11 @@ class PyodideSerialTransport(BaseSerialTransport):
         self._reader_task: asyncio.Task[None] | None = None
         self._writer_task: asyncio.Task[None] | None = None
 
+        # Last-written DTR/RTS output state; Web Serial `getSignals` only reports
+        # input lines, so output readback comes from this cache.
+        self._dtr_state = PinState.UNDEFINED
+        self._rts_state = PinState.UNDEFINED
+
     async def _connect(  # type: ignore[override]
         self,
         *,
@@ -285,7 +290,10 @@ class PyodideSerialTransport(BaseSerialTransport):
         assert self._js_port is not None
         result = await self._js_port.getSignals()
 
+        # `getSignals` only reports input lines; DTR/RTS come from the cache
         return ModemPins(
+            dtr=self._dtr_state,
+            rts=self._rts_state,
             cts=PinState.convert(result.clearToSend),
             car=PinState.convert(result.dataCarrierDetect),
             rng=PinState.convert(result.ringIndicator),
@@ -303,6 +311,11 @@ class PyodideSerialTransport(BaseSerialTransport):
         if signals:
             assert self._js_port is not None
             await self._js_port.setSignals(**signals)
+
+        if modem_pins.dtr is not PinState.UNDEFINED:
+            self._dtr_state = modem_pins.dtr
+        if modem_pins.rts is not PinState.UNDEFINED:
+            self._rts_state = modem_pins.rts
 
     def write(self, data: bytes | bytearray | memoryview) -> None:
         """Write data to the transport."""

--- a/serialx/platforms/serial_win32.py
+++ b/serialx/platforms/serial_win32.py
@@ -277,12 +277,11 @@ class Win32Serial(BaseSerial):
 
             SetCommState(self._handle, dcb)
 
-            # RTS cannot be manually set when hardware flow control is enabled
-            if not self._rtscts:
-                self.set_modem_pins(
-                    dtr=self._rtsdtr_on_open,
-                    rts=self._rtsdtr_on_open,
-                )
+            # RTS is owned by the driver when rtscts is set, DTR when dsrdtr is set
+            self.set_modem_pins(
+                dtr=self._dtr_on_open if not self._dsrdtr else PinState.UNDEFINED,
+                rts=self._rts_on_open if not self._rtscts else PinState.UNDEFINED,
+            )
 
             # Clear any errors
             ClearCommError(self._handle)
@@ -298,16 +297,20 @@ class Win32Serial(BaseSerial):
     def _close(self) -> None:
         """Close the serial port and release all handles."""
         if self._handle is not None:
-            # Windows has no way to automatically do this on close, we do it manually
-            if not self._rtscts:
-                # RTS cannot be manually set when hardware flow control is enabled
-                try:
-                    self.set_modem_pins(
-                        dtr=self._rtsdtr_on_close,
-                        rts=self._rtsdtr_on_close,
-                    )
-                except OSError:
-                    LOGGER.debug("Failed to set modem pins on close", exc_info=True)
+            # Windows has no way to automatically do this on close, we do it manually. A
+            # driver-owned line (RTS under rtscts, DTR under dsrdtr) cannot be adjusted
+            # via EscapeCommFunction, so skip those.
+            try:
+                self.set_modem_pins(
+                    dtr=(
+                        self._dtr_on_close if not self._dsrdtr else PinState.UNDEFINED
+                    ),
+                    rts=(
+                        self._rts_on_close if not self._rtscts else PinState.UNDEFINED
+                    ),
+                )
+            except OSError:
+                LOGGER.debug("Failed to set modem pins on close", exc_info=True)
 
             try:
                 CancelIo(self._handle)

--- a/serialx/platforms/serial_win32.py
+++ b/serialx/platforms/serial_win32.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, cast
 import pywintypes
 from typing_extensions import Buffer, Unpack
 from win32con import (
+    DTR_CONTROL_DISABLE,
     DTR_CONTROL_ENABLE,
     DTR_CONTROL_HANDSHAKE,
     EVENPARITY,
@@ -26,6 +27,7 @@ from win32con import (
     ONE5STOPBITS,
     ONESTOPBIT,
     OPEN_EXISTING,
+    RTS_CONTROL_DISABLE,
     RTS_CONTROL_ENABLE,
     RTS_CONTROL_HANDSHAKE,
     SPACEPARITY,
@@ -252,6 +254,9 @@ class Win32Serial(BaseSerial):
             if self._rtscts:
                 dcb.fRtsControl = RTS_CONTROL_HANDSHAKE
                 dcb.fOutxCtsFlow = 1
+            elif self._rts_on_open is PinState.LOW:
+                dcb.fRtsControl = RTS_CONTROL_DISABLE
+                dcb.fOutxCtsFlow = 0
             else:
                 dcb.fRtsControl = RTS_CONTROL_ENABLE
                 dcb.fOutxCtsFlow = 0
@@ -266,6 +271,9 @@ class Win32Serial(BaseSerial):
             if self._dsrdtr:
                 dcb.fDtrControl = DTR_CONTROL_HANDSHAKE
                 dcb.fOutxDsrFlow = 1
+            elif self._dtr_on_open is PinState.LOW:
+                dcb.fDtrControl = DTR_CONTROL_DISABLE
+                dcb.fOutxDsrFlow = 0
             else:
                 dcb.fDtrControl = DTR_CONTROL_ENABLE
                 dcb.fOutxDsrFlow = 0

--- a/serialx/platforms/serial_win32.py
+++ b/serialx/platforms/serial_win32.py
@@ -277,11 +277,8 @@ class Win32Serial(BaseSerial):
 
             SetCommState(self._handle, dcb)
 
-            # RTS is owned by the driver when rtscts is set, DTR when dsrdtr is set
-            self.set_modem_pins(
-                dtr=self._dtr_on_open if not self._dsrdtr else PinState.UNDEFINED,
-                rts=self._rts_on_open if not self._rtscts else PinState.UNDEFINED,
-            )
+            # Driver-owned lines (RTS under rtscts, DTR under dsrdtr) are skipped
+            self.set_modem_pins(self._modem_pins_on_open())
 
             # Clear any errors
             ClearCommError(self._handle)
@@ -299,16 +296,9 @@ class Win32Serial(BaseSerial):
         if self._handle is not None:
             # Windows has no way to automatically do this on close, we do it manually. A
             # driver-owned line (RTS under rtscts, DTR under dsrdtr) cannot be adjusted
-            # via EscapeCommFunction, so skip those.
+            # via EscapeCommFunction, so those are skipped.
             try:
-                self.set_modem_pins(
-                    dtr=(
-                        self._dtr_on_close if not self._dsrdtr else PinState.UNDEFINED
-                    ),
-                    rts=(
-                        self._rts_on_close if not self._rtscts else PinState.UNDEFINED
-                    ),
-                )
+                self.set_modem_pins(self._modem_pins_on_close())
             except OSError:
                 LOGGER.debug("Failed to set modem pins on close", exc_info=True)
 

--- a/tests/test_async_transports.py
+++ b/tests/test_async_transports.py
@@ -992,8 +992,8 @@ async def test_async_deassert_on_open(serial_pair: SerialPair) -> None:
         async with serialx.async_serial_for_url(
             serial_pair.right,
             baudrate=115200,
-            rtsdtr_on_open=PinState.HIGH,
-            rtsdtr_on_close=PinState.HIGH,
+            rts_on_open=PinState.HIGH,
+            rts_on_close=PinState.HIGH,
         ) as right:
             await right.set_modem_pins(rts=True)
             await asyncio.sleep(serial_pair.modem_line_propagation_delay)
@@ -1005,8 +1005,8 @@ async def test_async_deassert_on_open(serial_pair: SerialPair) -> None:
         async with serialx.async_serial_for_url(
             serial_pair.right,
             baudrate=115200,
-            rtsdtr_on_open=PinState.LOW,
-            rtsdtr_on_close=PinState.HIGH,
+            rts_on_open=PinState.LOW,
+            rts_on_close=PinState.HIGH,
         ) as right:
             await asyncio.sleep(serial_pair.modem_line_propagation_delay)
             assert (await left.get_modem_pins()).cts is PinState.LOW
@@ -1032,8 +1032,8 @@ async def test_async_hang_up_on_close(serial_pair: SerialPair) -> None:
         async with serialx.async_serial_for_url(
             serial_pair.right,
             baudrate=115200,
-            rtsdtr_on_close=PinState.HIGH,
-            rtsdtr_on_open=PinState.HIGH,
+            rts_on_close=PinState.HIGH,
+            rts_on_open=PinState.HIGH,
         ) as right:
             await right.set_modem_pins(rts=True)
             await asyncio.sleep(serial_pair.modem_line_propagation_delay)
@@ -1045,8 +1045,8 @@ async def test_async_hang_up_on_close(serial_pair: SerialPair) -> None:
         async with serialx.async_serial_for_url(
             serial_pair.right,
             baudrate=115200,
-            rtsdtr_on_close=PinState.HIGH,
-            rtsdtr_on_open=PinState.HIGH,
+            rts_on_close=PinState.HIGH,
+            rts_on_open=PinState.HIGH,
         ) as right:
             await asyncio.sleep(serial_pair.modem_line_propagation_delay)
             assert (await left.get_modem_pins()).cts is PinState.HIGH
@@ -1057,8 +1057,8 @@ async def test_async_hang_up_on_close(serial_pair: SerialPair) -> None:
         async with serialx.async_serial_for_url(
             serial_pair.right,
             baudrate=115200,
-            rtsdtr_on_close=PinState.LOW,
-            rtsdtr_on_open=PinState.HIGH,
+            rts_on_close=PinState.LOW,
+            rts_on_open=PinState.HIGH,
         ) as right:
             await asyncio.sleep(serial_pair.modem_line_propagation_delay)
             assert (await left.get_modem_pins()).cts is PinState.HIGH
@@ -1070,7 +1070,7 @@ async def test_async_hang_up_on_close(serial_pair: SerialPair) -> None:
 @pytest.mark.skipif(sys.platform == "win32", reason="CloseHandle resets modem signals")
 @pytest.mark.skip_quirks(SerialQuirk.NO_RTS_CTS, SerialQuirk.NO_DTR_DSR)
 @pytest.mark.parametrize(
-    ("rtscts", "rtsdtr_on_open", "expected_state"),
+    ("rtscts", "rts_on_open", "expected_state"),
     [
         (False, PinState.HIGH, PinState.HIGH),
         (False, PinState.LOW, PinState.LOW),
@@ -1081,10 +1081,10 @@ async def test_async_hang_up_on_close(serial_pair: SerialPair) -> None:
 async def test_async_deassert_on_open_with_rtscts(
     serial_pair: SerialPair,
     rtscts: bool,
-    rtsdtr_on_open: PinState,
+    rts_on_open: PinState,
     expected_state: PinState,
 ) -> None:
-    """Test interaction of rtsdtr_on_open with rtscts."""
+    """Test interaction of rts_on_open with rtscts."""
 
     if serial_pair.uri_scheme in (
         "linux://",
@@ -1099,8 +1099,8 @@ async def test_async_deassert_on_open_with_rtscts(
             serial_pair.right,
             baudrate=115200,
             rtscts=False,
-            rtsdtr_on_open=PinState.HIGH,
-            rtsdtr_on_close=PinState.HIGH,
+            rts_on_open=PinState.HIGH,
+            rts_on_close=PinState.HIGH,
         ) as right:
             await right.set_modem_pins(rts=True)
             await asyncio.sleep(serial_pair.modem_line_propagation_delay)
@@ -1113,7 +1113,7 @@ async def test_async_deassert_on_open_with_rtscts(
             serial_pair.right,
             baudrate=115200,
             rtscts=rtscts,
-            rtsdtr_on_open=rtsdtr_on_open,
+            rts_on_open=rts_on_open,
         ) as right:
             await asyncio.sleep(serial_pair.modem_line_propagation_delay)
             assert (await left.get_modem_pins()).cts is expected_state

--- a/tests/test_pyserial_compat.py
+++ b/tests/test_pyserial_compat.py
@@ -169,6 +169,39 @@ def test_compat_set_dtr_rts_before_open() -> None:
     assert s.rts_on_open is PinState.HIGH
 
 
+def test_compat_legacy_rtsdtr_kwargs() -> None:
+    """The legacy `rtsdtr_on_*` kwargs map to both pins and warn."""
+    with pytest.warns(DeprecationWarning, match="rtsdtr_on_open"):
+        s = Serial(rtsdtr_on_open=PinState.LOW, rtsdtr_on_close=PinState.HIGH)
+
+    # A single legacy value drives both DTR and RTS
+    assert s.dtr_on_open is PinState.LOW
+    assert s.rts_on_open is PinState.LOW
+    assert s.dtr_on_close is PinState.HIGH
+    assert s.rts_on_close is PinState.HIGH
+
+
+def test_compat_legacy_rtsdtr_one_sided() -> None:
+    """Only the legacy kwarg that is passed overrides; the other keeps defaults."""
+    with pytest.warns(DeprecationWarning, match="rtsdtr_on_open"):
+        s = Serial(rtsdtr_on_open=PinState.LOW)
+
+    assert s.dtr_on_open is PinState.LOW
+    assert s.rts_on_open is PinState.LOW
+    # close side untouched -> defaults
+    assert s.dtr_on_close is PinState.LOW
+    assert s.rts_on_close is PinState.LOW
+
+
+def test_compat_no_legacy_kwargs_does_not_warn(
+    recwarn: pytest.WarningsRecorder,
+) -> None:
+    """Constructing without the legacy kwargs emits no deprecation warning."""
+    Serial(dtr_on_open=PinState.LOW, rts_on_open=PinState.HIGH)
+
+    assert [w for w in recwarn.list if issubclass(w.category, DeprecationWarning)] == []
+
+
 def test_compat_do_not_open(serial_pair: SerialPair) -> None:
     """Test `do_not_open` backwards compatibility."""
     with pytest.raises(RuntimeError, match="do_not_open=False is not supported"):

--- a/tests/test_pyserial_compat.py
+++ b/tests/test_pyserial_compat.py
@@ -25,6 +25,7 @@ from serialx import (
     STOPBITS_ONE_POINT_FIVE,
     STOPBITS_TWO,
     Parity,
+    PinState,
     Serial,
     SerialPortInfo,
 )
@@ -148,6 +149,24 @@ def test_compat_no_arg_construction() -> None:
     assert s.path is None
     assert s.baudrate == 9600
     assert s.port is None
+
+
+def test_compat_set_dtr_rts_before_open() -> None:
+    """Test the pyserial configure-then-open pattern for DTR/RTS."""
+    s = Serial()
+
+    # Defaults reflect the on-open state (dtr_on_open=rts_on_open=HIGH)
+    assert s.dtr is True
+    assert s.rts is True
+
+    # Setting before open seeds the state applied on open instead of raising
+    s.dtr = False
+    s.rts = True
+
+    assert s.dtr is False
+    assert s.rts is True
+    assert s.dtr_on_open is PinState.LOW
+    assert s.rts_on_open is PinState.HIGH
 
 
 def test_compat_do_not_open(serial_pair: SerialPair) -> None:

--- a/tests/test_sync_transports.py
+++ b/tests/test_sync_transports.py
@@ -962,29 +962,29 @@ def test_deassert_on_open(serial_pair: SerialPair) -> None:
         with Serial.from_url(
             serial_pair.right,
             baudrate=115200,
-            rtsdtr_on_open=PinState.HIGH,
-            rtsdtr_on_close=PinState.HIGH,
+            rts_on_open=PinState.HIGH,
+            rts_on_close=PinState.HIGH,
         ) as right:
             right.set_modem_pins(rts=True)
             time.sleep(serial_pair.modem_line_propagation_delay)
             assert left.get_modem_pins().cts is PinState.HIGH
 
-        # rtsdtr_on_close=HIGH keeps RTS asserted
+        # rts_on_close=HIGH keeps RTS asserted
         time.sleep(serial_pair.modem_line_propagation_delay)
         assert left.get_modem_pins().cts is PinState.HIGH
 
         with Serial.from_url(
             serial_pair.right,
             baudrate=115200,
-            rtsdtr_on_open=PinState.LOW,
-            rtsdtr_on_close=PinState.HIGH,
+            rts_on_open=PinState.LOW,
+            rts_on_close=PinState.HIGH,
         ) as right:
-            # rtsdtr_on_open=LOW deasserts RTS
+            # rts_on_open=LOW deasserts RTS
             time.sleep(serial_pair.modem_line_propagation_delay)
             assert left.get_modem_pins().cts is PinState.LOW
             right.set_modem_pins(rts=True)
 
-        # rtsdtr_on_close=HIGH keeps RTS asserted
+        # rts_on_close=HIGH keeps RTS asserted
         time.sleep(serial_pair.modem_line_propagation_delay)
         assert left.get_modem_pins().cts is PinState.HIGH
 
@@ -1005,8 +1005,8 @@ def test_hang_up_on_close(serial_pair: SerialPair) -> None:
         with Serial.from_url(
             serial_pair.right,
             baudrate=115200,
-            rtsdtr_on_close=PinState.HIGH,
-            rtsdtr_on_open=PinState.HIGH,
+            rts_on_close=PinState.HIGH,
+            rts_on_open=PinState.HIGH,
         ) as right:
             right.set_modem_pins(rts=True)
             time.sleep(serial_pair.modem_line_propagation_delay)
@@ -1018,8 +1018,8 @@ def test_hang_up_on_close(serial_pair: SerialPair) -> None:
         with Serial.from_url(
             serial_pair.right,
             baudrate=115200,
-            rtsdtr_on_close=PinState.HIGH,
-            rtsdtr_on_open=PinState.HIGH,
+            rts_on_close=PinState.HIGH,
+            rts_on_open=PinState.HIGH,
         ) as right:
             time.sleep(serial_pair.modem_line_propagation_delay)
             assert left.get_modem_pins().cts is PinState.HIGH
@@ -1030,8 +1030,8 @@ def test_hang_up_on_close(serial_pair: SerialPair) -> None:
         with Serial.from_url(
             serial_pair.right,
             baudrate=115200,
-            rtsdtr_on_close=PinState.LOW,
-            rtsdtr_on_open=PinState.HIGH,
+            rts_on_close=PinState.LOW,
+            rts_on_open=PinState.HIGH,
         ) as right:
             time.sleep(serial_pair.modem_line_propagation_delay)
             assert left.get_modem_pins().cts is PinState.HIGH
@@ -1043,7 +1043,7 @@ def test_hang_up_on_close(serial_pair: SerialPair) -> None:
 @pytest.mark.skipif(sys.platform == "win32", reason="CloseHandle resets modem signals")
 @pytest.mark.skip_quirks(SerialQuirk.NO_RTS_CTS, SerialQuirk.NO_DTR_DSR)
 @pytest.mark.parametrize(
-    ("rtscts", "rtsdtr_on_open", "expected_state"),
+    ("rtscts", "rts_on_open", "expected_state"),
     [
         (False, PinState.HIGH, PinState.HIGH),
         (False, PinState.LOW, PinState.LOW),
@@ -1054,10 +1054,10 @@ def test_hang_up_on_close(serial_pair: SerialPair) -> None:
 def test_deassert_on_open_with_rtscts(
     serial_pair: SerialPair,
     rtscts: bool,
-    rtsdtr_on_open: PinState,
+    rts_on_open: PinState,
     expected_state: PinState,
 ) -> None:
-    """Test interaction of rtsdtr_on_open with rtscts."""
+    """Test interaction of rts_on_open with rtscts."""
     if serial_pair.uri_scheme in (
         "linux://",
         "darwin://",
@@ -1071,8 +1071,8 @@ def test_deassert_on_open_with_rtscts(
             serial_pair.right,
             baudrate=115200,
             rtscts=False,
-            rtsdtr_on_open=PinState.HIGH,
-            rtsdtr_on_close=PinState.HIGH,
+            rts_on_open=PinState.HIGH,
+            rts_on_close=PinState.HIGH,
         ) as right:
             right.set_modem_pins(rts=True)
             time.sleep(serial_pair.modem_line_propagation_delay)
@@ -1085,7 +1085,7 @@ def test_deassert_on_open_with_rtscts(
             serial_pair.right,
             baudrate=115200,
             rtscts=rtscts,
-            rtsdtr_on_open=rtsdtr_on_open,
+            rts_on_open=rts_on_open,
         ):
             time.sleep(serial_pair.modem_line_propagation_delay)
             assert left.get_modem_pins().cts is expected_state


### PR DESCRIPTION
This PR splits `rtsdtr_on_open` and `rtsdtr_on_close` into separate kwargs for `dtr_on_open`, `rts_on_open`, etc.

I've also fixed Windows pin low behavior with `RTS_CONTROL_DISABLE`.

Fixes #107.